### PR TITLE
Fix tileLoadTile to check if tile already loaded

### DIFF
--- a/source/blood/src/tile.cpp
+++ b/source/blood/src/tile.cpp
@@ -147,7 +147,7 @@ void tileProcessGLVoxels(void)
 
 char * tileLoadTile(int nTile)
 {
-    tileLoad(nTile);
+    if (!waloff[nTile]) tileLoad(nTile);
     return (char*)waloff[nTile];
 }
 


### PR DESCRIPTION
While working on my RISC OS port I spotted that there was a lot of stuttering, especially when firing weapons. Some debugging revealed that it was because tileLoadTile wasn't checking to see if the tile was already loaded before calling tileLoad.