### PR TITLE
fix SMK playback

### DIFF
--- a/source/blood/src/credits.cpp
+++ b/source/blood/src/credits.cpp
@@ -168,7 +168,6 @@ int credKOpen4Load(char *&pzFile)
 
 void credPlaySmk(const char *_pzSMK, const char *_pzWAV, int nWav)
 {
-    return;
 #if 0
     CSMKPlayer smkPlayer;
     if (dword_148E14 >= 0)


### PR DESCRIPTION
Related issue: https://github.com/nukeykt/NBlood/issues/128
For some reason, this `return` was added when merging code from EDuke32 and it caused cinematics to not play anymore.