### PR TITLE
 Porting modern features for mappers from GDX

### DIFF
--- a/source/blood/src/actor.cpp
+++ b/source/blood/src/actor.cpp
@@ -292,6 +292,7 @@ VECTORDATA gVectorData[] = {
         FX_NONE, FX_NONE, FX_NONE, -1,
         513, 513
     },
+    // Gill bite
     {
         DAMAGE_TYPE_2,
         9,
@@ -316,9 +317,9 @@ VECTORDATA gVectorData[] = {
         FX_NONE, FX_NONE, FX_NONE, 502,
         FX_NONE, FX_NONE, FX_NONE, -1,
         FX_NONE, FX_NONE, FX_NONE, -1,
-        0, 0
+        499, 499
     },
-    // Gill bite
+            // Beast slash
     {
         DAMAGE_TYPE_3,
         50,
@@ -343,9 +344,9 @@ VECTORDATA gVectorData[] = {
         FX_NONE, FX_NONE, FX_NONE, 502,
         FX_NONE, FX_NONE, FX_NONE, -1,
         FX_NONE, FX_NONE, FX_NONE, -1,
-        499, 499
+        9012, 9014
     },
-    // Beast slash
+            // Axe
     {
         DAMAGE_TYPE_2,
         18,
@@ -370,9 +371,9 @@ VECTORDATA gVectorData[] = {
         FX_NONE, FX_6, FX_NONE, 502,
         FX_NONE, FX_NONE, FX_NONE, -1,
         FX_NONE, FX_5, FX_NONE, -1,
-        9012, 9014
+        1101, 1101
     },
-    // Axe
+            // Cleaver
     {
         DAMAGE_TYPE_2,
         9,
@@ -397,9 +398,9 @@ VECTORDATA gVectorData[] = {
         FX_NONE, FX_6, FX_NONE, 502,
         FX_NONE, FX_NONE, FX_NONE, -1,
         FX_NONE, FX_5, FX_NONE, -1,
-        1101, 1101
+        1207, 1207
     },
-    // Cleaver
+            // Phantasm slash
     {
         DAMAGE_TYPE_2,
         20,
@@ -424,9 +425,9 @@ VECTORDATA gVectorData[] = {
         FX_NONE, FX_6, FX_NONE, 502,
         FX_NONE, FX_NONE, FX_NONE, -1,
         FX_NONE, FX_5, FX_NONE, -1,
-        1207, 1207
+        499, 495
     },
-    // Phantasm slash
+            // Gargoyle Slash
     {
         DAMAGE_TYPE_2,
         16,
@@ -451,9 +452,9 @@ VECTORDATA gVectorData[] = {
         FX_NONE, FX_6, FX_NONE, 502,
         FX_NONE, FX_NONE, FX_NONE, -1,
         FX_NONE, FX_5, FX_NONE, -1,
-        499, 495
+        495, 496
     },
-    // Gargoyle Slash
+            // Cerberus bite
     {
         DAMAGE_TYPE_2,
         19,
@@ -478,9 +479,9 @@ VECTORDATA gVectorData[] = {
         FX_NONE, FX_NONE, FX_NONE, 502,
         FX_NONE, FX_NONE, FX_NONE, -1,
         FX_NONE, FX_NONE, FX_NONE, -1,
-        495, 496
+        9013, 499
     },
-    // Cerberus bite
+            // Hound bite
     {
         DAMAGE_TYPE_2,
         10,
@@ -505,9 +506,9 @@ VECTORDATA gVectorData[] = {
         FX_NONE, FX_NONE, FX_NONE, 502,
         FX_NONE, FX_NONE, FX_NONE, -1,
         FX_NONE, FX_NONE, FX_NONE, -1,
-        9013, 499
+        1307, 1308
     },
-    // Hound bite
+            // Rat bite
     {
         DAMAGE_TYPE_2,
         4,
@@ -532,9 +533,9 @@ VECTORDATA gVectorData[] = {
         FX_NONE, FX_NONE, FX_NONE, 502,
         FX_NONE, FX_NONE, FX_NONE, -1,
         FX_NONE, FX_NONE, FX_NONE, -1,
-        1307, 1308
+        499, 499
     },
-    // Rat bite
+            // Spider bite
     {
         DAMAGE_TYPE_2,
         8,
@@ -561,7 +562,7 @@ VECTORDATA gVectorData[] = {
         FX_NONE, FX_NONE, FX_NONE, -1,
         499, 499
     },
-    // Spider bite
+            // Unk
     {
         DAMAGE_TYPE_2,
         9,
@@ -588,7 +589,7 @@ VECTORDATA gVectorData[] = {
         FX_NONE, FX_NONE, FX_NONE, -1,
         499, 499
     },
-    // Unk
+    
     {
         (DAMAGE_TYPE)-1,
         0,
@@ -694,8 +695,7 @@ VECTORDATA gVectorData[] = {
         FX_NONE, FX_NONE, FX_NONE, 357,
         FX_NONE, FX_NONE, FX_NONE, 357,
         FX_NONE, FX_NONE, FX_NONE, 357,
-        0, 0
-        //357, 499,
+        357, 499
     },
 };
 
@@ -2281,7 +2281,7 @@ THINGINFO thingInfo[] = {
         256, 256, 256, 64, 0, 0, 512,
         1
     },
-    // 433 - kGDXThingThrowableRock
+    // 434 - kGDXThingThrowableRock
     {
         5,
         6,
@@ -2297,6 +2297,23 @@ THINGINFO thingInfo[] = {
         32,
         0, 0, 0, 0, 0, 0, 0,
         1
+    },
+    // 435 - kGDXThingCustomDudeLifeLeech
+    {
+        150,
+        30,
+        48,
+        3,
+        32768,
+        1600,
+        257,
+        800,
+        (char)-128,
+        0,
+        48,
+        48,
+        64, 64, 112, 64, 0, 96, 96,
+        1,
     },
 };
 
@@ -2628,12 +2645,25 @@ void actInit(void)
             if (!IsPlayerSprite(pSprite))
             {
                 pSprite->cstat |= 4096+256+1;
-                pSprite->clipdist = dudeInfo[nType].clipdist;
+                
+                // By NoOne: allow user clipdist for custom dude.
+                switch (pSprite->type) {
+                    case kGDXDudeUniversalCultist:
+                    case kGDXGenDudeBurning:
+                        break;
+                    default:
+                        pSprite->clipdist = dudeInfo[nType].clipdist;
+                        break;
+                }
+
                 xvel[nSprite] = yvel[nSprite] = zvel[nSprite] = 0;
                 
                 // By NoOne: add a way to set custom hp for every enemy - should work only if map just started and not loaded.
                 if (pXSprite->data4 <= 0) pXSprite->health = dudeInfo[nType].startHealth << 4;
-                else pXSprite->health = pXSprite->data4;
+                else {
+                    long hp = pXSprite->data4 << 4;
+                    pXSprite->health = (hp > 0) ? ((hp <= 65535) ? hp : 65535) : 1;
+                }
             }
 
             int seqStartId = dudeInfo[nType].seqStartID;
@@ -2657,7 +2687,7 @@ void actInit(void)
                         }
 
                         if (!gSysRes.Lookup(i, "SEQ")) {
-                            //ThrowError("No SEQ file with ID " + i + " found for custom dude #" + pSprite->xvel + "!\nData2 (SEQ Base): " + pXSprite->data2 + "\nSwitching to default animation!");
+                            //ThrowError("No SEQ file  found for custom dude!");
                             pXSprite->data2 = dudeInfo[nType].seqStartID;
                             seqStartId = pXSprite->data2;
                             break;
@@ -2687,8 +2717,15 @@ void ConcussSprite(int a1, spritetype *pSprite, int x, int y, int z, int a6)
     if (pSprite->hitag & 1)
     {
         int mass = 0;
-        if (pSprite->type >= kDudeBase && pSprite->type < kDudeMax)
-            mass = dudeInfo[pSprite->type-kDudeBase].mass;
+        if (IsDudeSprite(pSprite)) {
+            mass = dudeInfo[pSprite->lotag - kDudeBase].mass;
+            switch (pSprite->lotag) {
+            case kGDXDudeUniversalCultist:
+            case kGDXGenDudeBurning:
+                mass = getDudeMassBySpriteSize(pSprite);
+                break;
+            }
+        }
         else if (pSprite->type >= kThingBase && pSprite->type < kThingMax)
             mass = thingInfo[pSprite->type-400].at2;
         else
@@ -3000,17 +3037,32 @@ void actKillDude(int a1, spritetype *pSprite, DAMAGE_TYPE a3, int a4)
         removeDudeStuff(pSprite);
         XSPRITE* pXIncarnation = getNextIncarnation(pXSprite);
         if (pXIncarnation == NULL) {
-            if (a3 == DAMAGE_TYPE_1) {
-                if (pXSprite->medium == 0) {
-                    pSprite->type = kGDXGenDudeBurning;
-                    aiNewState(pSprite, pXSprite, &GDXGenDudeBurnGoto);
-                    actHealDude(pXSprite, dudeInfo[55].startHealth, dudeInfo[55].startHealth);
-                    if (pXSprite->burnTime <= 0) pXSprite->burnTime = 1200;
-                    gDudeExtra[pSprite->extra].at0 = gFrameClock + 360;
-                    return;
-                }
-                else a3 = DAMAGE_TYPE_0;
+            
+            if (pXSprite->data1 >= 459 && pXSprite->data1 < (459 + kExplodeMax) - 1 &&
+                Chance(0x4000) && a3 != 5 && a3 != 4) {
+
+                doExplosion(pSprite, pXSprite->data1 - 459);
+                if (Chance(0x9000)) a3 = (DAMAGE_TYPE) 3;
             }
+
+            if (a3 == DAMAGE_TYPE_1) {
+                if ((gSysRes.Lookup(pXSprite->data2 + 15, "SEQ") || gSysRes.Lookup(pXSprite->data2 + 16, "SEQ"))
+                    && gSysRes.Lookup(pXSprite->data2 + 3, "SEQ") && pXSprite->medium == 0) {
+
+                        pSprite->type = kGDXGenDudeBurning;
+                        aiNewState(pSprite, pXSprite, &GDXGenDudeBurnGoto);
+                        actHealDude(pXSprite, dudeInfo[55].startHealth, dudeInfo[55].startHealth);
+                        if (pXSprite->burnTime <= 0) pXSprite->burnTime = 1200;
+                        gDudeExtra[pSprite->extra].at0 = gFrameClock + 360;
+                        return;
+
+                } else {
+                    pXSprite->burnTime = 0;
+                    pXSprite->burnSource = -1;
+                    a3 = DAMAGE_TYPE_0;
+                }
+            }
+            
         } else {
             int seqId = pXSprite->data2 + 18;
             if (!gSysRes.Lookup(seqId, "SEQ")) {
@@ -3501,6 +3553,21 @@ void actKillDude(int a1, spritetype *pSprite, DAMAGE_TYPE a3, int a4)
         seqSpawn(dudeInfo[nType].seqStartID+nSeq, 3, nXSprite, -1);
         break;
     }
+    
+                                    // kMaxSprites = custom dude had once life leech
+    if (pSprite->owner != -1 && pSprite->owner != kMaxSprites) {
+        //int owner = actSpriteIdToOwnerId(pSprite->xvel);
+        int owner = pSprite->owner;
+        switch (sprite[owner].lotag) {
+        case kGDXDudeUniversalCultist:
+        case kGDXGenDudeBurning:
+            if (owner != -1) gDudeExtra[sprite[owner].extra].at6.u1.at4--;
+            break;
+        default:
+            break;
+        }
+    }
+    
     if (a3 == DAMAGE_TYPE_3)
     {
         DUDEINFO *pDudeInfo = &dudeInfo[pSprite->type-kDudeBase];
@@ -3581,7 +3648,7 @@ int actDamageSprite(int nSource, spritetype *pSprite, DAMAGE_TYPE a3, int a4)
         pXSprite->health = ClipLow(pXSprite->health-a4, 0);
         if (!pXSprite->health)
         {
-            if (pSprite->type == 431)
+            if (pSprite->type == 431 || pSprite->type == kGDXThingCustomDudeLifeLeech)
             {
                 GibSprite(pSprite, GIBTYPE_14, NULL, NULL);
                 pXSprite->data1 = 0;
@@ -4022,8 +4089,8 @@ void actTouchFloor(spritetype *pSprite, int nSector)
 {
     dassert(pSprite != NULL);
     dassert(nSector >= 0 && nSector < kMaxSectors);
-    sectortype *pSector = &sector[nSector];
-    XSECTOR *pXSector = NULL;
+    sectortype * pSector = &sector[nSector];
+    XSECTOR * pXSector = NULL;
     if (pSector->extra > 0)
         pXSector = &xsector[pSector->extra];
 
@@ -4033,15 +4100,15 @@ void actTouchFloor(spritetype *pSprite, int nSector)
         if (pSector->lotag == 618)
             nDamageType = (DAMAGE_TYPE)ClipRange(pXSector->damageType, DAMAGE_TYPE_0, DAMAGE_TYPE_6);
         else
-            nDamageType = (DAMAGE_TYPE)ClipRange(pXSector->damageType-1, DAMAGE_TYPE_0, DAMAGE_TYPE_6);
+            nDamageType = (DAMAGE_TYPE)ClipRange(pXSector->damageType - 1, DAMAGE_TYPE_0, DAMAGE_TYPE_6);
         int nDamage;
         if (pXSector->data)
             nDamage = ClipRange(pXSector->data, 0, 1000);
         else
             nDamage = 1000;
-        actDamageSprite(pSprite->index, pSprite, nDamageType, scale(4, nDamage, 120)<<4);
+        actDamageSprite(pSprite->index, pSprite, nDamageType, scale(4, nDamage, 120) << 4);
     }
-    if (tileGetSurfType(nSector+0x4000) == 14)
+    if (tileGetSurfType(nSector + 0x4000) == 14)
     {
         actDamageSprite(pSprite->index, pSprite, DAMAGE_TYPE_1, 16);
         sfxPlay3DSound(pSprite, 352, 5, 2);
@@ -4085,9 +4152,44 @@ void ProcessTouchObjects(spritetype *pSprite, int nXSprite)
                     pSprite2->hitag |= 5;
                     xvel[pSprite2->index] += mulscale(4, pSprite2->x-sprite[nSprite].x, 2);
                     yvel[pSprite2->index] += mulscale(4, pSprite2->y-sprite[nSprite].y, 2);
-                    if (pSprite2->type == 229)
-                        if (!IsPlayerSprite(pSprite) || gPlayer[pSprite->type-kDudePlayer1].at31a == 0)
-                            actDamageSprite(pSprite2->index, pSprite, DAMAGE_TYPE_3, pXSprite->health<<2);
+                    
+                    // by NoOne: add size shroom abilities
+                    if ((IsPlayerSprite(pSprite) && isShrinked(pSprite)) || (IsPlayerSprite(pSprite2) && isGrown(pSprite2))) {
+
+                        int mass1 = dudeInfo[pSprite2->type - kDudeBase].mass;
+                        int mass2 = dudeInfo[pSprite->type - kDudeBase].mass;
+                        
+                        if (mass1 > mass2) {
+                            int dmg = abs((mass1 - mass2) * (pSprite2->clipdist - pSprite->clipdist));
+                            if (IsDudeSprite(pSprite2)) {
+                                if (dmg > 0)
+                                    actDamageSprite(pSprite2->xvel, pSprite, (Chance(0x2000)) ? DAMAGE_TYPE_0 : (Chance(0x4000)) ? DAMAGE_TYPE_3 : DAMAGE_TYPE_2, dmg);
+
+                                if (Chance(0x0200))
+                                    actKickObject(pSprite2, pSprite);
+                            }
+                        }
+                    }
+                    
+                    if (!IsPlayerSprite(pSprite) || gPlayer[pSprite->type - kDudePlayer1].at31a == 0) {
+                        switch (pSprite2->type) {
+                            case 229:
+                                actDamageSprite(pSprite2->index, pSprite, DAMAGE_TYPE_3, pXSprite->health << 2);
+                                break;
+                            case kGDXDudeUniversalCultist:
+                            case kGDXGenDudeBurning:
+                                int dmg = (getDudeMassBySpriteSize(pSprite2) - getDudeMassBySpriteSize(pSprite)) + pSprite2->clipdist;
+                                if (dmg > 0) {
+                                    if (IsPlayerSprite(pSprite) && powerupCheck(&gPlayer[pSprite->type - kDudePlayer1],15) > 0)
+                                        actDamageSprite(pSprite2->xvel, pSprite, DAMAGE_TYPE_3, dmg);
+                                    else
+                                        actDamageSprite(pSprite2->xvel, pSprite, DAMAGE_TYPE_0, dmg);
+                                }
+                                break;
+
+                        }
+                            
+                    }
                 }
             }
             if (pSprite2->type == 454)
@@ -4114,6 +4216,24 @@ void ProcessTouchObjects(spritetype *pSprite, int nXSprite)
         {
             spritetype *pSprite2 = &sprite[nHitSprite];
             //XSPRITE *pXSprite2 = &Xsprite[pSprite2->extra];
+            
+            // by NoOne: add size shroom abilities
+            if ((IsPlayerSprite(pSprite2) && isShrinked(pSprite2)) || (IsPlayerSprite(pSprite) && isGrown(pSprite))) {
+                if (xvel[pSprite->xvel] != 0) {
+                    
+                    int mass1 = dudeInfo[pSprite->type - kDudeBase].mass;
+                    int mass2 = dudeInfo[pSprite2->type - kDudeBase].mass;
+                    
+                    if (mass1 > mass2) {
+                        actKickObject(pSprite, pSprite2);
+                        sfxPlay3DSound(pSprite, 357, -1, 1);
+                        int dmg = (mass1 - mass2) + abs(xvel[pSprite->xvel] >> 16);
+                        if (dmg > 0 && IsDudeSprite(pSprite2))
+                            actDamageSprite(nSprite, pSprite2, (Chance(0x2000)) ? DAMAGE_TYPE_0 : DAMAGE_TYPE_2, dmg);
+                    }
+                }
+            }
+            
             switch (pSprite2->type)
             {
             case 415:
@@ -4149,6 +4269,23 @@ void ProcessTouchObjects(spritetype *pSprite, int nXSprite)
         {
             spritetype *pSprite2 = &sprite[nHitSprite];
             XSPRITE *pXSprite2 = &xsprite[pSprite2->extra];
+            
+            // by NoOne: add size shroom abilities
+            if ((IsPlayerSprite(pSprite2) && isShrinked(pSprite2)) || (IsPlayerSprite(pSprite) && isGrown(pSprite))) {
+                
+                int mass1 = dudeInfo[pSprite->type - kDudeBase].mass;
+                int mass2 = dudeInfo[pSprite2->type - kDudeBase].mass;
+
+                if (mass1 > mass2 && IsDudeSprite(pSprite2)) {
+                    if ((IsPlayerSprite(pSprite2) && Chance(0x500)) || !IsPlayerSprite(pSprite2))
+                        actKickObject(pSprite, pSprite2);
+
+                    int dmg = (mass1 - mass2) + pSprite->clipdist;
+                    if (dmg > 0)
+                        actDamageSprite(nSprite, pSprite2, (Chance(0x2000)) ? DAMAGE_TYPE_0 : DAMAGE_TYPE_2, dmg);
+                }
+            }
+            
             switch (pSprite2->type)
             {
             case 415:
@@ -4216,7 +4353,7 @@ void ProcessTouchObjects(spritetype *pSprite, int nXSprite)
             case 236:
             case 237:
             case 238:
-                if (pPlayer)
+                if (pPlayer && !isShrinked(pSprite))
                     actDamageSprite(nSprite, pSprite2,DAMAGE_TYPE_2, 8);
                 break;
             }
@@ -4496,9 +4633,11 @@ void MoveDude(spritetype *pSprite)
                 actImpactMissile(pHitSprite, 3);
                 gHitInfo = hitInfo;
             }
-            if (pHitXSprite && pHitXSprite->Touch && !pHitXSprite->state && !pHitXSprite->isTriggered)
-                trTriggerSprite(nHitSprite, pHitXSprite, 33);
-            if (pDudeInfo->lockOut && pHitXSprite && pHitXSprite->Push && !pHitXSprite->key && !pHitXSprite->DudeLockout && !pHitXSprite->state && !pHitXSprite->busy && !pPlayer)
+                                                  // by NoOne: this is why touch for things never worked; they always ON
+            if (pHitXSprite && pHitXSprite->Touch /*&& !pHitXSprite->state*/ && !pHitXSprite->isTriggered) {
+                if (!pHitXSprite->DudeLockout || IsPlayerSprite(pSprite)) // allow dudeLockout for Touch flag
+                    trTriggerSprite(nHitSprite, pHitXSprite, 33);
+            } if (pDudeInfo->lockOut && pHitXSprite && pHitXSprite->Push && !pHitXSprite->key && !pHitXSprite->DudeLockout && !pHitXSprite->state && !pHitXSprite->busy && !pPlayer)
                 trTriggerSprite(nHitSprite, pHitXSprite, 30);
             break;
         }
@@ -5303,21 +5442,34 @@ void actProcessSprites(void)
                 pXSprite->burnTime = ClipLow(pXSprite->burnTime-4,0);
                 actDamageSprite(actOwnerIdToSpriteId(pXSprite->burnSource), pSprite, DAMAGE_TYPE_1, 8);
             }
-            if (pXSprite->Proximity)
-            {
-                if (pSprite->type == 431)
-                    pXSprite->target = -1;
+
+                                   // by NoOne: make Sight flag work and don't process sight flag for things which is locked or triggered
+            if (pXSprite->Sight && pXSprite->locked != 1 && pXSprite->isTriggered != true) {
+                for (int i = connecthead; i >= 0; i = connectpoint2[i]) {
+                    PLAYER* pPlayer = &gPlayer[i]; int z = pPlayer->at6f - pPlayer->pSprite->z;
+                    int hitCode = VectorScan(pPlayer->pSprite, 0, z, pPlayer->at1be.dx, pPlayer->at1be.dy, pPlayer->at1be.dz, 512000, 1);
+                    if (hitCode != 3 || gHitInfo.hitsprite != pSprite->xvel) continue;
+                    trTriggerSprite(nSprite, pXSprite, 34);
+                    pXSprite->locked = 1; // lock it once triggered, so it can be unlocked again
+              
+                    break;
+                }
+            }
+                                       // by NoOne: don't process locked or 1-shot things for proximity
+            if (pXSprite->Proximity && pXSprite->locked != 1 && pXSprite->isTriggered != true) {
+                if (pSprite->type == 431) pXSprite->target = -1;
                 for (int nSprite2 = headspritestat[6]; nSprite2 >= 0; nSprite2 = nNextSprite)
                 {
-                    int v1b0 = 96;
+                    
                     nNextSprite = nextspritestat[nSprite2];
                     spritetype *pSprite2 = &sprite[nSprite2];
-                    if (pSprite2->hitag&32)
-                        continue;
+                    if (pSprite2->hitag&32) continue;
                     XSPRITE *pXSprite2 = &xsprite[pSprite2->extra];
                     if ((unsigned int)pXSprite2->health > 0)
                     {
-                        if (pSprite->type == 431 && pXSprite->target == -1)
+                        int proxyDist = 96;
+                        if (pSprite->type == kGDXThingCustomDudeLifeLeech) proxyDist = 512;
+                        else if (pSprite->type == 431 && pXSprite->target == -1)
                         {
                             int nOwner = actOwnerIdToSpriteId(pSprite->owner);
                             spritetype *pOwner = &sprite[nOwner];
@@ -5331,9 +5483,9 @@ void actProcessSprites(void)
                                 continue;
                             if (gGameOptions.nGameType == 1 && pPlayer2)
                                 continue;
-                            v1b0 = 512;
+                            proxyDist = 512;
                         }
-                        if (CheckProximity(pSprite2, pSprite->x, pSprite->y, pSprite->z, pSprite->sectnum, v1b0)) {
+                        if (CheckProximity(pSprite2, pSprite->x, pSprite->y, pSprite->z, pSprite->sectnum, proxyDist)) {
                             
                             switch (pSprite->type) {
                                 case kGDXThingTNTProx:
@@ -5344,6 +5496,9 @@ void actProcessSprites(void)
                                     if (!Chance(0x4000) && nNextSprite >= 0) continue;
                                     if (pSprite2->cstat & 0x10001) pXSprite->target = pSprite2->index;
                                     else continue;
+                                    break;
+                                case kGDXThingCustomDudeLifeLeech:
+                                    if (pXSprite->target != pSprite2->xvel) continue;
                                     break;
                             }
                             if (pSprite->owner == -1) actPropagateSpriteOwner(pSprite, pSprite2);
@@ -6019,6 +6174,7 @@ spritetype * actSpawnThing(int nSector, int x, int y, int z, int nThingType)
         pXThing->isTriggered = 0;
         break;
     case 431:
+    case kGDXThingCustomDudeLifeLeech:
         pXThing->data1 = 0;
         pXThing->data2 = 0;
         pXThing->data3 = 0;
@@ -6455,6 +6611,16 @@ void actFireVector(spritetype *pShooter, int a2, int a3, int a4, int a5, int a6,
             if (pSprite->statnum == 6)
             {
                 int t = pSprite->type == 426 ? 0 : dudeInfo[pSprite->type-kDudeBase].mass;
+                
+                if (IsDudeSprite(pSprite)) {
+                    switch (pSprite->lotag) {
+                    case kGDXDudeUniversalCultist:
+                    case kGDXGenDudeBurning:
+                        t = getDudeMassBySpriteSize(pSprite);
+                        break;
+                    }
+                }
+
                 if (t > 0 && pVectorData->at5)
                 {
                     int t2 = divscale(pVectorData->at5, t, 8);
@@ -6818,7 +6984,7 @@ int GetRandDataVal(int *rData, spritetype* pSprite) {
 }
 
 // this function drops random item using random pickup generator(s)
-spritetype* DropRandomPickupObject(spritetype* pSprite) {
+spritetype* DropRandomPickupObject(spritetype* pSprite, short prevItem) {
     spritetype* pSprite2 = NULL;
 
     int rData[4]; int selected = -1;
@@ -6830,15 +6996,15 @@ spritetype* DropRandomPickupObject(spritetype* pSprite) {
         if (rData[i] < kWeaponItemBase || rData[i] >= kItemMax)
             rData[i] = 0;
 
-    if ((selected = GetRandDataVal(rData,NULL)) > 0) {
+    int maxRetries = 9;
+    while ((selected = GetRandDataVal(rData, NULL)) == prevItem) if (maxRetries <= 0) break;
+    if (selected > 0) {
         spritetype* pSource = pSprite; XSPRITE* pXSource = &xsprite[pSource->extra];
         pSprite2 = actDropObject(pSprite, selected);
-
-        if ((pSource->hitag & kHitagExtBit) != 0) {
-            int nXSprite2 = pSprite2->extra;
-            if (nXSprite2 == -1)
-                nXSprite2 = dbInsertXSprite(pSprite2->index);
-            XSPRITE *pXSprite2 = &xsprite[nXSprite2];
+        pXSource->dropMsg = pSprite2->lotag; // store dropped item lotag in dropMsg
+        
+        if ((pSource->hitag & 0x0001) != 0 && dbInsertXSprite(pSprite2->index) != -1) {
+            XSPRITE *pXSprite2 = &xsprite[pSprite2->extra];
 
             // inherit spawn sprite trigger settings, so designer can send command when item picked up.
             pXSprite2->txID = pXSource->txID;
@@ -6961,3 +7127,60 @@ spritetype* actSpawnCustomDude(spritetype* pSprite, int nDist) {
     aiInitSprite(pDude);
     return pDude;
 }
+
+int getDudeMassBySpriteSize(spritetype* pSprite) {
+    int mass = 0; int minMass = 5;
+    if (IsDudeSprite(pSprite)) {
+        int picnum = pSprite->picnum; Seq* pSeq = NULL;
+        int seqStartId = dudeInfo[pSprite->lotag - kDudeBase].seqStartID;
+        switch (pSprite->lotag) {
+        case kGDXDudeUniversalCultist:
+        case kGDXGenDudeBurning:
+            seqStartId = xsprite[pSprite->extra].data2;
+            break;
+        }
+
+        
+        DICTNODE* hSeq = gSysRes.Lookup(seqStartId, "SEQ");
+        pSeq = (Seq*)gSysRes.Load(hSeq);
+        if (pSeq != NULL)
+            picnum = seqGetTile(&pSeq->frames[0]);
+
+        int clipDist = pSprite->clipdist;
+        if (clipDist <= 0)
+            clipDist = dudeInfo[pSprite->lotag - kDudeBase].clipdist;
+
+        int xrepeat = pSprite->xrepeat;
+        int x = tilesiz[picnum].x;
+        if (xrepeat > 64) x += ((xrepeat - 64) * 2);
+        else if (xrepeat < 64) x -= ((64 - xrepeat) * 2);
+
+        int yrepeat = pSprite->yrepeat;
+        int y = tilesiz[picnum].y;
+        if (yrepeat > 64) y += ((yrepeat - 64) * 2);
+        else if (yrepeat < 64) y -= ((64 - yrepeat) * 2);
+
+        mass = ((x + y) * clipDist) / 25;
+        //if ((mass+=(x+y)) > 200) mass+=((mass - 200)*16);
+    }
+
+    if (mass < minMass) return minMass;
+    else if (mass > 65000) return 65000;
+    return mass;
+}
+
+
+bool ceilIsTooLow(spritetype* pSprite) {
+    if (pSprite != NULL) {
+
+        sectortype* pSector = &sector[pSprite->sectnum];
+        int a = pSector->ceilingz - pSector->floorz;
+        int top, bottom;
+        GetSpriteExtents(pSprite, &top, &bottom);
+        int b = top - bottom;
+        if (a > b) return true;
+    }
+
+    return false;
+}
+

--- a/source/blood/src/actor.h
+++ b/source/blood/src/actor.h
@@ -268,7 +268,7 @@ void actFireVector(spritetype *pShooter, int a2, int a3, int a4, int a5, int a6,
 void actPostSprite(int nSprite, int nStatus);
 void actPostProcess(void);
 void MakeSplash(spritetype *pSprite, XSPRITE *pXSprite);
-spritetype* DropRandomPickupObject(spritetype* pSprite);
+spritetype* DropRandomPickupObject(spritetype* pSprite, short prevItem);
 spritetype* spawnRandomDude(spritetype* pSprite);
 int GetDataVal(spritetype* pSprite, int data);
 int my_random(int a, int b);
@@ -276,3 +276,5 @@ int GetRandDataVal(int *rData, spritetype* pSprite);
 bool sfxPlayMissileSound(spritetype* pSprite, int missileId);
 bool sfxPlayVectorSound(spritetype* pSprite, int vectorId);
 spritetype* actSpawnCustomDude(spritetype* pSprite, int nDist);
+int getDudeMassBySpriteSize(spritetype* pSprite);
+bool ceilIsTooLow(spritetype* pSprite);

--- a/source/blood/src/aiunicult.h
+++ b/source/blood/src/aiunicult.h
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //-------------------------------------------------------------------------
 #pragma once
 #include "ai.h"
+#include "eventq.h"
 
 extern AISTATE GDXGenDudeIdleL;
 extern AISTATE GDXGenDudeIdleW;
@@ -33,6 +34,9 @@ extern AISTATE GDXGenDudeGotoW;
 extern AISTATE GDXGenDudeDodgeL;
 extern AISTATE GDXGenDudeDodgeD;
 extern AISTATE GDXGenDudeDodgeW;
+extern AISTATE GDXGenDudeDodgeDmgL;
+extern AISTATE GDXGenDudeDodgeDmgD;
+extern AISTATE GDXGenDudeDodgeDmgW;
 extern AISTATE GDXGenDudeChaseL;
 extern AISTATE GDXGenDudeChaseD;
 extern AISTATE GDXGenDudeChaseW;
@@ -63,3 +67,8 @@ void aiGenDudeMoveForward(spritetype* pSprite, XSPRITE* pXSprite);
 int getGenDudeMoveSpeed(spritetype* pSprite, int which, bool mul, bool shift);
 bool TargetNearThing(spritetype* pSprite, int thingType);
 int checkAttackState(spritetype* pSprite, XSPRITE* pXSprite);
+bool doExplosion(spritetype* pSprite, int nType);
+void dudeLeechOperate(spritetype* pSprite, XSPRITE* pXSprite, EVENT a3);
+int getDodgeChance(spritetype* pSprite);
+int getRecoilChance(spritetype* pSprite);
+bool dudeIsMelee(XSPRITE* pXSprite);

--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -585,12 +585,16 @@ void StartLevel(GAMEOPTIONS *gameOptions)
         if (pSprite->statnum < kMaxStatus && pSprite->extra > 0)
         {
             XSPRITE *pXSprite = &xsprite[pSprite->extra];
-            if ((pXSprite->lSkill&(1<<gameOptions->nDifficulty))
-            || (pXSprite->lS && gameOptions->nGameType == 0)
-            || (pXSprite->lB && gameOptions->nGameType == 2)
-            || (pXSprite->lT && gameOptions->nGameType == 3)
-            || (pXSprite->lC && gameOptions->nGameType == 1))
+            if ((pXSprite->lSkill & (1 << gameOptions->nDifficulty)) || (pXSprite->lS && gameOptions->nGameType == 0)
+                || (pXSprite->lB && gameOptions->nGameType == 2) || (pXSprite->lT && gameOptions->nGameType == 3)
+                || (pXSprite->lC && gameOptions->nGameType == 1)) {
+                
                 DeleteSprite(i);
+                continue;
+            }
+
+            if (sprite[i].lotag == kGDXDudeTargetChanger)
+                InsertSpriteStat(i, kStatGDXDudeTargetChanger);
         }
     }
     scrLoadPLUs();

--- a/source/blood/src/blood.h
+++ b/source/blood/src/blood.h
@@ -35,12 +35,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define kMissileBase 300
 #define kMissileMax 318
 #define kThingBase 400
-#define kThingMax 435
+#define kThingMax 436
 
-#define kMaxPowerUps 49
+#define kMaxPowerUps 51
 
 #define kStatRespawn 8
 #define kStatMarker 10
+#define kStatGDXDudeTargetChanger 20
 #define kStatFree 1024
 
 #define kLensSize 80
@@ -54,7 +55,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define kMaxPAL 5
 
 #define kWeaponItemBase 40
-#define kItemMax 149
+#define kItemMax 151
 
 // marker sprite types
 #define kMarkerSPStart 1
@@ -149,14 +150,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define kGDXSectorFXChanger 34
 #define kGDXObjDataChanger 35
 #define kGDXSpriteDamager 36
-// 37 reserved
+#define kGDXObjDataAccumulator 37
 #define kGDXEffectSpawner 38
 #define kGDXWindGenerator 39
 
 #define kGDXThingTNTProx 433 // detects only players
 #define kGDXThingThrowableRock 434 // does small damage if hits target
+#define kGDXThingCustomDudeLifeLeech 435 // the same as normal, except it aims in specified target
 #define kGDXDudeUniversalCultist 254
 #define kGDXGenDudeBurning 255
+
+#define kGDXItemMapLevel 150 // once picked up, draws whole minimap
 
 // ai state types
 #define kAiStateOther -1

--- a/source/blood/src/callback.cpp
+++ b/source/blood/src/callback.cpp
@@ -559,8 +559,14 @@ void sub_768E8(int nSprite) // 18
 void sub_769B4(int nSprite) // 19
 {
     spritetype *pSprite = &sprite[nSprite];
-    if (pSprite->statnum == 4 && pSprite->type == 431 && !(pSprite->hitag&32))
-        xsprite[pSprite->extra].stateTimer = 0;
+    if (pSprite->statnum == 4 && !(pSprite->hitag & 32)) {
+        switch (pSprite->lotag) {
+            case 431:
+            case kGDXThingCustomDudeLifeLeech:
+                xsprite[pSprite->extra].stateTimer = 0;
+                break;
+        }
+    }
 }
 
 void sub_76A08(spritetype *pSprite, spritetype *pSprite2, PLAYER *pPlayer)

--- a/source/blood/src/db.cpp
+++ b/source/blood/src/db.cpp
@@ -93,6 +93,8 @@ const char *gItemText[] = {
     "Red Team Base",
     "Blue Flag",
     "Red Flag",
+    "DUMMY",
+    "Level map",
 };
 
 const char *gAmmoText[] = {
@@ -132,6 +134,8 @@ const char *gWeaponText[] = {
     "Dynamite",
     "Life Leech",
 };
+
+
 
 void dbCrypt(char *pPtr, int nLength, int nKey)
 {

--- a/source/blood/src/db.h
+++ b/source/blood/src/db.h
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define kMaxXSectors 512
 
 #pragma pack(push, 1)
+
 struct AISTATE;
 
 struct XSPRITE {
@@ -79,7 +80,7 @@ struct XSPRITE {
     unsigned int medium : 2; // medium
     unsigned int respawn : 2; // Respawn option
     unsigned int lockMsg : 8; // Lock msg
-    unsigned int health : 12; // 1c_0
+    unsigned int health : 20; // 1c_0
     unsigned int dudeDeaf : 1; // dudeDeaf
     unsigned int dudeAmbush : 1; // dudeAmbush
     unsigned int dudeGuard : 1; // dudeGuard
@@ -97,7 +98,8 @@ struct XSPRITE {
     AISTATE *aiState; // ai
     signed int txIndex : 10; // used by kGDXSequentialTX to keep current TX ID index
     signed int cumulDamage : 16; // for dudes
-}; // 58
+    signed int scale; // used for scaling SEQ size on sprites
+};
 
 struct XSECTOR {
     signed int reference : 14;
@@ -168,7 +170,7 @@ struct XSECTOR {
     unsigned int floorpal : 4; // Floor pal2
     unsigned int at34_0 : 8; // Floor y panning frac
     unsigned int locked : 1; // Locked
-    unsigned int windVel : 10; // Wind vel
+    unsigned int windVel; // Wind vel (by NoOne: changed from 10 bit to use higher velocity values)
     unsigned int windAng : 11; // Wind ang
     unsigned int windAlways : 1; // Wind always
     unsigned int at37_7 : 1;

--- a/source/blood/src/dude.cpp
+++ b/source/blood/src/dude.cpp
@@ -1603,8 +1603,9 @@ DUDEINFO dudeInfo[kDudeMax-kDudeBase] =
     }
 };
 
-DUDEINFO gPlayerTemplate[2] = 
+DUDEINFO gPlayerTemplate[4] = 
 {
+    // normal human
     {
         0x2f00,
         100,
@@ -1633,6 +1634,8 @@ DUDEINFO gPlayerTemplate[2] =
         0,
         0
     },
+
+    // normal beast
     {
         0x2900,
         100,
@@ -1660,5 +1663,65 @@ DUDEINFO gPlayerTemplate[2] =
         0, 0, 0, 0, 0, 0, 0,
         0,
         0
-    }
+    },
+
+    // shrink human
+    {
+        12032,
+        100,
+        10, // mass
+        1200,
+        16, // clipdist
+        0,
+        0x10,
+        0x800,
+        0xc800,
+        0x155,
+        0,
+        10,
+        10,
+        0x100,
+        0x10,
+        0x8000,
+        0x1,
+        0,
+        0,
+        0,
+        0x40,
+        15, -1, -1, // gib type
+        1024, 1024, 1024, 1024, 256, 1024, 1024, //damage shift
+        0, 0, 0, 0, 0, 0, 0,
+        0,
+        0
+    },
+
+     // grown human
+     {
+         12032,
+         100,
+         1100, // mass
+         1200,
+         100, // clipdist
+         0,
+         0x10,
+         0x800,
+         0xc800,
+         0x155,
+         0,
+         10,
+         10,
+         0x100,
+         0x10,
+         0x8000,
+         0x1,
+         0,
+         0,
+         0,
+         0x40,
+         15, 7, 7, // gib type
+         64, 64, 64, 64, 256, 64, 64, // damage shift
+         0, 0, 0, 0, 0, 0, 0,
+         0,
+         0
+     },
 };

--- a/source/blood/src/dude.h
+++ b/source/blood/src/dude.h
@@ -53,4 +53,4 @@ struct DUDEINFO {
 };
 
 extern DUDEINFO dudeInfo[kDudeMax-kDudeBase];
-extern DUDEINFO gPlayerTemplate[2];
+extern DUDEINFO gPlayerTemplate[4];

--- a/source/blood/src/eventq.h
+++ b/source/blood/src/eventq.h
@@ -26,8 +26,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 struct RXBUCKET
 {
-    unsigned int at0_0 : 13;
-    unsigned int at1_5 : 3;
+    unsigned int index : 13;
+    unsigned int type : 3;
 };
 extern RXBUCKET rxBucket[];
 extern unsigned short bucketHead[];
@@ -52,9 +52,9 @@ enum COMMAND_ID {
 };
 
 struct EVENT {
-    unsigned int at0_0 : 13; // index
-    unsigned int at1_5 : 3; // type
-    unsigned int at2_0 : 8; // cmd
+    unsigned int index : 13; // index
+    unsigned int type : 3; // type
+    unsigned int cmd : 8; // cmd
     unsigned int funcID : 8; // callback
 }; // <= 4 bytes
 

--- a/source/blood/src/player.h
+++ b/source/blood/src/player.h
@@ -33,6 +33,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 enum LifeMode {
     kModeHuman = 0,
     kModeBeast,
+    kModeHumanShrink,
+    kModeHumanGrown,
 };
 
 struct PACKINFO {
@@ -179,7 +181,7 @@ struct AMMOINFO {
     signed char at4;
 };
 
-extern POSTURE gPosture[][3];
+extern POSTURE gPosture[4][3];
 
 extern PLAYER gPlayer[kMaxPlayers];
 extern PLAYER *gMe, *gView;
@@ -233,3 +235,9 @@ void sub_41250(PLAYER *pPlayer);
 void playerLandingSound(PLAYER *pPlayer);
 void PlayerSurvive(int, int nXSprite);
 void PlayerKeelsOver(int, int nXSprite);
+bool isGrown(spritetype* pSprite);
+bool isShrinked(spritetype* pSprite);
+bool shrinkPlayerSize(PLAYER* pPlayer, int divider);
+bool growPlayerSize(PLAYER* pPlayer, int multiplier);
+bool resetPlayerSize(PLAYER* pPlayer);
+void deactivateSizeShrooms(PLAYER* pPlayer);

--- a/source/blood/src/seq.h
+++ b/source/blood/src/seq.h
@@ -22,6 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //-------------------------------------------------------------------------
 #pragma once
 #include "resource.h"
+
 struct SEQFRAME {
     unsigned int tile : 12;
     unsigned int at1_4 : 1; // transparent

--- a/source/blood/src/sfx.cpp
+++ b/source/blood/src/sfx.cpp
@@ -279,8 +279,8 @@ void sfxPlay3DSound(spritetype *pSprite, int soundId, int a3, int a4)
     RestoreInterrupts();
 }
 
-// By NoOne: same as previous, but allows to set custom pitch for sound. Used by SFX gen now.
-void sfxPlay3DSoundCP(spritetype* pSprite, int soundId, int a3, int a4, int pitch)
+// By NoOne: same as previous, but allows to set custom pitch for sound AND volume. Used by SFX gen now.
+void sfxPlay3DSoundCP(spritetype* pSprite, int soundId, int a3, int a4, int pitch, int volume)
 {
     if (!SoundToggle || !pSprite || soundId < 0) return;
     DICTNODE* hRes = gSoundRes.Lookup(soundId, "SFX");
@@ -346,7 +346,7 @@ void sfxPlay3DSoundCP(spritetype* pSprite, int soundId, int a3, int a4, int pitc
     pBonkle->at2c = pBonkle->at20;
     pBonkle->atc = soundId;
     pBonkle->at8 = hRes;
-    pBonkle->at1c = pEffect->relVol;
+    pBonkle->at1c = (volume <= 0) ? pEffect->relVol : volume;
     pBonkle->at18 = v14;
     Calc3DValues(pBonkle);
     int priority = 1;

--- a/source/blood/src/sfx.h
+++ b/source/blood/src/sfx.h
@@ -27,7 +27,7 @@ void sfxInit(void);
 void sfxTerm(void);
 void sfxPlay3DSound(int x, int y, int z, int soundId, int nSector);
 void sfxPlay3DSound(spritetype *pSprite, int soundId, int a3 = -1, int a4 = 0);
-void sfxPlay3DSoundCP(spritetype* pSprite, int soundId, int a3 = -1, int a4 = 0, int pitch = 0);
+void sfxPlay3DSoundCP(spritetype* pSprite, int soundId, int a3 = -1, int a4 = 0, int pitch = 0, int volume = 0);
 void sfxKill3DSound(spritetype *pSprite, int a2 = -1, int a3 = -1);
 void sfxKillAllSounds(void);
 void sfxUpdate3DSounds(void);

--- a/source/blood/src/triggers.cpp
+++ b/source/blood/src/triggers.cpp
@@ -213,8 +213,8 @@ void ReverseBusy(int a1, BUSYID a2)
 
 unsigned int GetSourceBusy(EVENT a1)
 {
-    int nIndex = a1.at0_0;
-    switch (a1.at1_5)
+    int nIndex = a1.index;
+    switch (a1.type)
     {
     case 6:
     {
@@ -240,7 +240,7 @@ unsigned int GetSourceBusy(EVENT a1)
 
 void sub_43CF8(spritetype *pSprite, XSPRITE *pXSprite, EVENT a3)
 {
-    switch (a3.at2_0)
+    switch (a3.cmd)
     {
     case 30:
     {
@@ -322,21 +322,31 @@ void ActivateGenerator(int);
 void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
 {
     spritetype *pSprite = &sprite[nSprite];
-    switch (a3.at2_0)
+    switch (a3.cmd)
     {
     case 6:
         pXSprite->locked = 1;
+        switch (pSprite->type) {
+        case kGDXWindGenerator:
+            stopWindOnSectors(pXSprite);
+            break;
+        }
         return;
     case 7:
         pXSprite->locked = 0;
         return;
     case 8:
         pXSprite->locked = pXSprite->locked ^ 1;
+        switch(pSprite->type) {
+         case kGDXWindGenerator:
+            if (pXSprite->locked == 1) stopWindOnSectors(pXSprite);
+            break;
+        }
         return;
     }
     if (pSprite->statnum == 6 && pSprite->type >= kDudeBase && pSprite->type < kDudeMax)
     {
-        switch (a3.at2_0)
+        switch (a3.cmd)
         {
         case 0:
             SetSpriteState(nSprite, pXSprite, 0);
@@ -391,7 +401,7 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
             pXSprite->txID = tx; 
         }
 
-        switch (a3.at2_0)
+        switch (a3.cmd)
         {
         case COMMAND_ID_0:
             SetSpriteState(nSprite, pXSprite, 0);
@@ -420,6 +430,17 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
                 pXSprite->data1 = (short)pXSprite->data4;
                 pXSprite->data4 = tmp;
             }
+            
+            // force send command to all TX id in a range
+            if (pSprite->hitag == 1) {
+                for (int i = pXSprite->data1; i <= pXSprite->data4; i++) {
+                    evSend(nSprite, 3, i, (COMMAND_ID) pXSprite->command);
+                }
+
+                pXSprite->txIndex = 0;
+                SetSpriteState(nSprite, pXSprite, pXSprite->state ^ 1);
+                break;
+            }
 
             // Make sure txIndex is correct as we store current index of TX ID here.
             if (pXSprite->txIndex < pXSprite->data1) pXSprite->txIndex = pXSprite->data1;
@@ -433,7 +454,7 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
             else if (pXSprite->txIndex < 0) pXSprite->txIndex = 3;
         }
 
-        switch (a3.at2_0) {
+        switch (a3.cmd) {
             case COMMAND_ID_0:
                 if (range == false) {
                     while (cnt-- >= 0) { // skip empty data fields
@@ -481,7 +502,7 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
     case 413:
         if (pXSprite->health > 0)
         {
-            if (a3.at2_0 == 1)
+            if (a3.cmd == 1)
             {
                 if (SetSpriteState(nSprite, pXSprite, 1))
                 {
@@ -490,7 +511,7 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
                         pXSprite->data2 = pXSprite->data1;
                 }
             }
-            else if (a3.at2_0 == 0)
+            else if (a3.cmd == 0)
             {
                 if (SetSpriteState(nSprite, pXSprite, 0))
                     seqSpawn(40, 3, pSprite->extra, -1);
@@ -510,7 +531,7 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
             actPostSprite(nSprite, kStatFree);
         break;
     case 456:
-        switch (a3.at2_0)
+        switch (a3.cmd)
         {
         case 0:
             pXSprite->state = 0;
@@ -530,7 +551,7 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
         }
         break;
     case 452:
-        if (a3.at2_0 == 1)
+        if (a3.cmd == 1)
         {
             if (SetSpriteState(nSprite, pXSprite, 1))
             {
@@ -538,7 +559,7 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
                 sfxPlay3DSound(pSprite, 441, 0, 0);
             }
         }
-        else if (a3.at2_0 == 0)
+        else if (a3.cmd == 0)
         {
             if (SetSpriteState(nSprite, pXSprite, 0))
             {
@@ -548,7 +569,7 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
         }
         break;
     case 23:
-        switch (a3.at2_0)
+        switch (a3.cmd)
         {
         case 0:
             SetSpriteState(nSprite, pXSprite, 0);
@@ -565,7 +586,7 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
         }
         break;
     case 20:
-        switch (a3.at2_0)
+        switch (a3.cmd)
         {
         case 0:
             if (SetSpriteState(nSprite, pXSprite, 0))
@@ -587,7 +608,7 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
         }
         break;
     case 21:
-        switch (a3.at2_0)
+        switch (a3.cmd)
         {
         case 0:
             if (SetSpriteState(nSprite, pXSprite, 0))
@@ -622,7 +643,7 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
             evSend(nSprite, 3, pXSprite->txID, COMMAND_ID_5);
         break;
     case 22:
-        switch (a3.at2_0)
+        switch (a3.cmd)
         {
         case 0:
             pXSprite->data1--;
@@ -648,15 +669,13 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
     case kGDXObjSizeChanger:
     case kGDXSectorFXChanger:
     case kGDXObjDataChanger:
-        /*
-        By NoOne: works only if have link command, but sends new command.
-        Sending new command is *required*, because types above are universal
-        and can paste properties in different objects.
-        */
-        if (pXSprite->command == COMMAND_ID_5) {
+        // by NoOne: Sending new command instead of link is *required*, because types above 
+        //are universal and can paste properties in different objects.
+        if (pXSprite->command == COMMAND_ID_5)
             evSend(nSprite, 3, pXSprite->txID, kGDXCommandPaste);
-
-            //SetSpriteState(nSprite, pXSprite, pXSprite.restState ^ 1);
+        else {
+            evSend(nSprite, 3, pXSprite->txID, kGDXCommandPaste); // send first command to change properties
+            evSend(nSprite, 3, pXSprite->txID, (COMMAND_ID) pXSprite->command); // then send normal command
         }
         break;
     // this type damages sprite with given damageType
@@ -665,7 +684,19 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
         break;
     case 40: // Random weapon
     case 80: // Random ammo
-        DropRandomPickupObject(pSprite);
+        // let's first search for previously dropped items and remove it
+        if (pXSprite->dropMsg > 0) {
+            for (short nItem = headspritestat[3]; nItem >= 0; nItem = nextspritestat[nItem]) {
+                spritetype* pItem = &sprite[nItem];
+                if (pItem->lotag == pXSprite->dropMsg && pItem->x == pSprite->x && pItem->y == pSprite->y && pItem->z == pSprite->z) {
+                    gFX.fxSpawn((FX_ID) 29, pSprite->sectnum, pSprite->x, pSprite->y, pSprite->z, 0);
+                    deletesprite(nItem);
+                    break;
+                }
+            }
+        }
+        // then drop item
+        DropRandomPickupObject(pSprite, pXSprite->dropMsg);
         break;
     case kGDXCustomDudeSpawn:
         if (gGameOptions.nMonsterSettings && actSpawnCustomDude(pSprite, -1) != NULL)
@@ -730,7 +761,7 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
         actExplodeSprite(pSprite);
         break;
     case 459:
-        switch (a3.at2_0)
+        switch (a3.cmd)
         {
         case 1:
             SetSpriteState(nSprite, pXSprite, 1);
@@ -743,31 +774,39 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
         break;
     case kGDXSeqSpawner:
     case kGDXEffectSpawner:
-        switch (a3.at2_0)
-        {
-        case COMMAND_ID_0:
-            SetSpriteState(nSprite, pXSprite, 0);
-            break;
-        case COMMAND_ID_21:
-            ActivateGenerator(nSprite);
-            if (pXSprite->txID != 0)
-                evSend(nSprite, 3, pXSprite->txID, (COMMAND_ID)pXSprite->command);
-            if (pXSprite->busyTime > 0)
-                evPost(nSprite, 3, ClipLow((int(pXSprite->busyTime) + Random2(pXSprite->data1)) * 120 / 10, 0), COMMAND_ID_21);
-            break;
-        default:
-            if (pXSprite->state == 0) {
+        switch (a3.cmd) {
+            case COMMAND_ID_0:
+                SetSpriteState(nSprite, pXSprite, 0);
+                break;
+            case COMMAND_ID_1:
+                if (pXSprite->state == 1) break;
+                fallthrough__;
+            case COMMAND_ID_21:
                 SetSpriteState(nSprite, pXSprite, 1);
-                evPost(nSprite, 3, 0, COMMAND_ID_21);
-            }
-            break;
+                if (pXSprite->txID <= 0)
+                    (pSprite->type == kGDXSeqSpawner) ? useSeqSpawnerGen(pXSprite, NULL) : useEffectGen(pXSprite, NULL);
+                else if (pXSprite->command == COMMAND_ID_5)
+                    evSend(nSprite, 3, pXSprite->txID, kGDXCommandPaste);
+                else {
+                    evSend(nSprite, 3, pXSprite->txID, kGDXCommandPaste);
+                    evSend(nSprite, 3, pXSprite->txID, (COMMAND_ID) pXSprite->command);
+                }
+            
+                if (pXSprite->busyTime > 0)
+                    evPost(nSprite, 3, ClipLow((int(pXSprite->busyTime) + Random2(pXSprite->data1)) * 120 / 10, 0), COMMAND_ID_21);
+                break;
+
+            case COMMAND_ID_3:
+                if (pXSprite->state == 0) evPost(nSprite, 3, 0, COMMAND_ID_21);
+                else evPost(nSprite, 3, 0, COMMAND_ID_0);
+                break;
         }
 
         break;
     case 402:
         if (pSprite->statnum == 8)
             break;
-        if (a3.at2_0 != 1)
+        if (a3.cmd != 1)
             actExplodeSprite(pSprite);
         else
         {
@@ -779,7 +818,7 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
     case kGDXThingTNTProx:
         if (pSprite->statnum == 8)
             break;
-        switch (a3.at2_0)
+        switch (a3.cmd)
         {
         case 35:
             if (!pXSprite->state)
@@ -801,67 +840,116 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
     case 431:
         sub_43CF8(pSprite, pXSprite, a3);
         break;
+    case kGDXThingCustomDudeLifeLeech:
+        dudeLeechOperate(pSprite, pXSprite, a3);
+        break;
     case kGDXWindGenerator:
-        switch (a3.at2_0)
-        {
+        switch (a3.cmd) {
         case COMMAND_ID_0:
+            stopWindOnSectors(pXSprite);
             SetSpriteState(nSprite, pXSprite, 0);
             break;
+        case COMMAND_ID_1:
+            if (pXSprite->state == 1) break;
+            fallthrough__;
         case COMMAND_ID_21:
-            if (pXSprite->txID != 0)
+            SetSpriteState(nSprite, pXSprite, 1);
+            if (pXSprite->txID <= 0) useSectorWindGen(pXSprite, NULL);
+            else if (pXSprite->command == COMMAND_ID_5)
                 evSend(nSprite, 3, pXSprite->txID, kGDXCommandPaste);
-            if (pXSprite->busyTime > 0)
-                if (pXSprite->txID != 0)
-                    evSend(nSprite, 3, pXSprite->txID, kGDXCommandPaste);
+            else {
+                evSend(nSprite, 3, pXSprite->txID, kGDXCommandPaste);
+                evSend(nSprite, 3, pXSprite->txID, (COMMAND_ID) pXSprite->command);
+            }
+
             if (pXSprite->busyTime > 0)
                 evPost(nSprite, 3, pXSprite->busyTime, COMMAND_ID_21);
             break;
-        default:
-            if (pXSprite->state == 0) {
-                SetSpriteState(nSprite, pXSprite, 1);
-                evPost(nSprite, 3, 0, COMMAND_ID_21);
-            }
+        case COMMAND_ID_3:
+            if (pXSprite->state == 0) evPost(nSprite, 3, 0, COMMAND_ID_21);
+            else evPost(nSprite, 3, 0, COMMAND_ID_0);
             break;
         }
 
         break;
     case kGDXDudeTargetChanger:
     {
-        // required to wake monsters after genIdle state.
+        // this one is required if data4 of generator was dynamically changed
+        // it turns monsters in normal idle state instead of genIdle, so they
+        // not ignore the world.
         bool activated = false;
         if (pXSprite->dropMsg == 3 && 3 != pXSprite->data4) {
             activateDudes(pXSprite->txID);
             activated = true;
         }
 
-        switch (a3.at2_0)
+        switch (a3.cmd)
         {
         case COMMAND_ID_0:
-            if (pXSprite->data4 == 3 && activated == false)
-                activateDudes(pXSprite->txID);
-
+            if (pXSprite->data4 == 3 && activated == false) activateDudes(pXSprite->txID);
             SetSpriteState(nSprite, pXSprite, 0);
             break;
+        case COMMAND_ID_1:
+            if (pXSprite->state == 1) break;
+            fallthrough__;
         case COMMAND_ID_21:
-            if (pXSprite->txID != 0)
-                evSend(nSprite, 3, pXSprite->txID, kGDXCommandPaste);
-            if (pXSprite->busyTime > 0)
-                if (pXSprite->txID != 0)
-                    evSend(nSprite, 3, pXSprite->txID, kGDXCommandPaste);
-            if (pXSprite->busyTime > 0)
-                evPost(nSprite, 3, pXSprite->busyTime, COMMAND_ID_21);
-            break;
-        default:
-            if (pXSprite->state == 0) {
-                SetSpriteState(nSprite, pXSprite, 1);
-                evPost(nSprite, 3, 0, COMMAND_ID_21);
+            SetSpriteState(nSprite, pXSprite, 1);
+            if (pXSprite->txID <= 0 || !getDudesForTargetChg(pXSprite)) {
+                evPost(nSprite, 3, 0, COMMAND_ID_0);
+                break;
             }
+            else if (pXSprite->command == COMMAND_ID_5)
+                evSend(nSprite, 3, pXSprite->txID, kGDXCommandPaste);
+            else {
+                evSend(nSprite, 3, pXSprite->txID, kGDXCommandPaste);
+                evSend(nSprite, 3, pXSprite->txID, (COMMAND_ID)pXSprite->command);
+            }
+
+            if (pXSprite->busyTime > 0) evPost(nSprite, 3, pXSprite->busyTime, COMMAND_ID_21);
+            break;
+        case COMMAND_ID_3:
+            if (pXSprite->state == 0) evPost(nSprite, 3, 0, COMMAND_ID_21);
+            else evPost(nSprite, 3, 0, COMMAND_ID_0);
             break;
         }
 
         pXSprite->dropMsg = (short)pXSprite->data4;
         break;
     }
+    case kGDXObjDataAccumulator:
+            switch (a3.cmd) {
+            case COMMAND_ID_0:
+                SetSpriteState(nSprite, pXSprite, 0);
+                break;
+            case COMMAND_ID_1:
+                if (pXSprite->state == 1) break;
+            case COMMAND_ID_21:
+                SetSpriteState(nSprite, pXSprite, 1);
+
+                // force OFF after *all* TX objects reach the goal value
+                if (pSprite->hitag == 0 && goalValueIsReached(pXSprite)) {
+                    evPost(nSprite, 3, 0, COMMAND_ID_0);
+                    break;
+                }
+
+                if (pXSprite->data1 > 0 && pXSprite->data1 <= 4 && pXSprite->data2 > 0) {
+                    if (pXSprite->txID != 0) {
+                        if (pXSprite->command == COMMAND_ID_5)
+                            evSend(nSprite, 3, pXSprite->txID, kGDXCommandPaste);
+                        else {
+                            evSend(nSprite, 3, pXSprite->txID, kGDXCommandPaste);
+                            evSend(nSprite, 3, pXSprite->txID, (COMMAND_ID) pXSprite->command);
+                        }
+                    }
+                    if (pXSprite->busyTime > 0) evPost(nSprite, 3, pXSprite->busyTime, COMMAND_ID_21);
+                }
+                break;
+            case COMMAND_ID_3:
+                if (pXSprite->state == 0) evPost(nSprite, 3, 0, COMMAND_ID_21);
+                else evPost(nSprite, 3, 0, COMMAND_ID_0);
+                break;
+            }
+        break;
     case 700:
     case 701:
     case 702:
@@ -871,7 +959,7 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
     case 706:
     case 707:
     case 708:
-        switch (a3.at2_0)
+        switch (a3.cmd)
         {
         case 0:
             SetSpriteState(nSprite, pXSprite, 0);
@@ -910,7 +998,7 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
     case 425:
     case 426:
     case 427:
-        switch (a3.at2_0)
+        switch (a3.cmd)
         {
         case 0:
             if (SetSpriteState(nSprite, pXSprite, 0))
@@ -927,7 +1015,7 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
         }
         break;
     default:
-        switch (a3.at2_0)
+        switch (a3.cmd)
         {
         case 0:
             SetSpriteState(nSprite, pXSprite, 0);
@@ -942,6 +1030,121 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
         break;
     }
 }
+
+// by NoOne: this function stops wind on all TX sectors affected by WindGen after it goes off state.
+void stopWindOnSectors(XSPRITE* pXSource) {
+    for (int i = bucketHead[pXSource->txID]; i < bucketHead[pXSource->txID + 1]; i++) {
+        if (rxBucket[i].type != 3) continue;
+        XSECTOR * pXSector = &xsector[sector[rxBucket[i].index].extra];
+        if ((pXSector->state == 1 && !pXSector->windAlways) || sprite[pXSource->reference].hitag == 1)
+            pXSector->windVel = 0;
+    }
+}
+
+void useSectorWindGen(XSPRITE* pXSource, sectortype* pSector) {
+    
+    spritetype* pSource = &sprite[pXSource->reference];
+    XSECTOR* pXSector = NULL; bool forceWind = false;
+
+    if (pSector == NULL) {
+        
+        if (sector[pSource->sectnum].extra < 0) {
+            int nXSector = dbInsertXSector(pSource->sectnum);
+            if (nXSector > 0) pXSector = &xsector[nXSector];
+            else return;
+
+            forceWind = true;
+
+        } else {
+            pXSector = &xsector[sector[pSource->sectnum].extra];
+        }
+    } else {
+        pXSector = &xsector[pSector->extra];
+    }
+    
+    if (pSource->hitag) {
+        pXSector->panAlways = 1;
+        pXSector->windAlways = 1;
+    } else if (forceWind) 
+        pXSector->windAlways = 1;
+
+    if (pXSource->data2 > 32766) pXSource->data2 = 32767;
+
+    if (pXSource->data1 == 1 || pXSource->data1 == 3) pXSector->windVel = Random(pXSource->data2);
+    else pXSector->windVel = pXSource->data2;
+
+    if (pXSource->data1 == 2 || pXSource->data1 == 3) {
+        short ang = pSource->ang;
+        while (pSource->ang == ang)
+            pSource->ang = Random3(kAng360);
+    }
+
+    pXSector->windAng = pSource->ang;
+
+    if (pXSource->data3 > 0 && pXSource->data3 < 4) {
+        switch (pXSource->data3) {
+        case 1:
+            pXSector->panFloor = true;
+            pXSector->panCeiling = false;
+            break;
+        case 2:
+            pXSector->panFloor = false;
+            pXSector->panCeiling = true;
+            break;
+        case 3:
+            pXSector->panFloor = true;
+            pXSector->panCeiling = true;
+            break;
+        }
+
+        pXSector->panAngle = pXSector->windAng;
+        pXSector->panVel = pXSector->windVel;
+    }
+}
+
+void useSeqSpawnerGen(XSPRITE* pXSource, spritetype* pSprite) {
+    if (pSprite == NULL) pSprite = &sprite[pXSource->reference];
+    if (pSprite->extra < 0) return;
+    
+    seqSpawn(pXSource->data2, 3, pSprite->extra, (pXSource->data3 > 0) ? pXSource->data3 : -1);
+    if (pXSource->data4 > 0)
+        sfxPlay3DSound(pSprite, pXSource->data4, -1, 0);
+}
+
+void useEffectGen(XSPRITE* pXSource, spritetype* pSprite) {
+    if (pSprite == NULL) pSprite = &sprite[pXSource->reference];
+    if (pSprite->extra < 0) return;
+
+    int top, bottom; GetSpriteExtents(pSprite, &top, &bottom); int cnt = pXSource->data4;
+    spritetype* pEffect = NULL; if (cnt > 32) cnt = 32;
+
+    while (cnt-- >= 0) {
+        if (cnt > 0) {
+
+            int dx = Random3(250);
+            int dy = Random3(150);
+
+            pEffect = gFX.fxSpawn((FX_ID)pXSource->data2, pSprite->sectnum, pSprite->x + dx, pSprite->y + dy, top, 0);
+
+        }
+        else {
+            pEffect = gFX.fxSpawn((FX_ID)pXSource->data2, pSprite->sectnum, pSprite->x, pSprite->y, top, 0);
+        }
+
+        if (pEffect != NULL) {
+            if (pEffect->pal <= 0) pEffect->pal = pSprite->pal;
+            if (pEffect->xrepeat <= 0) pEffect->xrepeat = pSprite->xrepeat;
+            if (pEffect->yrepeat <= 0) pEffect->yrepeat = pSprite->yrepeat;
+            if (pEffect->shade == 0) pEffect->shade = pSprite->shade;
+        }
+    }
+
+    if (pXSource->data3 > 0)
+        sfxPlay3DSound(pSprite, pXSource->data3, -1, 0);
+
+}
+
+
 
 void SetupGibWallState(walltype *pWall, XWALL *pXWall)
 {
@@ -976,7 +1179,7 @@ void SetupGibWallState(walltype *pWall, XWALL *pXWall)
 void OperateWall(int nWall, XWALL *pXWall, EVENT a3)
 {
     walltype *pWall = &wall[nWall];
-    switch (a3.at2_0)
+    switch (a3.cmd)
     {
     case 6:
         pXWall->locked = 1;
@@ -991,7 +1194,7 @@ void OperateWall(int nWall, XWALL *pXWall, EVENT a3)
     if (pWall->lotag == 511)
     {
         char bStatus;
-        switch (a3.at2_0)
+        switch (a3.cmd)
         {
         case 1:
         case 51:
@@ -1017,7 +1220,7 @@ void OperateWall(int nWall, XWALL *pXWall, EVENT a3)
         }
         return;
     }
-    switch (a3.at2_0)
+    switch (a3.cmd)
     {
     case 0:
         SetWallState(nWall, pXWall, 0);
@@ -1663,7 +1866,7 @@ int PathBusy(unsigned int nSector, unsigned int a2)
 
 void OperateDoor(unsigned int nSector, XSECTOR *pXSector, EVENT a3, BUSYID a4) 
 {
-    switch (a3.at2_0)
+    switch (a3.cmd)
     {
     case 0:
         if (pXSector->busy)
@@ -1792,7 +1995,7 @@ void OperatePath(unsigned int nSector, XSECTOR *pXSector, EVENT a3)
     pXSector->at2e_0 = nSprite;
     pXSector->at24_0 = pSprite2->z;
     pXSector->at28_0 = pSprite->z;
-    switch (a3.at2_0)
+    switch (a3.cmd)
     {
     case 1:
         pXSector->state = 0;
@@ -1808,7 +2011,7 @@ void OperateSector(unsigned int nSector, XSECTOR *pXSector, EVENT a3)
 {
     dassert(nSector < (unsigned int)numsectors);
     sectortype *pSector = &sector[nSector];
-    switch (a3.at2_0)
+    switch (a3.cmd)
     {
     case 6:
         pXSector->locked = 1;
@@ -1860,7 +2063,7 @@ void OperateSector(unsigned int nSector, XSECTOR *pXSector, EVENT a3)
             OperateDoor(nSector, pXSector, a3, BUSYID_4);
             break;
         case 613:
-            switch (a3.at2_0)
+            switch (a3.cmd)
             {
             case 1:
                 pXSector->state = 0;
@@ -1887,7 +2090,7 @@ void OperateSector(unsigned int nSector, XSECTOR *pXSector, EVENT a3)
                 OperateDoor(nSector, pXSector, a3, BUSYID_6);
             else
             {
-                switch (a3.at2_0)
+                switch (a3.cmd)
                 {
                 case 0:
                     SetSectorState(nSector, pXSector, 0);
@@ -1955,7 +2158,7 @@ void LinkSector(int nSector, XSECTOR *pXSector, EVENT a3)
     case kSecCounter:
     {
         int nXIndex;
-        nXIndex = sector[a3.at0_0].extra;
+        nXIndex = sector[a3.index].extra;
         XSECTOR* pXSector2 = &xsector[nXIndex];
         pXSector->waitTimeA = pXSector2->waitTimeA;
         pXSector->data = pXSector2->data;
@@ -1986,8 +2189,8 @@ void LinkSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
     case kMarkerUpStack:
     case kMarkerLowStack:
     {
-        if (a3.at1_5 != 3) break;
-        spritetype *pSprite2 = &sprite[a3.at0_0];
+        if (a3.type != 3) break;
+        spritetype *pSprite2 = &sprite[a3.index];
         if (pSprite2->extra < 0) break;
         XSPRITE *pXSprite2 = &xsprite[pSprite2->extra];
 
@@ -2076,9 +2279,9 @@ void LinkSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
     case kMarkerPath:
     {
         // only path marker to path marker link allowed
-        if (a3.at1_5 == 3)
+        if (a3.type == 3)
         {
-            int nXSprite2 = sprite[a3.at0_0].extra;
+            int nXSprite2 = sprite[a3.index].extra;
             // get master path marker data fields
             pXSprite->data1 = xsprite[nXSprite2].data1;
             pXSprite->data2 = xsprite[nXSprite2].data2;
@@ -2093,9 +2296,9 @@ void LinkSprite(int nSprite, XSPRITE *pXSprite, EVENT a3)
     break;
     case kSwitchCombo:
     {
-        if (a3.at1_5 == 3)
+        if (a3.type == 3)
         {
-            int nSprite2 = a3.at0_0;
+            int nSprite2 = a3.index;
             int nXSprite2 = sprite[nSprite2].extra;
             dassert(nXSprite2 > 0 && nXSprite2 < kMaxXSprites);
             pXSprite->data1 = xsprite[nXSprite2].data1;
@@ -2139,7 +2342,7 @@ void trTriggerSector(unsigned int nSector, XSECTOR *pXSector, int a3)
         else
         {
             EVENT evnt;
-            evnt.at2_0 = a3;
+            evnt.cmd = a3;
             OperateSector(nSector, pXSector, evnt);
         }
     }
@@ -2151,11 +2354,11 @@ void trMessageSector(unsigned int nSector, EVENT a2)
     dassert(sector[nSector].extra > 0 && sector[nSector].extra < kMaxXSectors);
     int nXSector = sector[nSector].extra;
     XSECTOR *pXSector = &xsector[nXSector];
-    if (!pXSector->locked || a2.at2_0 == 7 || a2.at2_0 == 8)
+    if (!pXSector->locked || a2.cmd == 7 || a2.cmd == 8)
     {
-        if (a2.at2_0 == 5)
+        if (a2.cmd == 5)
             LinkSector(nSector, pXSector, a2);
-        else if (a2.at2_0 == kGDXCommandPaste)
+        else if (a2.cmd == kGDXCommandPaste)
             pastePropertiesInObj(6, nSector, a2);
         else
             OperateSector(nSector, pXSector, a2);
@@ -2177,7 +2380,7 @@ void trTriggerWall(unsigned int nWall, XWALL *pXWall, int a3)
         else
         {
             EVENT evnt;
-            evnt.at2_0 = a3;
+            evnt.cmd = a3;
             OperateWall(nWall, pXWall, evnt);
         }
     }
@@ -2189,11 +2392,11 @@ void trMessageWall(unsigned int nWall, EVENT a2)
     dassert(wall[nWall].extra > 0 && wall[nWall].extra < kMaxXWalls);
     int nXWall = wall[nWall].extra;
     XWALL *pXWall = &xwall[nXWall];
-    if (!pXWall->locked || a2.at2_0 == 7 || a2.at2_0 == 8)
+    if (!pXWall->locked || a2.cmd == 7 || a2.cmd == 8)
     {
-        if (a2.at2_0 == 5)
+        if (a2.cmd == 5)
             LinkWall(nWall, pXWall, a2);
-        else if (a2.at2_0 == kGDXCommandPaste)
+        else if (a2.cmd == kGDXCommandPaste)
             pastePropertiesInObj(0, nWall, a2);
         else
             OperateWall(nWall, pXWall, a2);
@@ -2214,7 +2417,7 @@ void trTriggerSprite(unsigned int nSprite, XSPRITE *pXSprite, int a3)
         else
         {
             EVENT evnt;
-            evnt.at2_0 = a3;
+            evnt.cmd = a3;
             OperateSprite(nSprite, pXSprite, evnt);
         }
     }
@@ -2226,13 +2429,13 @@ void trMessageSprite(unsigned int nSprite, EVENT a2)
         return;
     int nXSprite = sprite[nSprite].extra;
     XSPRITE *pXSprite = &xsprite[nXSprite];
-    if (!pXSprite->locked || a2.at2_0 == 7 || a2.at2_0 == 8)
+    if (!pXSprite->locked || a2.cmd == 7 || a2.cmd == 8)
     {
-        if (a2.at2_0 == 5)
+        if (a2.cmd == 5)
             LinkSprite(nSprite, pXSprite, a2);
-        else if (a2.at2_0 == kGDXCommandPaste)
+        else if (a2.cmd == kGDXCommandPaste)
             pastePropertiesInObj(3, nSprite, a2);
-        else if (a2.at2_0 == kGDXCommandSpriteDamage)
+        else if (a2.cmd == kGDXCommandSpriteDamage)
             trDamageSprite(3, nSprite, a2);
         else
             OperateSprite(nSprite, pXSprite, a2);
@@ -2244,21 +2447,21 @@ void trDamageSprite(int type, int nDest, EVENT event) {
     UNREFERENCED_PARAMETER(type);
 
     /* - damages xsprite via TX ID	- */
-    /* - data1 = damage type		- */
+    /* - data3 = damage type		- */
     /* - data4 = damage amount		- */
 
-    if (event.at1_5 == 3) {
-        spritetype* pSource = NULL; pSource = &sprite[event.at0_0];
+    if (event.type == 3) {
+        spritetype* pSource = NULL; pSource = &sprite[event.index];
         XSPRITE* pXSource = &xsprite[pSource->extra];
-        XSPRITE pXSprite = xsprite[sprite[nDest].extra];
-        if (pXSprite.health > 0) {
+        if (xsprite[sprite[nDest].extra].health > 0) {
             if (pXSource->data4 == 0)
                 pXSource->data4 = 65535;
 
+            int dmgType = pXSource->data3;
             if (pXSource->data3 >= 7)
-                pXSource->data3 = (short)Random(6);
+                dmgType = Random(6);
 
-            actDamageSprite(pSource->xvel, &sprite[nDest], (DAMAGE_TYPE)pXSource->data3, pXSource->data4);
+            actDamageSprite(pSource->xvel, &sprite[nDest], (DAMAGE_TYPE) dmgType, pXSource->data4);
         }
     }
 }
@@ -2268,10 +2471,98 @@ bool valueIsBetween(int val, int min, int max) {
 }
 // By NoOne: this function used by various new GDX types.
 void pastePropertiesInObj(int type, int nDest, EVENT event) {
-    spritetype* pSource = NULL; pSource = &sprite[event.at0_0];
-    if (pSource == NULL || event.at1_5 != 3) return;
+    spritetype* pSource = NULL; pSource = &sprite[event.index];
+    if (pSource == NULL || event.type != 3) return;
     XSPRITE* pXSource = &xsprite[pSource->extra];
-    if (pSource->type == kGDXWindGenerator) {
+    
+    if (pSource->type == kGDXEffectSpawner) {
+        /* - Effect Spawner can spawn any effect passed in data2 on it's or txID sprite - */
+        if (pXSource->data2 < 0 || pXSource->data2 >= kFXMax) return;
+        else if (type == 3)  useEffectGen(pXSource, &sprite[nDest]);
+        return;
+
+    } else if (pSource->type == kGDXSeqSpawner) {
+        /* - SEQ Spawner takes data2 as SEQ ID and spawns it on it's or TX ID sprite - */
+        if (pXSource->data2 <= 0 || !gSysRes.Lookup(pXSource->data2, "SEQ")) return;
+        else if (type == 3) useSeqSpawnerGen(pXSource, &sprite[nDest]);
+        return;
+
+    } else if (pSource->type == kGDXObjDataAccumulator) {
+        /* - Object Data Accumulator allows to perform sum and sub operations in data fields of object - */
+        /* - data1 = destination data index 															- */
+        /* - data2 = step value																			- */
+        /* - data3 = min value																			- */
+        /* - data4 = max value																			- */
+        /* - min > max = sub, 	min < max = sum															- */
+
+        /* - hitag: 0 = force OFF if goal value was reached for all objects		     					- */
+        /* - hitag: 2 = force swap min and max if goal value was reached								- */
+        /* - hitag: 3 = force reset counter	                                           					- */
+
+        if (pXSource->data3 < 0) pXSource->data3 = 0;
+        else if (pXSource->data3 > 32766) pXSource->data3 = 32767;
+        if (pXSource->data4 < 0) pXSource->data4 = 0;
+        else if (pXSource->data4 > 32766) pXSource->data4 = 32767;
+
+        long data = getDataFieldOfObject(type, nDest, pXSource->data1);
+        if (data == -65535) return;
+        else if (pXSource->data3 < pXSource->data4) {
+
+            if (data < pXSource->data3) data = pXSource->data3;
+            if (data > pXSource->data4) data = pXSource->data4;
+
+            if ((data += pXSource->data2) >= pXSource->data4) {
+                switch (pSource->hitag) {
+                case 0:
+                case 1:
+                    if (data > pXSource->data4) data = pXSource->data4;
+                    break;
+                case 2:
+                {
+                    if (data > pXSource->data4) data = pXSource->data4;
+                    if (!goalValueIsReached(pXSource)) break;
+                    int tmp = pXSource->data4;
+                    pXSource->data4 = pXSource->data3;
+                    pXSource->data3 = (short)tmp;
+                    break;
+                }
+                case 3:
+                    if (data > pXSource->data4) data = pXSource->data3;
+                    break;
+                }
+            }
+
+        }
+        else if (pXSource->data3 > pXSource->data4) {
+
+            if (data > pXSource->data3) data = pXSource->data3;
+            if (data < pXSource->data4) data = pXSource->data4;
+
+            if ((data -= pXSource->data2) <= pXSource->data4) {
+                switch (pSource->hitag) {
+                case 0:
+                case 1:
+                    if (data < pXSource->data4) data = pXSource->data4;
+                    break;
+                case 2:
+                {
+                    if (data < pXSource->data4) data = pXSource->data4;
+                    int tmp = pXSource->data4;
+                    pXSource->data4 = pXSource->data3;
+                    pXSource->data3 = (short)tmp;
+                    break;
+                }
+                case 3:
+                    if (data < pXSource->data4) data = pXSource->data3;
+                    break;
+                }
+            }
+        }
+        
+        setDataValueOfObject(type, nDest, pXSource->data1, (short)data);
+        return;
+
+    } else if (pSource->type == kGDXWindGenerator) {
 
         /* - Wind generator via TX or for current sector if TX ID not specified - */
         /* - sprite.ang = sector wind direction									- */
@@ -2289,52 +2580,11 @@ void pastePropertiesInObj(int type, int nDest, EVENT event) {
         /* - 		 3: pan both												- */
 
         /* - hi-tag = 1: force windAlways and panAlways							- */
-
-        if (type != 6)
-            return;
         
-        XSECTOR* pXSector = &xsector[sector[nDest].extra];
+        if (pXSource->data2 < 0) return;
+        else if (type == 6) useSectorWindGen(pXSource, &sector[nDest]);
+        return;
 
-        if ((pSource->hitag & kHitagExtBit) != 0) {
-            pXSector->panAlways = true;
-            pXSector->windAlways = true;
-        }
-
-        if (pXSource->data1 == 1 || pXSource->data1 == 3)
-            pXSector->windVel = Random2(pXSource->data2);
-        else
-            pXSector->windVel = pXSource->data2;
-
-        if (pXSource->data1 == 2 || pXSource->data1 == 3) {
-            short ang = pSource->ang;
-            while (pSource->ang == ang) {
-                pSource->ang = (short) Random2(2048);
-            }
-        }
-
-        pXSector->windAng = pSource->ang;
-
-        if (pXSource->data3 == 1) {
-            pXSector->panAngle = (short) pXSector->windAng;
-            pXSector->panVel = (short) pXSector->windVel;
-        }
-
-        if (pXSource->data4 > 0) {
-            switch (pXSource->data4) {
-            case 1:
-                pXSector->panFloor = true;
-                pXSector->panCeiling = false;
-                break;
-            case 2:
-                pXSector->panFloor = false;
-                pXSector->panCeiling = true;
-                break;
-            case 3:
-                pXSector->panFloor = true;
-                pXSector->panCeiling = true;
-                break;
-            }
-        }
 
     } else if (pSource->type == kGDXObjDataChanger) {
 
@@ -2451,7 +2701,8 @@ void pastePropertiesInObj(int type, int nDest, EVENT event) {
 
         // dude is burning?
         if (pXSprite->burnTime > 0 && pXSprite->burnSource >= 0 && pXSprite->burnSource < kMaxSprites) {
-            if (!IsBurningDude(pSprite)) {
+            if (!IsBurningDude(pSprite))
+            {
                 spritetype* pBurnSource = &sprite[pXSprite->burnSource];
                 if (pBurnSource->extra >= 0) {
                     if (pXSource->data2 == 1 && isMateOf(pXSprite, &xsprite[pBurnSource->extra])) {
@@ -2480,18 +2731,18 @@ void pastePropertiesInObj(int type, int nDest, EVENT event) {
             if (pXSource->data4 == 3) {
                 aiSetTarget(pXSprite, pSprite->x, pSprite->y, pSprite->z);
                 aiSetGenIdleState(pSprite, pXSprite);
-                if (pSprite->type == 254)
-                   removeLeech(leechIsDropped(pSprite));
+                if (pSprite->lotag == kGDXDudeUniversalCultist)
+                    removeLeech(leechIsDropped(pSprite));
             }
             else if (pXSource->data4 == 4) {
                 aiSetTarget(pXSprite, pPlayer->x, pPlayer->y, pPlayer->z);
-                if (pSprite->lotag == 254)
+                if (pSprite->lotag == kGDXDudeUniversalCultist)
                     removeLeech(leechIsDropped(pSprite));
             }
         }
 
         int maxAlarmDudes = 8 + Random(8);
-        if (pXSprite->target > -1 && sprite[pXSprite->target].extra > -1) {
+        if (pXSprite->target > -1 && sprite[pXSprite->target].extra > -1 && pPlayer == NULL) {
             pTarget = &sprite[pXSprite->target]; pXTarget = &xsprite[pTarget->extra];
 
             if (unitCanFly(pSprite) && isMeleeUnit(pTarget) && !unitCanFly(pTarget))
@@ -2502,14 +2753,36 @@ void pastePropertiesInObj(int type, int nDest, EVENT event) {
             if (!IsDudeSprite(pTarget) || pXTarget->health < 1 || !dudeCanSeeTarget(pXSprite, pDudeInfo, pTarget)) {
                 aiSetTarget(pXSprite, pSprite->x, pSprite->y, pSprite->z);
 
+                // dude attack or attacked by target that does not fit by data id?
+            }
+            else if (pXSource->data1 != 666 && pXTarget->data1 != pXSource->data1) {
+                if (affectedByTargetChg(pXTarget)) {
+
+                    // force stop attack target
+                    aiSetTarget(pXSprite, pSprite->x, pSprite->y, pSprite->z);
+                    if (pXSprite->burnSource == pTarget->xvel) {
+                        pXSprite->burnTime = 0;
+                        pXSprite->burnSource = -1;
+                    }
+
+                    // force stop attack dude
+                    aiSetTarget(pXTarget, pTarget->x, pTarget->y, pTarget->z);
+                    if (pXTarget->burnSource == pSprite->xvel) {
+                        pXTarget->burnTime = 0;
+                        pXTarget->burnSource = -1;
+                    }
+                }
+                
+            }
             // instantly kill annoying spiders, rats, hands etc if dude is big enough
-            } else if (isAnnoyingUnit(pTarget) && !isAnnoyingUnit(pSprite) && tilesiz[pSprite->picnum].y >= 60 &&
+            else if (isAnnoyingUnit(pTarget) && !isAnnoyingUnit(pSprite) && tilesiz[pSprite->picnum].y >= 60 &&
                 getTargetDist(pSprite, pDudeInfo, pTarget) < 2) {
 
-                actKillDude(pSource->xvel, pTarget, (DAMAGE_TYPE)0, 65535);
+                actKillDude(pSource->xvel, pTarget, DAMAGE_TYPE_0, 65535);
                 aiSetTarget(pXSprite, pSprite->x, pSprite->y, pSprite->z);
 
-            } else if (pXSource->data2 == 1 && isMateOf(pXSprite, pXTarget)) {
+            }
+            else if (pXSource->data2 == 1 && isMateOf(pXSprite, pXTarget)) {
                 spritetype* pMate = pTarget; XSPRITE* pXMate = pXTarget;
 
                 // heal dude
@@ -2522,7 +2795,7 @@ void pastePropertiesInObj(int type, int nDest, EVENT event) {
                 if (pXMate->data4 > 0 && pXMate->health < pXMate->data4)
                     actHealDude(pXMate, receiveHp, pXMate->data4);
                 else {
-                    DUDEINFO* pTDudeInfo = &dudeInfo[pMate->type - kDudeBase];
+                    DUDEINFO* pTDudeInfo = &dudeInfo[pMate->lotag - kDudeBase];
                     if (pXMate->health < pTDudeInfo->startHealth)
                         actHealDude(pXMate, receiveHp, pTDudeInfo->startHealth);
                 }
@@ -2532,12 +2805,14 @@ void pastePropertiesInObj(int type, int nDest, EVENT event) {
                     // force mate stop attack dude, if he does
                     if (pXMate->target == pSprite->xvel) {
                         aiSetTarget(pXMate, pMate->x, pMate->y, pMate->z);
-                    } else if (!isMateOf(pXSprite, &xsprite[pTarget->extra])) {
+                    }
+                    else if (!isMateOf(pXSprite, &xsprite[pTarget->extra])) {
                         // force dude to attack same target that mate have
                         aiSetTarget(pXSprite, pTarget->xvel);
                         return;
 
-                    } else {
+                    }
+                    else {
                         // force mate to stop attack another mate
                         aiSetTarget(pXMate, pMate->x, pMate->y, pMate->z);
                     }
@@ -2547,17 +2822,20 @@ void pastePropertiesInObj(int type, int nDest, EVENT event) {
                 if (pXSprite->target == pMate->xvel)
                     aiSetTarget(pXSprite, pSprite->x, pSprite->y, pSprite->z);
 
-                // check if targets aims player then force this target to fight with dude
-            } else if (targetIsPlayer(pXTarget) != NULL) {
+                
+            }
+            // check if targets aims player then force this target to fight with dude
+            else if (targetIsPlayer(pXTarget) != NULL) {
                 aiSetTarget(pXTarget, pSprite->xvel);
             }
 
             int mDist = 3; if (isMeleeUnit(pSprite)) mDist = 2;
-            //int mDist = 2;
             if (pXSprite->target >= 0 && getTargetDist(pSprite, pDudeInfo, &sprite[pXSprite->target]) < mDist) {
                 return;
+                
+            }
             // lets try to look for target that fits better by distance
-            } else if ((gFrameClock & 128) != 0 && (pXSprite->target < 0 || getTargetDist(pSprite, pDudeInfo, pTarget) >= mDist)) {
+            else if ((gFrameClock & 256) != 0 && (pXSprite->target < 0 || getTargetDist(pSprite, pDudeInfo, pTarget) >= mDist)) {
                 pTarget = getTargetInRange(pSprite, 0, mDist, pXSource->data1, pXSource->data2);
                 if (pTarget != NULL) {
                     pXTarget = &xsprite[pTarget->extra];
@@ -2581,13 +2859,12 @@ void pastePropertiesInObj(int type, int nDest, EVENT event) {
                         if (!isActive(pTarget->xvel))
                             aiActivateDude(pTarget, pXTarget);
                     }
-                
                     return;
                 }
             }
         }
 
-        if (pXSprite->target < 0 && (gFrameClock & 32) != 0) {
+        if ((pXSprite->target < 0 || pPlayer != NULL) && (gFrameClock & 32) != 0) {
             // try find first target that dude can see
             for (int nSprite = headspritestat[6]; nSprite >= 0; nSprite = nextspritestat[nSprite]) {
                 pTarget = &sprite[nSprite]; pXTarget = &xsprite[pTarget->extra];
@@ -2603,8 +2880,10 @@ void pastePropertiesInObj(int type, int nDest, EVENT event) {
                 // avoid self aiming and those who dude can't see
                 else if (!dudeCanSeeTarget(pXSprite, pDudeInfo, pTarget) || pSprite->xvel == pTarget->xvel) {
                     continue;
+                    
+                }
                 // if Target Changer have data1 = 666, everyone can be target, except AI team mates.
-                } else if (pXSource->data1 != 666) {
+                else if (pXSource->data1 != 666) {
                     if (pXSource->data1 != pXTarget->data1)
                         continue;
                 }
@@ -2636,14 +2915,14 @@ void pastePropertiesInObj(int type, int nDest, EVENT event) {
         }
 
         // got no target - let's ask mates if they have targets
-        if (pXSprite->target < 0 && pXSource->data2 == 1 && (gFrameClock & 64) != 0) {
+        if ((pXSprite->target < 0 || pPlayer != NULL) && pXSource->data2 == 1 && (gFrameClock & 64) != 0) {
             spritetype* pMateTarget = NULL;
             if ((pMateTarget = getMateTargets(pXSprite)) != NULL && pMateTarget->extra > 0) {
                 XSPRITE* pXMateTarget = &xsprite[pMateTarget->extra];
                 if (dudeCanSeeTarget(pXSprite, pDudeInfo, pMateTarget)) {
                     if (pXMateTarget->target < 0) {
                         aiSetTarget(pXMateTarget, pSprite->xvel);
-                        if (!isActive(pMateTarget->xvel))
+                        if (IsDudeSprite(pMateTarget) && !isActive(pMateTarget->xvel))
                             aiActivateDude(pMateTarget, pXMateTarget);
                     }
 
@@ -2652,25 +2931,21 @@ void pastePropertiesInObj(int type, int nDest, EVENT event) {
                         aiActivateDude(pSprite, pXSprite);
                     return;
 
-                // try walk in mate direction in case if not see the target
-                } else if (pXMateTarget->target >= 0 && dudeCanSeeTarget(pXSprite, pDudeInfo, &sprite[pXMateTarget->target])) {
+                    // try walk in mate direction in case if not see the target
+                }
+                else if (pXMateTarget->target >= 0 && dudeCanSeeTarget(pXSprite, pDudeInfo, &sprite[pXMateTarget->target])) {
                     spritetype* pMate = &sprite[pXMateTarget->target];
                     pXSprite->target = pMateTarget->xvel;
-                    //pXSprite.target = -1;
                     pXSprite->targetX = pMate->x;
                     pXSprite->targetY = pMate->y;
                     pXSprite->targetZ = pMate->z;
                     if (!isActive(pSprite->xvel))
                         aiActivateDude(pSprite, pXSprite);
                     return;
-
-                // try just walk around
-                } else if ((gFrameClock & 72) != 0 && !isActive(pSprite->xvel)) {
-                    aiActivateDude(pSprite, pXSprite);
-                    return;
                 }
             }
         }
+
     } else if (pSource->type == kGDXObjSizeChanger) {
 
         /* - size and pan changer of sprite/wall/sector via TX ID 	- */
@@ -2819,9 +3094,37 @@ void pastePropertiesInObj(int type, int nDest, EVENT event) {
         {
             XSECTOR* pXSector = &xsector[sector[nDest].extra];
 
-            if (valueIsBetween(pXSource->data1, -1, 32767)) {
-                if (pXSource->data1 == 1) pXSector->Underwater = 1;
-                else pXSector->Underwater = 0;
+            switch (pXSource->data1) {
+            case 0:
+                pXSector->Underwater = false;
+                break;
+            case 1:
+                pXSector->Underwater = true;
+                break;
+            case 2:
+                pXSector->Depth = 0;
+                break;
+            case 3:
+                pXSector->Depth = 1;
+                break;
+            case 4:
+                pXSector->Depth = 2;
+                break;
+            case 5:
+                pXSector->Depth = 3;
+                break;
+            case 6:
+                pXSector->Depth = 4;
+                break;
+            case 7:
+                pXSector->Depth = 5;
+                break;
+            case 8:
+                pXSector->Depth = 6;
+                break;
+            case 9:
+                pXSector->Depth = 7;
+                break;
             }
 
             if (valueIsBetween(pXSource->data2, -1, 32767)) {
@@ -2911,8 +3214,8 @@ spritetype* getMateTargets(XSPRITE* pXSprite) {
     
     // original code
     for (int i = bucketHead[rx]; i < bucketHead[rx + 1]; i++) {
-        if (rxBucket[i].at1_5 == 3) {
-            pMate = &sprite[rxBucket[i].at0_0];
+        if (rxBucket[i].type == 3) {
+            pMate = &sprite[rxBucket[i].index];
             if (pMate->extra < 0 || pMate->xvel == sprite[pXSprite->reference].xvel || !IsDudeSprite(pMate))
                 continue;
 
@@ -2933,10 +3236,10 @@ bool isMatesHaveSameTarget(XSPRITE* pXLeader, spritetype* pTarget, int allow) {
 
     for (int i = bucketHead[rx]; i < bucketHead[rx + 1]; i++) {
 
-        if (rxBucket[i].at1_5 != 3)
+        if (rxBucket[i].type != 3)
             continue;
 
-        pMate = &sprite[rxBucket[i].at0_0];
+        pMate = &sprite[rxBucket[i].index];
         if (pMate->extra < 0 || pMate->xvel == sprite[pXLeader->reference].xvel || !IsDudeSprite(pMate))
             continue;
 
@@ -2986,19 +3289,106 @@ bool dudeCanSeeTarget(XSPRITE* pXDude, DUDEINFO* pDudeInfo, spritetype* pTarget)
 
 }
 
-// this function required if monsters in genIdle ai state. It wakes up monsters
+// by NoOne: this function required if monsters in genIdle ai state. It wakes up monsters
 // when kGDXDudeTargetChanger goes to off state, so they won't ignore the world.
 void activateDudes(int rx) {
     for (int i = bucketHead[rx]; i < bucketHead[rx + 1]; i++) {
-        if (rxBucket[i].at1_5 != 3)
-            continue;
-
-        spritetype * pDude = &sprite[rxBucket[i].at0_0]; XSPRITE * pXDude = &xsprite[pDude->extra];
-        if (!IsDudeSprite(pDude)) continue;
-        if (pXDude->aiState->stateType == kAiStateGenIdle) {
+        if (rxBucket[i].type != 3) continue;
+        spritetype * pDude = &sprite[rxBucket[i].index]; XSPRITE * pXDude = &xsprite[pDude->extra];
+        if (!IsDudeSprite(pDude) || pXDude->aiState->stateType != kAiStateGenIdle) continue;
             aiInitSprite(pDude);
+    }
+}
+
+bool affectedByTargetChg(XSPRITE* pXDude) {
+    if (pXDude->rxID <= 0 || pXDude->locked == 1) return false;
+    for (int nSprite = headspritestat[kStatGDXDudeTargetChanger]; nSprite >= 0; nSprite = nextspritestat[nSprite]) {
+        XSPRITE* pXSprite = (sprite[nSprite].extra >= 0) ? &xsprite[sprite[nSprite].extra] : NULL;
+        if (pXSprite == NULL || pXSprite->txID <= 0 || pXSprite->state != 1) continue;
+        for (int i = bucketHead[pXSprite->txID]; i < bucketHead[pXSprite->txID + 1]; i++) {
+            if (rxBucket[i].type != 3) continue;
+
+            spritetype* pSprite = &sprite[rxBucket[i].index];
+            if (pSprite->extra < 0 || !IsDudeSprite(pSprite)) continue;
+            else if (pSprite->xvel == sprite[pXDude->reference].xvel) return true;
         }
     }
+    return false;
+}
+
+int getDataFieldOfObject(int objType, int objIndex, int dataIndex) {
+    int data = -65535;
+    switch (objType) {
+    case 3:
+        switch (dataIndex) {
+        case 1:
+            return xsprite[sprite[objIndex].extra].data1;
+        case 2:
+            return xsprite[sprite[objIndex].extra].data2;
+        case 3:
+            return xsprite[sprite[objIndex].extra].data3;
+        case 4:
+            return xsprite[sprite[objIndex].extra].data4;
+        default:
+            return data;
+        }
+    case 0:
+        return xsector[sector[objIndex].extra].data;
+    case 6:
+        return xwall[wall[objIndex].extra].data;
+    default:
+        return data;
+    }
+}
+
+bool setDataValueOfObject(int objType, int objIndex, int dataIndex, int value) {
+    switch (objType) {
+    case 3:
+        switch (dataIndex) {
+        case 1:
+            xsprite[sprite[objIndex].extra].data1 = (short)value;
+            return true;
+        case 2:
+            xsprite[sprite[objIndex].extra].data2 = (short)value;
+            return true;
+        case 3:
+            xsprite[sprite[objIndex].extra].data3 = (short)value;
+            return true;
+        case 4:
+            xsprite[sprite[objIndex].extra].data4 = (short)value;
+            return true;
+        default:
+            return false;
+        }
+    case 0:
+        xsector[sector[objIndex].extra].data = (short)value;
+        return true;
+    case 6:
+        xwall[wall[objIndex].extra].data = (short)value;
+        return true;
+    default:
+        return false;
+    }
+}
+
+// by NoOne: this function checks if all TX objects have the same value
+bool goalValueIsReached(XSPRITE* pXSprite) {
+    for (int i = bucketHead[pXSprite->txID]; i < bucketHead[pXSprite->txID + 1]; i++) {
+        if (getDataFieldOfObject(rxBucket[i].type, rxBucket[i].index, pXSprite->data1) != pXSprite->data4)
+            return false;
+    }
+    return true;
+}
+
+// by NoOne: this function tells if there any dude found for kGDXDudeTargetChanger
+bool getDudesForTargetChg(XSPRITE* pXSprite) {
+    for (int i = bucketHead[pXSprite->txID]; i < bucketHead[pXSprite->txID + 1]; i++) {
+        if (rxBucket[i].type != 3) continue;
+        else if (IsDudeSprite(&sprite[rxBucket[i].index]) &&
+            xsprite[sprite[rxBucket[i].index].extra].health > 0) return true;
+    }
+
+    return false;
 }
 
 void disturbDudesInSight(spritetype* pSprite, int max) {
@@ -3142,12 +3532,7 @@ bool isMeleeUnit(spritetype* pDude) {
     case 251: // beast
         return true;
     case kGDXDudeUniversalCultist:
-    {
-        int data1 = xsprite[pDude->extra].data1;
-        if ((data1 >= 6 && data1 < 19) || data1 == 22 || data1 == 304 || data1 == 308)
-            return true;
-        return false;
-    }
+        return (pDude->extra >= 0 && dudeIsMelee(&xsprite[pDude->extra]));
     default:
         return false;
     }
@@ -3474,12 +3859,18 @@ void InitGenerator(int nSprite)
     case kGDXDudeTargetChanger:
         pSprite->cstat &= ~kSprBlock;
         pSprite->cstat |= kSprInvisible;
-        if (pXSprite->busyTime <= 0) pXSprite->busyTime = 1;
+        if (pXSprite->busyTime <= 0) pXSprite->busyTime = 5;
         if (pXSprite->state != pXSprite->restState)
-            evPost(nSprite, 3, pXSprite->busyTime, COMMAND_ID_21); // using different time intervals here
+            evPost(nSprite, 3, 0, COMMAND_ID_21);
         return;
+    case kGDXObjDataAccumulator:
     case kGDXSeqSpawner:
     case kGDXEffectSpawner:
+        pSprite->cstat &= ~kSprBlock;
+        pSprite->cstat |= kSprInvisible;
+        if (pXSprite->state != pXSprite->restState)
+            evPost(nSprite, 3, 0, COMMAND_ID_21);
+        return;
     case 700:
         pSprite->cstat &= ~kSprBlock;
         pSprite->cstat |= kSprInvisible;
@@ -3497,53 +3888,7 @@ void ActivateGenerator(int nSprite)
     int nXSprite = pSprite->extra;
     dassert(nXSprite > 0);
     XSPRITE *pXSprite = &xsprite[nXSprite];
-    switch (pSprite->type)
-    {
-    
-    /* - By NoOne: SEQ Spawner takes data2 as SEQ ID and spawns it - */
-    case kGDXSeqSpawner:
-        if (fileExistsRFF(pXSprite->data2, "SEQ")) {
-            if (pXSprite->data3 > 0 && pXSprite->data2 > 0)
-                seqSpawn(pXSprite->data2, 3, pSprite->extra, pXSprite->data3); // spawn seq with callback
-            else if (pXSprite->data2 > 0)
-                seqSpawn(pXSprite->data2, 3, pSprite->extra, -1); // just spawn seq
-            if (pXSprite->data4 > 0)
-                sfxPlay3DSound(pSprite, pXSprite->data4, -1, 0);
-        }
-        break;
-    
-    /* - By NoOne: Effect Spawner can spawn any effect passed in data2 - */
-    case kGDXEffectSpawner:
-        if (pXSprite->data2 >= 0 && pXSprite->data2 <= kFXMax) {
-           int top, bottom; GetSpriteExtents(pSprite,&top,&bottom); int cnt = pXSprite->data4;
-            spritetype *pEffect = NULL; if (cnt > 32) cnt = 32;
-
-            while (cnt-- >= 0) {
-                if (cnt > 0) {
-
-                    int dx = Random3(250);
-                    int dy = Random3(150);
-
-                    pEffect = gFX.fxSpawn((FX_ID)pXSprite->data2, pSprite->sectnum, pSprite->x + dx, pSprite->y + dy, top, 0);
-
-                }
-                else {
-                    pEffect = gFX.fxSpawn((FX_ID)pXSprite->data2, pSprite->sectnum, pSprite->x, pSprite->y, top, 0);
-                }
-
-                if (pEffect != NULL) {
-                    if (pEffect->pal <= 0) pEffect->pal = pSprite->pal;
-                    if (pEffect->xrepeat <= 0) pEffect->xrepeat = pSprite->xrepeat;
-                    if (pEffect->yrepeat <= 0) pEffect->yrepeat = pSprite->yrepeat;
-                    if (pEffect->shade == 0) pEffect->shade = pSprite->shade;
-                }
-            }
-
-            if (pXSprite->data3 > 0)
-                sfxPlay3DSound(pSprite, pXSprite->data3, -1, 0);
-        }
-        break;
-
+    switch (pSprite->type) {
     case 701:
     {
         int top, bottom;

--- a/source/blood/src/triggers.h
+++ b/source/blood/src/triggers.h
@@ -61,4 +61,13 @@ bool isAnnoyingUnit(spritetype* pDude);
 bool unitCanFly(spritetype* pDude);
 bool isMeleeUnit(spritetype* pDude);
 void activateDudes(int rx);
+bool affectedByTargetChg(XSPRITE* pXDude);
+int getDataFieldOfObject(int objType, int objIndex, int dataIndex);
+bool setDataValueOfObject(int objType, int objIndex, int dataIndex, int value);
+bool goalValueIsReached(XSPRITE* pXSprite);
+bool getDudesForTargetChg(XSPRITE* pXSprite);
+void stopWindOnSectors(XSPRITE* pXSource);
+void useSectorWindGen(XSPRITE* pXSource, sectortype* pSector);
+void useEffectGen(XSPRITE* pXSource, spritetype* pSprite);
+void useSeqSpawnerGen(XSPRITE* pXSource, spritetype* pSprite);
 // -------------------------------------------------------


### PR DESCRIPTION
Seq Spawner should can spawn seq on TX ID sprite
FX Effect Gen should can spawn effect on TX ID sprite
Dudelockout for Proximity
Sight flag (just for player)
Touch flag for any type
Dudelockout for Touch
Data accumulator type (as generator)
Force OFF Data accumulator type after goal value reached for all objects
Remove previously dropped items from random item generators if it was not picked up.
Wind Generator should can create wind on current sector, if TX ID is empty
The wind should stop after wind gen is off
Free data4 for wind gen
Custom dude: Count mass according sprite ((sprite size + repeats) * clipdist) / 25
Custom dude: Recoil chance according mass and weaponType
Custom dude: Stomp target if sprite is too small
Custom dude: Custom clipdist for (affects mass also)
Custom dude: Make burning state as an option
Custom dude can be kamikadze
Custom dude can summon any dude (except custom one)
Changes for custom dude
Force send command to all TX ID in the same time for SequentialTX
Changes in generators
CMD 5: Link = just change properties of object, default: change properties of object, then send command.
Sector depth control in data1 of PropertiesChanger
Fix selecting target for tchg (player as target)
INI Message instead of Picked Up message if lock msg specified (can be empty)
Grow shroom item
Shrink shroom item
! Map item (can't pickup)
Custom amount for pickups (weapons, health items and ammo ready)
! SEQ Surface Sound Trigger (can't detect if you stay on sprite instead sector floor)