### PR TITLE
Fix AppVeyor builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,7 @@ branches:
 
 clone_depth: 5
 
-image: Visual Studio 2017
+image: Visual Studio 2019 Preview
 
 platform:
   - Win32


### PR DESCRIPTION
Switched to VS2019 Preview image as there is no release version provided yet
Still much better than builds erroneously reported as broken