### PR TITLE
fix compiling without opengl

### DIFF
--- a/source/blood/src/tile.cpp
+++ b/source/blood/src/tile.cpp
@@ -113,7 +113,9 @@ int tileInit(char a1, const char *a2)
 
     artLoaded = 1;
 
+    #ifdef USE_OPENGL
     PolymostProcessVoxels_Callback = tileProcessGLVoxels;
+    #endif
 
     return 1;
 }


### PR DESCRIPTION
when compiling without OpenGL tileProcessGLVoxels is called yet never defined nor declared

