### PR TITLE
Fix the crosshair

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ DerivedData/
 *.dSYM/
 
 .DS_Store
+/texturecache
+/texturecache.index

--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -1614,7 +1614,6 @@ RESTART:
     UpdateNetworkMenus();
     if (!gDemo.at0 && gDemo.at59ef > 0 && gGameOptions.nGameType == 0 && !bNoDemo)
         gDemo.SetupPlayback(NULL);
-    viewGetCrosshairColor();
     viewSetCrosshairColor(CrosshairColors.r, CrosshairColors.g, CrosshairColors.b);
     gQuitGame = 0;
     gRestartGame = 0;

--- a/source/blood/src/config.cpp
+++ b/source/blood/src/config.cpp
@@ -814,7 +814,7 @@ void CONFIG_WriteSettings(void) // save binds and aliases to <cfgname>_settings.
 
         OSD_WriteAliases(fp);
 
-        if (g_crosshairSum != -1 && g_crosshairSum != DefaultCrosshairColors.r+(DefaultCrosshairColors.g<<8)+(DefaultCrosshairColors.b<<16))
+        if (g_isAlterDefaultCrosshair)
             Bfprintf(fp, "crosshaircolor %d %d %d\n", CrosshairColors.r, CrosshairColors.g, CrosshairColors.b);
 
         OSD_WriteCvars(fp);

--- a/source/blood/src/osdcmd.cpp
+++ b/source/blood/src/osdcmd.cpp
@@ -311,7 +311,7 @@ static int osdcmd_crosshaircolor(osdcmdptr_t parm)
     uint8_t const g = Batol(parm->parms[1]);
     uint8_t const b = Batol(parm->parms[2]);
 
-	g_isAlterDefaultCrosshair = true;
+    g_isAlterDefaultCrosshair = true;
     viewSetCrosshairColor(r,g,b);
 
     if (!OSD_ParsingScript())
@@ -322,11 +322,11 @@ static int osdcmd_crosshaircolor(osdcmdptr_t parm)
 
 static int osdcmd_resetcrosshair(osdcmdptr_t UNUSED(parm))
 {
-	UNREFERENCED_CONST_PARAMETER(parm);
-	g_isAlterDefaultCrosshair = false;
-	viewResetCrosshairToDefault();
+    UNREFERENCED_CONST_PARAMETER(parm);
+    g_isAlterDefaultCrosshair = false;
+    viewResetCrosshairToDefault();
 
-	return OSDCMD_OK;
+    return OSDCMD_OK;
 }
 
 static int osdcmd_give(osdcmdptr_t parm)
@@ -1049,7 +1049,7 @@ int32_t registerosdcommands(void)
     OSD_RegisterFunction("bind",R"(bind <key> <string>: associates a keypress with a string of console input. Type "bind showkeys" for a list of keys and "listsymbols" for a list of valid console commands.)", osdcmd_bind);
 //    OSD_RegisterFunction("cmenu","cmenu <#>: jumps to menu", osdcmd_cmenu);
     OSD_RegisterFunction("crosshaircolor","crosshaircolor: changes the crosshair color", osdcmd_crosshaircolor);
-	OSD_RegisterFunction("crosshairreset", "crosshairreset: restores the original crosshair", osdcmd_resetcrosshair);
+    OSD_RegisterFunction("crosshairreset", "crosshairreset: restores the original crosshair", osdcmd_resetcrosshair);
 //
 //#if !defined NETCODE_DISABLE
 //    OSD_RegisterFunction("connect","connect: connects to a multiplayer game", osdcmd_connect);

--- a/source/blood/src/osdcmd.cpp
+++ b/source/blood/src/osdcmd.cpp
@@ -311,12 +311,22 @@ static int osdcmd_crosshaircolor(osdcmdptr_t parm)
     uint8_t const g = Batol(parm->parms[1]);
     uint8_t const b = Batol(parm->parms[2]);
 
+	g_isAlterDefaultCrosshair = true;
     viewSetCrosshairColor(r,g,b);
 
     if (!OSD_ParsingScript())
         OSD_Printf("%s\n", parm->raw);
 
     return OSDCMD_OK;
+}
+
+static int osdcmd_resetcrosshair(osdcmdptr_t UNUSED(parm))
+{
+	UNREFERENCED_CONST_PARAMETER(parm);
+	g_isAlterDefaultCrosshair = false;
+	viewResetCrosshairToDefault();
+
+	return OSDCMD_OK;
 }
 
 static int osdcmd_give(osdcmdptr_t parm)
@@ -456,12 +466,10 @@ void onvideomodechange(int32_t newmode)
 
     videoSetPalette(ud.brightness>>2, palid, 0);
     g_restorePalette = -1;
-    g_crosshairSum = -1;
 #endif
     if (newmode)
         scrResetPalette();
     UpdateDacs(gLastPal, false);
-    g_crosshairSum = -1;
 }
 
 static int osdcmd_button(osdcmdptr_t parm)
@@ -1041,6 +1049,7 @@ int32_t registerosdcommands(void)
     OSD_RegisterFunction("bind",R"(bind <key> <string>: associates a keypress with a string of console input. Type "bind showkeys" for a list of keys and "listsymbols" for a list of valid console commands.)", osdcmd_bind);
 //    OSD_RegisterFunction("cmenu","cmenu <#>: jumps to menu", osdcmd_cmenu);
     OSD_RegisterFunction("crosshaircolor","crosshaircolor: changes the crosshair color", osdcmd_crosshaircolor);
+	OSD_RegisterFunction("crosshairreset", "crosshairreset: restores the original crosshair", osdcmd_resetcrosshair);
 //
 //#if !defined NETCODE_DISABLE
 //    OSD_RegisterFunction("connect","connect: connects to a multiplayer game", osdcmd_connect);

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -3506,52 +3506,52 @@ bool g_isAlterDefaultCrosshair = false;
 
 void viewSetCrosshairColor(int32_t r, int32_t g, int32_t b)
 {
-	if (!g_isAlterDefaultCrosshair)
-		return;
+    if (!g_isAlterDefaultCrosshair)
+        return;
 
-	CrosshairColors.r = r;
-	CrosshairColors.g = g;
-	CrosshairColors.b = b;
+    CrosshairColors.r = r;
+    CrosshairColors.g = g;
+    CrosshairColors.b = b;
 
-	tileLoad(kCrosshairTile);
+    tileLoad(kCrosshairTile);
 
-	if (!waloff[kCrosshairTile])
-		return;
+    if (!waloff[kCrosshairTile])
+        return;
 
-	char *ptr = (char *)waloff[kCrosshairTile];
+    char *ptr = (char *)waloff[kCrosshairTile];
 
-	int32_t ii = tilesiz[kCrosshairTile].x * tilesiz[kCrosshairTile].y;
+    int32_t ii = tilesiz[kCrosshairTile].x * tilesiz[kCrosshairTile].y;
 
-	dassert(ii > 0);
+    dassert(ii > 0);
 
-	int32_t i = (videoGetRenderMode() == REND_CLASSIC)
-		? paletteGetClosestColor(CrosshairColors.r, CrosshairColors.g, CrosshairColors.b)
-		: paletteGetClosestColor(255, 255, 255);  // use white in GL so we can tint it to the right color
+    int32_t i = (videoGetRenderMode() == REND_CLASSIC)
+        ? paletteGetClosestColor(CrosshairColors.r, CrosshairColors.g, CrosshairColors.b)
+        : paletteGetClosestColor(255, 255, 255);  // use white in GL so we can tint it to the right color
 
-	do
-	{
-		if (*ptr != 255)
-			*ptr = i;
-		ptr++;
-	} while (--ii);
+    do
+    {
+        if (*ptr != 255)
+            *ptr = i;
+        ptr++;
+    } while (--ii);
 
-	paletteMakeLookupTable(CROSSHAIR_PAL, NULL, CrosshairColors.r, CrosshairColors.g, CrosshairColors.b, 1);
+    paletteMakeLookupTable(CROSSHAIR_PAL, NULL, CrosshairColors.r, CrosshairColors.g, CrosshairColors.b, 1);
 
 #ifdef USE_OPENGL
-	// XXX: this makes us also load all hightile textures tinted with the crosshair color!
-	polytint_t & crosshairtint = hictinting[CROSSHAIR_PAL];
-	crosshairtint.r = CrosshairColors.r;
-	crosshairtint.g = CrosshairColors.g;
-	crosshairtint.b = CrosshairColors.b;
-	crosshairtint.f = HICTINT_USEONART | HICTINT_GRAYSCALE;
+    // XXX: this makes us also load all hightile textures tinted with the crosshair color!
+    polytint_t & crosshairtint = hictinting[CROSSHAIR_PAL];
+    crosshairtint.r = CrosshairColors.r;
+    crosshairtint.g = CrosshairColors.g;
+    crosshairtint.b = CrosshairColors.b;
+    crosshairtint.f = HICTINT_USEONART | HICTINT_GRAYSCALE;
 #endif
-	tileInvalidate(kCrosshairTile, -1, -1);
+    tileInvalidate(kCrosshairTile, -1, -1);
 }
 
 void viewResetCrosshairToDefault(void)
 {
-	paletteFreeLookupTable(CROSSHAIR_PAL);
-	tileLoad(kCrosshairTile);
+    paletteFreeLookupTable(CROSSHAIR_PAL);
+    tileLoad(kCrosshairTile);
 }
 
 #define COLOR_RED redcol

--- a/source/blood/src/view.h
+++ b/source/blood/src/view.h
@@ -94,8 +94,7 @@ extern int gViewXCenter, gViewYCenter;
 extern int gViewX0, gViewY0, gViewX1, gViewY1;
 extern int gViewX0S, gViewY0S, gViewX1S, gViewY1S;
 extern palette_t CrosshairColors;
-extern palette_t DefaultCrosshairColors;
-extern int32_t g_crosshairSum;
+extern bool g_isAlterDefaultCrosshair;
 extern int32_t r_maxfps;
 extern int32_t r_maxfpsoffset;
 extern double g_frameDelay;
@@ -154,8 +153,8 @@ void viewLoadingScreenUpdate(const char *pzText4 = NULL, int nPercent = -1);
 void viewLoadingScreen(int nTile, const char *pText, const char *pText2, const char *pText3);
 void viewUpdateDelirium(void);
 void viewUpdateShake(void);
-void viewGetCrosshairColor(void);
 void viewSetCrosshairColor(int32_t r, int32_t g, int32_t b);
+void viewResetCrosshairToDefault(void);
 void viewPrintFPS(void);
 
 


### PR DESCRIPTION
Currently the crosshair looks different in NBlood than in the original game. In the original it consists of multiple colors like the corresponding tile but in NBlood it is just one color. It is because NBlood is recoloring the crosshair by the "crosshaircolor" console feature, although nothing is asking for it.
I kept the possibility to change the color of the crosshair from the console or config file. I also added the "crosshairreset" console command if somebody wants to restore the original crosshair, so it is not needed to quit the game, edit the config file (by deleting the crosshaircolor setting) and restart the game.