### PR TITLE
fix invalid function call

### DIFF
--- a/source/build/src/engine.cpp
+++ b/source/build/src/engine.cpp
@@ -8475,11 +8475,13 @@ void renderDrawMasks(void)
         int32_t back = i;
         for (; i >= 0; --i)
         {
+#ifdef USE_OPENGL
             if (polymost_spriteHasTranslucency(&tsprite[i]))
             {
                 tspriteptr[spritesortcnt] = &tsprite[i];
                 ++spritesortcnt;
             } else
+#endif
             {
                 tspriteptr[back] = &tsprite[i];
                 --back;


### PR DESCRIPTION
without USE_OPENGL polymost_spriteHadTranslucency  is never declared nor defined
this PR adds preprocessor directives to get around that