### PR TITLE
Remove references to missing .manifest files

### DIFF
--- a/platform/Windows/eduke32.vcxproj
+++ b/platform/Windows/eduke32.vcxproj
@@ -301,9 +301,6 @@
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">%(PreprocessorDefinitions);POLYMER=1</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemGroup>
-  <ItemGroup>
-    <Manifest Include="eduke32.exe.manifest" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/platform/Windows/mapster32.vcxproj
+++ b/platform/Windows/mapster32.vcxproj
@@ -246,9 +246,6 @@
       </AdditionalIncludeDirectories>
     </ResourceCompile>
   </ItemGroup>
-  <ItemGroup>
-    <Manifest Include="mapster32.exe.manifest" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>


### PR DESCRIPTION
This fixes 32-bit Windows builds

Continuous integration builds are finally green