### PR TITLE
Fix linux compilation

### DIFF
--- a/source/blood/src/db.cpp
+++ b/source/blood/src/db.cpp
@@ -34,6 +34,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "db.h"
 #include "iob.h"
 
+#ifdef __linux__
+#include <linux/limits.h>
+#define _MAX_PATH PATH_MAX
+#endif
+
 unsigned short gStatCount[kMaxStatus + 1];
 
 XSPRITE xsprite[kMaxXSprites];

--- a/source/blood/src/db.cpp
+++ b/source/blood/src/db.cpp
@@ -34,11 +34,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "db.h"
 #include "iob.h"
 
-#ifdef __linux__
-#include <linux/limits.h>
-#define _MAX_PATH PATH_MAX
-#endif
-
 unsigned short gStatCount[kMaxStatus + 1];
 
 XSPRITE xsprite[kMaxXSprites];
@@ -1294,8 +1289,8 @@ int dbLoadMap(const char *pPath, int *pX, int *pY, int *pZ, short *pAngle, short
 
 int dbSaveMap(const char *pPath, int nX, int nY, int nZ, short nAngle, short nSector)
 {
-    char sMapExt[_MAX_PATH];
-    char sBakExt[_MAX_PATH];
+    char sMapExt[BMAX_PATH];
+    char sBakExt[BMAX_PATH];
     int16_t tpskyoff[256];
     int nSpriteNum;
     psky_t *pSky = tileSetupSky(0);

--- a/source/blood/src/gui.cpp
+++ b/source/blood/src/gui.cpp
@@ -322,7 +322,7 @@ void TitleBar::HandleEvent(GEVENT *event)
     }
 }
 
-Window::Window(int a1, int a2, int a3, int a4, const char* a5) : Panel(a1, a2, a3, a4, 1, 1, -1)
+Win::Win(int a1, int a2, int a3, int a4, const char* a5) : Panel(a1, a2, a3, a4, 1, 1, -1)
 {
     at62 = new TitleBar(3, 3, a3-6, 12, a5);
     at5e = new Container(3, 15, a3-6, a4-18);
@@ -571,7 +571,7 @@ void EditText::HandleEvent(GEVENT *event)
 EditNumber::EditNumber(int a1, int a2, int a3, int a4, int a5) : EditText(a1, a2, a3, a4, "")
 {
     at130 = a5;
-    itoa(a5, at24, 10);
+    snprintf(at24, 0x100, "%i", a5);
     at128 = at124 = strlen(at24);
 }
 
@@ -919,7 +919,7 @@ MODAL_RESULT ShowModal(Container* container)
 
 int GetNumberBox(const char* a1, int a2, int a3)
 {
-    Window window(0, 0, 168, 40, a1);
+    Win window(0, 0, 168, 40, a1);
     EditNumber* editnumber = new EditNumber(4, 4, 154, 16, a2);
 
     window.at5e->Insert(editnumber);

--- a/source/blood/src/gui.h
+++ b/source/blood/src/gui.h
@@ -144,12 +144,12 @@ public:
     int at124;
 };
 
-class Window : public Panel
+class Win : public Panel
 {
 public:
     Container* at5e;
     TitleBar* at62;
-    Window(int, int, int, int, const char*);
+    Win(int, int, int, int, const char*);
 };
 
 class Button : public Widget

--- a/source/blood/src/startgtk.game.cpp
+++ b/source/blood/src/startgtk.game.cpp
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "dynamicgtk.h"
 #include "blood.h"
 #include "gtkpixdata.h"
+#include "global.h"
 
 enum
 {

--- a/source/blood/src/startgtk.game.cpp
+++ b/source/blood/src/startgtk.game.cpp
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "dynamicgtk.h"
 #include "blood.h"
 #include "gtkpixdata.h"
-#include "global.h"
+#include "globals.h"
 
 enum
 {

--- a/source/blood/src/startosx.game.mm
+++ b/source/blood/src/startosx.game.mm
@@ -11,6 +11,7 @@
 #include "build.h"
 #include "compat.h"
 #include "baselayer.h"
+#include "globals.h"
 
 #ifndef MAC_OS_X_VERSION_10_5
 # define NSImageScaleNone NSScaleNone


### PR DESCRIPTION
Various things in the code did not allow for compilation under Linux
I think this PR resolves that

Changes:
- _MAX_PATH defines as PATH_MAX
- Window renamed to Win, the X header already typedefs Window as an XID
- replace itoa with snprintf, should give the same results

This PR needs to be tested with MSVC to ensure nothing broke on the Windows side