### PR TITLE
fix Cheogh being brown instead of gray on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ project.xcworkspace/
 
 .DS_Store
 ._*
+/movie
+/blud*.png
+/*.DEM
+/game*.sav

--- a/Common.mak
+++ b/Common.mak
@@ -454,7 +454,7 @@ else
     LTO := 1
 
     ifeq ($(PLATFORM),LINUX)
-        if (ifeq (0,$(CLANG))
+        ifeq (0,$(CLANG))
             # This needs to be 1, otherwise Cheogh's color would be brown instead of gray on Linux
             OPTLEVEL := 1
         endif

--- a/Common.mak
+++ b/Common.mak
@@ -722,6 +722,12 @@ endif
 
 COMMONFLAGS += -fno-strict-aliasing -fno-threadsafe-statics $(F_JUMP_TABLES) $(F_NO_STACK_PROTECTOR)
 
+# This is needed, otherwise Cheogh will be brown on Linux
+ifneq ($(PLATFORM),WINDOWS)
+    ifeq ($(OPTLEVEL),2)
+        COMMONFLAGS += -fno-ipa-icf
+    endif
+endif
 
 ##### Warnings
 

--- a/Common.mak
+++ b/Common.mak
@@ -724,9 +724,7 @@ COMMONFLAGS += -fno-strict-aliasing -fno-threadsafe-statics $(F_JUMP_TABLES) $(F
 
 # This is needed, otherwise Cheogh will be brown on Linux
 ifneq ($(PLATFORM),WINDOWS)
-    ifeq ($(OPTLEVEL),2)
-        COMMONFLAGS += -fno-ipa-icf
-    endif
+    COMMONFLAGS += -fno-ipa-bit-cp -fno-ipa-cp -fno-ipa-icf -fno-ipa-vrp
 endif
 
 ##### Warnings

--- a/Common.mak
+++ b/Common.mak
@@ -450,18 +450,15 @@ ifeq ($(RELEASE),0)
 
     LTO := 0
 else
-    ifeq ($(PLATFORM),WINDOWS)
-        OPTLEVEL := 2
-    else
-        # This needs to be 1, otherwise Cheogh's color would be brown instead of gray on Linux
-        OPTLEVEL := 1
-        ifneq (0,$(CLANG))
-            # This needs to be 0, otherwise Cheogh's color would be brown instead of gray on Linux if compiled with Clang
-            OPTLEVEL := 0
+    OPTLEVEL := 2
+    LTO := 1
+
+    ifeq ($(PLATFORM),LINUX)
+        if (ifeq (0,$(CLANG))
+            # This needs to be 1, otherwise Cheogh's color would be brown instead of gray on Linux
+            OPTLEVEL := 1
         endif
     endif
-
-    LTO := 1
 endif
 
 ifneq (0,$(CLANG))

--- a/Common.mak
+++ b/Common.mak
@@ -455,6 +455,10 @@ else
     else
         # This needs to be 1, otherwise Cheogh's color would be brown instead of gray on Linux
         OPTLEVEL := 1
+        ifneq (0,$(CLANG))
+            # This needs to be 0, otherwise Cheogh's color would be brown instead of gray on Linux if compiled with Clang
+            OPTLEVEL := 0
+        endif
     endif
 
     LTO := 1

--- a/Common.mak
+++ b/Common.mak
@@ -450,7 +450,13 @@ ifeq ($(RELEASE),0)
 
     LTO := 0
 else
-    OPTLEVEL := 2
+    ifeq ($(PLATFORM),WINDOWS)
+        OPTLEVEL := 2
+    else
+        # This needs to be 1, otherwise Cheogh's color would be brown instead of gray on Linux
+        OPTLEVEL := 1
+    endif
+
     LTO := 1
 endif
 
@@ -722,12 +728,6 @@ endif
 
 COMMONFLAGS += -fno-strict-aliasing -fno-threadsafe-statics $(F_JUMP_TABLES) $(F_NO_STACK_PROTECTOR)
 
-# This is needed, otherwise Cheogh will be brown on Linux
-ifneq ($(PLATFORM),WINDOWS)
-    ifeq (0,$(CLANG)) # Sorry non-Windows Clang users, Cheogh will be brown for you (Clang doesn't know these flags)
-        COMMONFLAGS += -fno-ipa-bit-cp -fno-ipa-cp -fno-ipa-icf -fno-ipa-vrp
-    endif
-endif
 
 ##### Warnings
 

--- a/Common.mak
+++ b/Common.mak
@@ -724,7 +724,9 @@ COMMONFLAGS += -fno-strict-aliasing -fno-threadsafe-statics $(F_JUMP_TABLES) $(F
 
 # This is needed, otherwise Cheogh will be brown on Linux
 ifneq ($(PLATFORM),WINDOWS)
-    COMMONFLAGS += -fno-ipa-bit-cp -fno-ipa-cp -fno-ipa-icf -fno-ipa-vrp
+    ifeq (0,$(CLANG)) # Sorry non-Windows Clang users, Cheogh will be brown for you (Clang doesn't know these flags)
+        COMMONFLAGS += -fno-ipa-bit-cp -fno-ipa-cp -fno-ipa-icf -fno-ipa-vrp
+    endif
 endif
 
 ##### Warnings


### PR DESCRIPTION
Related issue: https://github.com/nukeykt/NBlood/issues/137

At the end of the day, this is what I find the most proper fix.
If I only disable some compiler optimizations, it still won't be perfect on Fedora (see the related issue). Furthermore, Clang doesn't know these flags and wouldn't be able to compile.

If I set -O1 instead of -O2 then Cheogh's color will be OK both on Ubuntu and Fedora in every case.
But if I compile with Clang, only the RELEASE=0 mode produces correct colors for Cheogh. But Clang is crap, sometimes it even removes your code entirely[1].

Since I cannot test Mac, and I don't want to waste time with the crappy Clang, I decided to fix this only for GCC on Linux.

I decided to disable O2 optimizations and just leave O1 optimizations. First time disabling `ipa-icf` did the job, but when later the code changed I had to disable `ipa-cp`. Who knows what the future brings? It is better to stay on the safe side, the compiler wants to be too clever, but it just messes up Cheogh. This is even worse than a security flaw[1] :D

[1]: https://www.redhat.com/en/blog/security-flaws-caused-compiler-optimizations