### PR TITLE
fix incorrect palette usage on Linux

### DIFF
--- a/Common.mak
+++ b/Common.mak
@@ -453,7 +453,7 @@ else
     OPTLEVEL := 2
     LTO := 1
 
-    # Fix Cheogh being brown instead of gray
+    # Fix palette rendering on Linux and BSD
     ifeq ($(HOSTPLATFORM),$(filter $(HOSTPLATFORM),LINUX BSD))
         ifeq (0,$(CLANG))
             ifeq (4,$(GCC_MAJOR))

--- a/Common.mak
+++ b/Common.mak
@@ -455,7 +455,7 @@ else
 
     # Fix Cheogh being brown instead of gray
     ifeq ($(HOSTPLATFORM),$(filter $(HOSTPLATFORM),LINUX BSD))
-        ifneq (0,$(CLANG))
+        ifeq (0,$(CLANG))
             ifeq (4,$(GCC_MAJOR))
                 ifneq (8,$(GCC_MINOR))
                     OPTLEVEL := 1

--- a/Common.mak
+++ b/Common.mak
@@ -452,6 +452,19 @@ ifeq ($(RELEASE),0)
 else
     OPTLEVEL := 2
     LTO := 1
+
+    # Fix Cheogh being brown instead of gray
+    ifeq ($(HOSTPLATFORM),$(filter $(HOSTPLATFORM),LINUX BSD))
+        ifneq (0,$(CLANG))
+            ifeq (4,$(GCC_MAJOR))
+                ifneq (8,$(GCC_MINOR))
+                    OPTLEVEL := 1
+                endif
+            else
+                OPTLEVEL := 1
+            endif
+        endif
+    endif
 endif
 
 ifneq (0,$(CLANG))


### PR DESCRIPTION
Related issue: https://github.com/nukeykt/NBlood/issues/137

Use optimization level 1 if building on Linux or BSD with GCC and GCC version is not 4.8.x.
Otherwise, some sprites will be rendered with wrong palettes (depending on where the sprite is on the map (floortype)). I tried GCC 5, 6, 7 and 9 but they are broken too, only 4.8.x works.