### PR TITLE
fix Illegal instruction crash on 32 bit AMD processors and Intel Pentium 3

### DIFF
--- a/Common.mak
+++ b/Common.mak
@@ -597,26 +597,25 @@ ifndef OPTOPT
         ifeq ($(PLATFORM),DARWIN)
             OPTOPT := -march=nocona -mmmx -msse -msse2 -msse3
         else
-            OPTOPT := -march=pentium3
+            OPTOPT := -march=pentium4
             ifneq (0,$(GCC_PREREQ_4))
                 OPTOPT += -mtune=generic
                 # -mstackrealign
             endif
-            OPTOPT += -mmmx -msse -mfpmath=sse
+            OPTOPT += -mmmx -msse -msse2 -mfpmath=sse
+
+            # Fix for older PCs than Pentium 4
+            ifeq ($(HOSTPLATFORM),LINUX)                
+                ifneq ($(shell $(CC) -march=native  -dM -E - < /dev/null | grep -i "__SSE2__" | wc -l),1)
+                    OPTOPT := -march=native
+                endif
+            endif
+
         endif
     endif
     ifeq ($(PLATFORM),WII)
         OPTOPT := -mtune=750
     endif
-endif
-
-ifeq ($(PACKAGE_REPOSITORY),0)
-    COMMONFLAGS += -O$(OPTLEVEL) $(OPTOPT)
-endif
-
-ifneq (0,$(LTO))
-    COMPILERFLAGS += -DUSING_LTO
-    COMMONFLAGS += -flto
 endif
 
 

--- a/Common.mak
+++ b/Common.mak
@@ -602,7 +602,7 @@ ifndef OPTOPT
                 OPTOPT += -mtune=generic
                 # -mstackrealign
             endif
-            OPTOPT += -mmmx -msse -msse2 -mfpmath=sse
+            OPTOPT += -mmmx -msse -mfpmath=sse
         endif
     endif
     ifeq ($(PLATFORM),WII)

--- a/Common.mak
+++ b/Common.mak
@@ -604,9 +604,9 @@ ifndef OPTOPT
             endif
             OPTOPT += -mmmx -msse -msse2 -mfpmath=sse
 
-            # Fix for older PCs than Pentium 4
-            ifeq ($(HOSTPLATFORM),LINUX)                
-                ifneq ($(shell $(CC) -march=native  -dM -E - < /dev/null | grep -i "__SSE2__" | wc -l),1)
+            # Fix for 32 bit CPUs on Linux without SSE2
+            ifeq ($(HOSTPLATFORM),LINUX)
+                ifneq ($(shell $(CC) -march=native -dM -E - < /dev/null | grep -i "__SSE2__" | wc -l),1)
                     OPTOPT := -march=native
                 endif
             endif
@@ -616,6 +616,15 @@ ifndef OPTOPT
     ifeq ($(PLATFORM),WII)
         OPTOPT := -mtune=750
     endif
+endif
+
+ifeq ($(PACKAGE_REPOSITORY),0)
+    COMMONFLAGS += -O$(OPTLEVEL) $(OPTOPT)
+endif
+
+ifneq (0,$(LTO))
+    COMPILERFLAGS += -DUSING_LTO
+    COMMONFLAGS += -flto
 endif
 
 


### PR DESCRIPTION
In the make file a few lines above it sets the architecture to Pentium 3 and then later it adds the SSE2 instruction set optimizations. Pentium 3 doesn't have SSE2, nor any 32 bit AMD CPU. Only Pentium 4 has it. It caused Illegal instruction crash for me on my AMD Athlon XP.
The problematic line was at source/build/src/osd.cpp:90
It wants to assign a double value and the compiler generated SSE2 code, only SSE2 has double float operators, which the Pentium 3 doesn't have.