### PR TITLE
Fix integer overflow when determine system memory size

### DIFF
--- a/source/build/src/compat.cpp
+++ b/source/build/src/compat.cpp
@@ -613,7 +613,7 @@ uint32_t Bgetsysmemsize(void)
     int64_t const scphyspages = sysconf(_SC_PHYS_PAGES);
 
     if (scpagesiz >= 0 && scphyspages >= 0)
-        siz = min<uint32_t>(UINT32_MAX, scpagesiz * scphyspages);
+        siz = (uint32_t)min<uint64_t>(UINT32_MAX, scpagesiz * scphyspages);
 
     //initprintf("Bgetsysmemsize(): %d pages of %d bytes, %d bytes of system memory\n",
     //		scphyspages, scpagesiz, siz);


### PR DESCRIPTION
On macOS sysconf(_SC_PAGE_SIZE) returns 4096 and sysconf(_SC_PHYS_PAGES) returns 4'194'304
scpagesiz * scphyspages is equal to 0x4'0000'0000 which becomes zero after casting to 32-bit unsigned integer
This leads to 'BUFFER TOO BIG TO FIT IN CACHE!' fatal error on startup