### PR TITLE
Add an option to let the music play continuously without restart if…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ DerivedData/
 .DS_Store
 /texturecache
 /texturecache.index
+/game00*.sav

--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -99,6 +99,9 @@ bool bNoAutoLoad = false;
 
 bool bVanilla = false;
 
+int gMusicPrevLoadedEpisode = -1;
+int gMusicPrevLoadedLevel = -1;
+
 char gUserMapFilename[BMAX_PATH];
 char gPName[MAXPLAYERNAME];
 
@@ -533,6 +536,8 @@ void StartLevel(GAMEOPTIONS *gameOptions)
     EndLevel();
     gStartNewGame = 0;
     ready2send = 0;
+    gMusicPrevLoadedEpisode = gGameOptions.nEpisode;
+    gMusicPrevLoadedLevel = gGameOptions.nLevel;
     if (gDemo.at0 && gGameStarted)
         gDemo.Close();
     netWaitForEveryone(0);

--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -467,7 +467,7 @@ void PreloadCache(void)
     if (gDemo.at1)
         return;
     if (MusicRestartsOnLoadToggle)
-        sndPlaySpecialMusicOrNothing(MUS_LOADING);
+        sndTryPlaySpecialMusic(MUS_LOADING);
     gSoundRes.PrecacheSounds();
     PreloadTiles();
     int clock = totalclock;

--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -463,7 +463,8 @@ void PreloadCache(void)
     char tempbuf[128];
     if (gDemo.at1)
         return;
-    sndPlaySpecialMusicOrNothing(MUS_LOADING);
+    if (MusicRestartsOnLoadToggle)
+        sndPlaySpecialMusicOrNothing(MUS_LOADING);
     gSoundRes.PrecacheSounds();
     PreloadTiles();
     int clock = totalclock;

--- a/source/blood/src/blood.h
+++ b/source/blood/src/blood.h
@@ -232,6 +232,8 @@ extern double g_gameUpdateTime, g_gameUpdateAndDrawTime;
 extern double g_gameUpdateAvgTime;
 extern int blood_globalflags;
 extern bool bVanilla;
+extern int gMusicPrevLoadedEpisode;
+extern int gMusicPrevLoadedLevel;
 
 extern int gFrameClock;
 

--- a/source/blood/src/config.cpp
+++ b/source/blood/src/config.cpp
@@ -70,6 +70,7 @@ int32_t scripthandle;
 int32_t setupread;
 int32_t SoundToggle;
 int32_t MusicToggle;
+int32_t MusicRestartsOnLoadToggle;
 int32_t CDAudioToggle;
 int32_t FXVolume;
 int32_t MusicVolume;
@@ -322,6 +323,7 @@ void CONFIG_SetDefaults(void)
     MouseBias       = 0;
     MouseDeadZone   = 0;
     MusicToggle     = 1;
+    MusicRestartsOnLoadToggle = 1;
     MusicVolume     = 195;
     NumBits         = 16;
     NumChannels     = 2;

--- a/source/blood/src/config.cpp
+++ b/source/blood/src/config.cpp
@@ -323,7 +323,7 @@ void CONFIG_SetDefaults(void)
     MouseBias       = 0;
     MouseDeadZone   = 0;
     MusicToggle     = 1;
-    MusicRestartsOnLoadToggle = 1;
+    MusicRestartsOnLoadToggle = 0;
     MusicVolume     = 195;
     NumBits         = 16;
     NumChannels     = 2;

--- a/source/blood/src/config.h
+++ b/source/blood/src/config.h
@@ -51,6 +51,7 @@ extern int32_t scripthandle;
 extern int32_t setupread;
 extern int32_t SoundToggle;
 extern int32_t MusicToggle;
+extern int32_t MusicRestartsOnLoadToggle;
 extern int32_t CDAudioToggle;
 extern int32_t FXVolume;
 extern int32_t MusicVolume;

--- a/source/blood/src/loadsave.cpp
+++ b/source/blood/src/loadsave.cpp
@@ -58,9 +58,6 @@ int LoadSave::hLFile = -1;
 
 short word_27AA54 = 0;
 
-int prevLoadedEpisode = -1;
-int prevLoadedLevel = -1;
-
 void sub_76FD4(void)
 {
     if (!dword_27AA44)
@@ -94,7 +91,7 @@ void LoadSave::Write(void *pData, int nSize)
         ThrowError("File error #%d writing save file.", errno);
 }
 
-void LoadSave::LoadGame(char *pzFile)
+void LoadSave::LoadGame(char *pzFile, bool demoWasPlayed)
 {
     sndKillAllSounds();
     sfxKillAllSounds();
@@ -157,10 +154,14 @@ void LoadSave::LoadGame(char *pzFile)
     gGameStarted = 1;
     bVanilla = false;
 
-    if (MusicRestartsOnLoadToggle || (prevLoadedEpisode != gGameOptions.nEpisode || prevLoadedLevel != gGameOptions.nLevel))
+    if (MusicRestartsOnLoadToggle
+        || demoWasPlayed
+        || (gMusicPrevLoadedEpisode != gGameOptions.nEpisode || gMusicPrevLoadedLevel != gGameOptions.nLevel))
+    {
         levelTryPlayMusic(gGameOptions.nEpisode, gGameOptions.nLevel);
-    prevLoadedEpisode = gGameOptions.nEpisode;
-    prevLoadedLevel = gGameOptions.nLevel;
+    }
+    gMusicPrevLoadedEpisode = gGameOptions.nEpisode;
+    gMusicPrevLoadedLevel = gGameOptions.nLevel;
 
     netBroadcastPlayerInfo(myconnectindex);
     //sndPlaySong(gGameOptions.zLevelSong, 1);
@@ -184,9 +185,6 @@ void LoadSave::SaveGame(char *pzFile)
     }
     fclose(hSFile);
     hSFile = NULL;
-
-    prevLoadedEpisode = gGameOptions.nEpisode;
-    prevLoadedLevel = gGameOptions.nLevel;
 }
 
 class MyLoadSave : public LoadSave

--- a/source/blood/src/loadsave.cpp
+++ b/source/blood/src/loadsave.cpp
@@ -29,6 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "ai.h"
 #include "asound.h"
 #include "blood.h"
+#include "demo.h"
 #include "globals.h"
 #include "db.h"
 #include "messages.h"
@@ -91,8 +92,12 @@ void LoadSave::Write(void *pData, int nSize)
         ThrowError("File error #%d writing save file.", errno);
 }
 
-void LoadSave::LoadGame(char *pzFile, bool demoWasPlayed)
+void LoadSave::LoadGame(char *pzFile)
 {
+    bool demoWasPlayed = gDemo.at1;
+    if (gDemo.at1)
+        gDemo.Close();
+
     sndKillAllSounds();
     sfxKillAllSounds();
     ambKillAll();

--- a/source/blood/src/loadsave.cpp
+++ b/source/blood/src/loadsave.cpp
@@ -58,6 +58,9 @@ int LoadSave::hLFile = -1;
 
 short word_27AA54 = 0;
 
+int prevLoadedEpisode = -1;
+int prevLoadedLevel = -1;
+
 void sub_76FD4(void)
 {
     if (!dword_27AA44)
@@ -153,7 +156,12 @@ void LoadSave::LoadGame(char *pzFile)
     gPaused = 0;
     gGameStarted = 1;
     bVanilla = false;
-    levelTryPlayMusic(gGameOptions.nEpisode ,gGameOptions.nLevel);
+
+    if (MusicRestartsOnLoadToggle || (prevLoadedEpisode != gGameOptions.nEpisode || prevLoadedLevel != gGameOptions.nLevel))
+        levelTryPlayMusic(gGameOptions.nEpisode, gGameOptions.nLevel);
+    prevLoadedEpisode = gGameOptions.nEpisode;
+    prevLoadedLevel = gGameOptions.nLevel;
+
     netBroadcastPlayerInfo(myconnectindex);
     //sndPlaySong(gGameOptions.zLevelSong, 1);
 }
@@ -176,6 +184,9 @@ void LoadSave::SaveGame(char *pzFile)
     }
     fclose(hSFile);
     hSFile = NULL;
+
+    prevLoadedEpisode = gGameOptions.nEpisode;
+    prevLoadedLevel = gGameOptions.nLevel;
 }
 
 class MyLoadSave : public LoadSave

--- a/source/blood/src/loadsave.h
+++ b/source/blood/src/loadsave.h
@@ -47,7 +47,7 @@ public:
     virtual void Load(void);
     void Read(void *, int);
     void Write(void *, int);
-    static void LoadGame(char *);
+    static void LoadGame(char *, bool);
     static void SaveGame(char *);
 };
 

--- a/source/blood/src/loadsave.h
+++ b/source/blood/src/loadsave.h
@@ -47,7 +47,7 @@ public:
     virtual void Load(void);
     void Read(void *, int);
     void Write(void *, int);
-    static void LoadGame(char *, bool);
+    static void LoadGame(char *);
     static void SaveGame(char *);
 };
 

--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -542,6 +542,7 @@ CGameMenuItemZBool itemOptionsDisplayPolymostDeliriumBlur("DELIRIUM EFFECT BLUR:
 
 void UpdateSoundToggle(CGameMenuItemZBool *pItem);
 void UpdateMusicToggle(CGameMenuItemZBool *pItem);
+void UpdateMusicRestartsOnLoadToggle(CGameMenuItemZBool* pItem);
 void Update3DToggle(CGameMenuItemZBool *pItem);
 void UpdateCDToggle(CGameMenuItemZBool *pItem);
 void UpdateSoundVolume(CGameMenuItemSlider *pItem);
@@ -569,8 +570,9 @@ const char *pzMusicDeviceStrings[] = {
 };
 
 CGameMenuItemTitle itemOptionsSoundTitle("SOUND SETUP", 1, 160, 20, 2038);
-CGameMenuItemZBool itemOptionsSoundSoundToggle("SOUND:", 3, 66, 60, 180, false, UpdateSoundToggle, NULL, NULL);
-CGameMenuItemZBool itemOptionsSoundMusicToggle("MUSIC:", 3, 66, 70, 180, false, UpdateMusicToggle, NULL, NULL);
+CGameMenuItemZBool itemOptionsSoundSoundToggle("SOUND:", 3, 66, 50, 180, false, UpdateSoundToggle, NULL, NULL);
+CGameMenuItemZBool itemOptionsSoundMusicToggle("MUSIC:", 3, 66, 60, 180, false, UpdateMusicToggle, NULL, NULL);
+CGameMenuItemZBool itemOptionsSoundMusicRestartsOnLoadToggle("MUSIC RESTARTS:", 3, 66, 70, 180, false, UpdateMusicRestartsOnLoadToggle, NULL, NULL);
 CGameMenuItemZBool itemOptionsSound3DToggle("3D AUDIO:", 3, 66, 80, 180, false, Update3DToggle, NULL, NULL);
 CGameMenuItemSlider itemOptionsSoundSoundVolume("SOUND VOLUME:", 3, 66, 90, 180, &FXVolume, 0, 256, 48, UpdateSoundVolume, -1, -1, kMenuSliderPercent);
 CGameMenuItemSlider itemOptionsSoundMusicVolume("MUSIC VOLUME:", 3, 66, 100, 180, &MusicVolume, 0, 256, 48, UpdateMusicVolume, -1, -1, kMenuSliderPercent);
@@ -1205,6 +1207,7 @@ void SetupOptionsMenu(void)
     menuOptionsSound.Add(&itemOptionsSoundTitle, false);
     menuOptionsSound.Add(&itemOptionsSoundSoundToggle, true);
     menuOptionsSound.Add(&itemOptionsSoundMusicToggle, false);
+    menuOptionsSound.Add(&itemOptionsSoundMusicRestartsOnLoadToggle, false);
     menuOptionsSound.Add(&itemOptionsSound3DToggle, false);
     menuOptionsSound.Add(&itemOptionsSoundSoundVolume, false);
     menuOptionsSound.Add(&itemOptionsSoundMusicVolume, false);
@@ -1772,6 +1775,11 @@ void UpdateMusicToggle(CGameMenuItemZBool *pItem)
     }
 }
 
+void UpdateMusicRestartsOnLoadToggle(CGameMenuItemZBool* pItem)
+{
+    MusicRestartsOnLoadToggle = pItem->at20;
+}
+
 void Update3DToggle(CGameMenuItemZBool *pItem)
 {
     gDoppler = pItem->at20;
@@ -1835,6 +1843,7 @@ void SetupOptionsSound(CGameMenuItemChain *pItem)
     UNREFERENCED_PARAMETER(pItem);
     itemOptionsSoundSoundToggle.at20 = SoundToggle;
     itemOptionsSoundMusicToggle.at20 = MusicToggle;
+    itemOptionsSoundMusicRestartsOnLoadToggle.at20 = MusicRestartsOnLoadToggle;
     itemOptionsSound3DToggle.at20 = gDoppler;
     itemOptionsSoundCDToggle.at20 = CDAudioToggle;
     itemOptionsSoundSampleRate.m_nFocus = 0;

--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -542,7 +542,6 @@ CGameMenuItemZBool itemOptionsDisplayPolymostDeliriumBlur("DELIRIUM EFFECT BLUR:
 
 void UpdateSoundToggle(CGameMenuItemZBool *pItem);
 void UpdateMusicToggle(CGameMenuItemZBool *pItem);
-void UpdateMusicRestartsOnLoadToggle(CGameMenuItemZBool* pItem);
 void Update3DToggle(CGameMenuItemZBool *pItem);
 void UpdateCDToggle(CGameMenuItemZBool *pItem);
 void UpdateSoundVolume(CGameMenuItemSlider *pItem);
@@ -570,9 +569,8 @@ const char *pzMusicDeviceStrings[] = {
 };
 
 CGameMenuItemTitle itemOptionsSoundTitle("SOUND SETUP", 1, 160, 20, 2038);
-CGameMenuItemZBool itemOptionsSoundSoundToggle("SOUND:", 3, 66, 50, 180, false, UpdateSoundToggle, NULL, NULL);
-CGameMenuItemZBool itemOptionsSoundMusicToggle("MUSIC:", 3, 66, 60, 180, false, UpdateMusicToggle, NULL, NULL);
-CGameMenuItemZBool itemOptionsSoundMusicRestartsOnLoadToggle("MUSIC RESTARTS:", 3, 66, 70, 180, false, UpdateMusicRestartsOnLoadToggle, NULL, NULL);
+CGameMenuItemZBool itemOptionsSoundSoundToggle("SOUND:", 3, 66, 60, 180, false, UpdateSoundToggle, NULL, NULL);
+CGameMenuItemZBool itemOptionsSoundMusicToggle("MUSIC:", 3, 66, 70, 180, false, UpdateMusicToggle, NULL, NULL);
 CGameMenuItemZBool itemOptionsSound3DToggle("3D AUDIO:", 3, 66, 80, 180, false, Update3DToggle, NULL, NULL);
 CGameMenuItemSlider itemOptionsSoundSoundVolume("SOUND VOLUME:", 3, 66, 90, 180, &FXVolume, 0, 256, 48, UpdateSoundVolume, -1, -1, kMenuSliderPercent);
 CGameMenuItemSlider itemOptionsSoundMusicVolume("MUSIC VOLUME:", 3, 66, 100, 180, &MusicVolume, 0, 256, 48, UpdateMusicVolume, -1, -1, kMenuSliderPercent);
@@ -1207,7 +1205,6 @@ void SetupOptionsMenu(void)
     menuOptionsSound.Add(&itemOptionsSoundTitle, false);
     menuOptionsSound.Add(&itemOptionsSoundSoundToggle, true);
     menuOptionsSound.Add(&itemOptionsSoundMusicToggle, false);
-    menuOptionsSound.Add(&itemOptionsSoundMusicRestartsOnLoadToggle, false);
     menuOptionsSound.Add(&itemOptionsSound3DToggle, false);
     menuOptionsSound.Add(&itemOptionsSoundSoundVolume, false);
     menuOptionsSound.Add(&itemOptionsSoundMusicVolume, false);
@@ -1775,11 +1772,6 @@ void UpdateMusicToggle(CGameMenuItemZBool *pItem)
     }
 }
 
-void UpdateMusicRestartsOnLoadToggle(CGameMenuItemZBool* pItem)
-{
-    MusicRestartsOnLoadToggle = pItem->at20;
-}
-
 void Update3DToggle(CGameMenuItemZBool *pItem)
 {
     gDoppler = pItem->at20;
@@ -1843,7 +1835,6 @@ void SetupOptionsSound(CGameMenuItemChain *pItem)
     UNREFERENCED_PARAMETER(pItem);
     itemOptionsSoundSoundToggle.at20 = SoundToggle;
     itemOptionsSoundMusicToggle.at20 = MusicToggle;
-    itemOptionsSoundMusicRestartsOnLoadToggle.at20 = MusicRestartsOnLoadToggle;
     itemOptionsSound3DToggle.at20 = gDoppler;
     itemOptionsSoundCDToggle.at20 = CDAudioToggle;
     itemOptionsSoundSampleRate.m_nFocus = 0;
@@ -2118,11 +2109,8 @@ void LoadGame(CGameMenuItemZEditBitmap *pItem, CGameMenuEvent *event)
     G_ModDirSnprintf(strLoadGameName, BMAX_PATH, "game00%02d.sav", nSlot);
     if (!testkopen(strLoadGameName, 0))
         return;
-    bool demoWasPlayed = gDemo.at1;
-    if (gDemo.at1)
-        gDemo.Close();
     viewLoadingScreen(2518, "Loading", "Loading Saved Game", strRestoreGameStrings[nSlot]);
-    LoadSave::LoadGame(strLoadGameName, demoWasPlayed);
+    LoadSave::LoadGame(strLoadGameName);
     gGameMenuMgr.Deactivate();
     gQuickLoadSlot = nSlot;
 }
@@ -2136,8 +2124,7 @@ void QuickLoadGame(void)
     if (!testkopen(strLoadGameName, 0))
         return;
     viewLoadingScreen(2518, "Loading", "Loading Saved Game", strRestoreGameStrings[gQuickLoadSlot]);
-    bool demoWasPlayed = gDemo.at1;
-    LoadSave::LoadGame(strLoadGameName, demoWasPlayed);
+    LoadSave::LoadGame(strLoadGameName);
     gGameMenuMgr.Deactivate();
 }
 

--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -2118,10 +2118,11 @@ void LoadGame(CGameMenuItemZEditBitmap *pItem, CGameMenuEvent *event)
     G_ModDirSnprintf(strLoadGameName, BMAX_PATH, "game00%02d.sav", nSlot);
     if (!testkopen(strLoadGameName, 0))
         return;
+    bool demoWasPlayed = gDemo.at1;
     if (gDemo.at1)
         gDemo.Close();
     viewLoadingScreen(2518, "Loading", "Loading Saved Game", strRestoreGameStrings[nSlot]);
-    LoadSave::LoadGame(strLoadGameName);
+    LoadSave::LoadGame(strLoadGameName, demoWasPlayed);
     gGameMenuMgr.Deactivate();
     gQuickLoadSlot = nSlot;
 }
@@ -2135,7 +2136,8 @@ void QuickLoadGame(void)
     if (!testkopen(strLoadGameName, 0))
         return;
     viewLoadingScreen(2518, "Loading", "Loading Saved Game", strRestoreGameStrings[gQuickLoadSlot]);
-    LoadSave::LoadGame(strLoadGameName);
+    bool demoWasPlayed = gDemo.at1;
+    LoadSave::LoadGame(strLoadGameName, demoWasPlayed);
     gGameMenuMgr.Deactivate();
 }
 

--- a/source/blood/src/osdcmd.cpp
+++ b/source/blood/src/osdcmd.cpp
@@ -969,6 +969,7 @@ int32_t registerosdcommands(void)
         { "in_mousesmoothing", "enable/disable mouse input smoothing", (void *)&SmoothInput, CVAR_BOOL, 0, 1 },
 //
         { "mus_enabled", "enables/disables music", (void *)&MusicToggle, CVAR_BOOL, 0, 1 },
+        { "mus_restartonload", "restart the music when loading a saved game with the same map or not", (void *)&MusicRestartsOnLoadToggle, CVAR_BOOL, 0, 1 },
         { "mus_volume", "controls music volume", (void *)&MusicVolume, CVAR_INT, 0, 255 },
         { "mus_device", "music device", (void *)&MusicDevice, CVAR_INT, 0, 1 },
         { "mus_redbook", "enables/disables redbook audio", (void *)&CDAudioToggle, CVAR_BOOL, 0, 1 },


### PR DESCRIPTION
…the player loads a game with the same map the player is already playing on.

On higher difficulties it is often very annoying that the music restarts from the beginning every time the player loads a saved game for the same map. It causes that only the first few seconds are played over and over again. In case of CD audio it is even worse because some of the tracks are starting with silence or low volume.

The original game had this behavior too, so I've kept it as the default, and I've added a new audio setting for this feature. BloodGDX has this feature too but it is enabled by default and cannot be turned off. My philosophy is that every new feature or modification should be opt-in to keep the game as close to the original as  possible.

Related issue: https://github.com/nukeykt/NBlood/issues/26

