### PR TITLE
Add AppVeyor and Travis CIs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,20 @@
+branches:
+  except:
+    - /^travis.*$/
+
+clone_depth: 5
+
+image: Visual Studio 2017
+
+platform:
+  - Win32
+  - x64
+
+configuration:
+  - Debug
+  - Release
+
+build:
+  project: platform/Windows/eduke32.sln
+  parallel: true
+  verbosity: minimal

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: cpp
+dist: xenial
+
+branches:
+  except: /^appveyor.*$/
+
+git:
+  depth: 5
+
+addons:
+  apt:
+    packages:
+      - libsdl2-mixer-dev
+      - libvorbis-dev
+      - libflac-dev
+      - libvpx-dev
+      - libglu1-mesa-dev
+      - libgtk2.0-dev
+      - libluajit-5.1-dev
+
+matrix:
+  include:
+    - os: linux
+      compiler: gcc
+
+    - os: linux
+      compiler: clang
+
+    - os: osx
+      osx_image: xcode10.1
+
+before_install:
+  - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+      brew install sdl2_mixer flac libvpx luajit;
+    fi
+
+script:
+  - make --jobs=2 --keep-going
+
+notifications:
+  email: false


### PR DESCRIPTION
Closes #3 

Please sign-in to [AppVeyor](https://www.appveyor.com) and [Travis](https://travis-ci.org) with your GitHub account. There you can enable CIs for your repositories.

Check build status of my fork [here](https://ci.appveyor.com/project/alexey-lysiuk/nblood/builds/22392594) and [here](https://travis-ci.org/alexey-lysiuk/NBlood/builds/493646356). As you can see, there are some issues ready to fix 😉 I'll take a look at macOS, most likely Linux will be fixed as well.