### PR TITLE
GetOptions fixes

### DIFF
--- a/source/blood/src/getopt.cpp
+++ b/source/blood/src/getopt.cpp
@@ -59,15 +59,21 @@ int GetOptions(SWITCH *switches)
         if (!switches[i].name)
             return -3;
         int nLength = strlen(switches[i].name);
-        if (!Bstrncasecmp(pChar, switches[i].name, nLength))
+        if (!Bstrncasecmp(pChar, switches[i].name, nLength) && (pChar[nLength]=='=' || pChar[nLength]==0))
         {
             pChar += nLength;
+            if (*pChar=='=')
+            {
+                pChar++;
+            }
+            else
+            {
+                pChar = NULL;
+            }
             break;
         }
     }
     vd = switches[i].at4;
-    if (*pChar == 0)
-        pChar = NULL;
     OptArgc = 0;
     while (OptArgc < switches[i].at8)
     {
@@ -76,9 +82,9 @@ int GetOptions(SWITCH *switches)
             if (OptIndex >= margc)
                 break;
             pChar = margv[OptIndex++];
+            if (strchr(SwitchChars, *pChar) != 0)
+                break;
         }
-        if (strchr(SwitchChars, *pChar) != 0)
-            break;
         OptArgv[OptArgc++] = pChar;
         pChar = NULL;
     }


### PR DESCRIPTION
It was impossible to use the -game_dir option, or use absolute paths on Unix due to confusion with Windows "/" switch character.

I think there are still a few quirks in the options handling to resolve, but this should get rid of a few of the bigger ones.