### PR TITLE
fix ceiling clipping

### DIFF
--- a/source/blood/src/actor.cpp
+++ b/source/blood/src/actor.cpp
@@ -4124,8 +4124,8 @@ void ProcessTouchObjects(spritetype *pSprite, int nXSprite)
     PLAYER *pPlayer = NULL;
     if (IsPlayerSprite(pSprite))
         pPlayer = &gPlayer[pSprite->type-kDudePlayer1];
-    int nHitSprite = pSpriteHit->ceilhit & 0x3fff;
-    switch (pSpriteHit->ceilhit&0xc000)
+    int nHitSprite = pSpriteHit->ceilhit & 0x1fff;
+    switch (pSpriteHit->ceilhit&0xe000)
     {
     case 0x8000:
         break;
@@ -4215,8 +4215,8 @@ void ProcessTouchObjects(spritetype *pSprite, int nXSprite)
         }
         break;
     }
-    nHitSprite = pSpriteHit->hit & 0x3fff;
-    switch (pSpriteHit->hit&0xc000)
+    nHitSprite = pSpriteHit->hit & 0x1fff;
+    switch (pSpriteHit->hit&0xe000)
     {
     case 0x8000:
         break;
@@ -4288,8 +4288,8 @@ void ProcessTouchObjects(spritetype *pSprite, int nXSprite)
         }
         break;
     }
-    nHitSprite = pSpriteHit->florhit & 0x3fff;
-    switch (pSpriteHit->florhit&0xc000)
+    nHitSprite = pSpriteHit->florhit & 0x1fff;
+    switch (pSpriteHit->florhit&0xe000)
     {
     case 0x8000:
         break;
@@ -4469,9 +4469,9 @@ int MoveThing(spritetype *pSprite)
             dassert(nSector >= 0 && nSector < kMaxSectors);
             ChangeSpriteSect(nSprite, nSector);
         }
-        if ((gSpriteHit[nXSprite].hit&0xc000) == 0x8000)
+        if ((gSpriteHit[nXSprite].hit&0xe000) == 0x8000)
         {
-            int nHitWall = gSpriteHit[nXSprite].hit&0x3fff;
+            int nHitWall = gSpriteHit[nXSprite].hit&0x1fff;
             actWallBounceVector((int*)&xvel[nSprite], (int*)&yvel[nSprite], nHitWall, pThingInfo->at7);
             switch (pSprite->type)
             {
@@ -4601,9 +4601,9 @@ int MoveThing(spritetype *pSprite)
     {
         int nVel = approxDist(xvel[nSprite], yvel[nSprite]);
         int nVelClipped = ClipHigh(nVel, 0x11111);
-        if ((floorHit & 0xc000) == 0xc000)
+        if ((floorHit & 0xe000) == 0xc000)
         {
-            int nHitSprite = floorHit & 0x3fff;
+            int nHitSprite = floorHit & 0x1fff;
             if ((sprite[nHitSprite].cstat & 0x30) == 0)
             {
                 xvel[nSprite] += mulscale(4, pSprite->x - sprite[nHitSprite].x, 2);
@@ -4663,7 +4663,7 @@ void MoveDude(spritetype *pSprite)
             if (sector[nSector].lotag >= 612 && sector[nSector].lotag <= 617)
             {
                 short nSector2 = nSector;
-                if (pushmove_old(&pSprite->x, &pSprite->y, &pSprite->z, &nSector2, wd, tz, bz, CLIPMASK0) == -1)
+                if (pushmove_old(&pSprite->x, &pSprite->y, &pSprite->z, &nSector2, wd, tz, bz, 0x13001) == -1)
                     actDamageSprite(nSprite, pSprite, DAMAGE_TYPE_0, 1000 << 4);
                 if (nSector2 != -1)
                     nSector = nSector2;
@@ -4671,11 +4671,11 @@ void MoveDude(spritetype *pSprite)
             dassert(nSector >= 0);
             pSprite->cstat = bakCstat;
         }
-        switch (gSpriteHit[nXSprite].hit&0xc000)
+        switch (gSpriteHit[nXSprite].hit&0xe000)
         {
         case 0xc000:
         {
-            int nHitSprite = gSpriteHit[nXSprite].hit&0x3fff;
+            int nHitSprite = gSpriteHit[nXSprite].hit&0x1fff;
             spritetype *pHitSprite = &sprite[nHitSprite];
             XSPRITE *pHitXSprite = NULL;
             // Should be pHitSprite here
@@ -4699,7 +4699,7 @@ void MoveDude(spritetype *pSprite)
         }
         case 0x8000:
         {
-            int nHitWall = gSpriteHit[nXSprite].hit&0x3fff;
+            int nHitWall = gSpriteHit[nXSprite].hit&0x1fff;
             walltype *pHitWall = &wall[nHitWall];
             XWALL *pHitXWall = NULL;
             if (pHitWall->extra > 0)
@@ -4775,7 +4775,7 @@ void MoveDude(spritetype *pSprite)
     if (zvel[nSprite])
         pSprite->z += zvel[nSprite]>>8;
     int ceilZ, ceilHit, floorZ, floorHit;
-    GetZRange(pSprite, &ceilZ, &ceilHit, &floorZ, &floorHit, wd, CLIPMASK0);
+    GetZRange(pSprite, &ceilZ, &ceilHit, &floorZ, &floorHit, wd, 0x13001);
     GetSpriteExtents(pSprite, &top, &bottom);
     if (pSprite->hitag & 2)
     {
@@ -4818,7 +4818,7 @@ void MoveDude(spritetype *pSprite)
     int nLink = CheckLink(pSprite);
     if (nLink)
     {
-        GetZRange(pSprite, &ceilZ, &ceilHit, &floorZ, &floorHit, wd, CLIPMASK0);
+        GetZRange(pSprite, &ceilZ, &ceilHit, &floorZ, &floorHit, wd, 0x13001);
         if (pPlayer)
             playerResetInertia(pPlayer);
         switch (nLink)
@@ -5030,7 +5030,7 @@ void MoveDude(spritetype *pSprite)
     {
         int floorZ2 = floorZ;
         int floorHit2 = floorHit;
-        GetZRange(pSprite, &ceilZ, &ceilHit, &floorZ, &floorHit, pSprite->clipdist<<2, CLIPMASK0);
+        GetZRange(pSprite, &ceilZ, &ceilHit, &floorZ, &floorHit, pSprite->clipdist<<2, 0x13001);
         if (bottom <= floorZ && pSprite->z - floorZ2 < bz)
         {
             floorZ = floorZ2;
@@ -5113,9 +5113,9 @@ void MoveDude(spritetype *pSprite)
     pXSprite->height = ClipLow(floorZ-bottom, 0)>>8;
     if (xvel[nSprite] || yvel[nSprite])
     {
-        if ((floorHit & 0xc000) == 0xc000)
+        if ((floorHit & 0xe000) == 0xc000)
         {
-            int nHitSprite = floorHit & 0x3fff;
+            int nHitSprite = floorHit & 0x1fff;
             if ((sprite[nHitSprite].cstat & 0x30) == 0)
             {
                 xvel[nSprite] += mulscale(4, pSprite->x - sprite[nHitSprite].x, 2);
@@ -5215,13 +5215,13 @@ int MoveMissile(spritetype *pSprite)
         }
         if (vdx)
         {
-            int nHitSprite = vdx & 0x3fff;
-            if ((vdx&0xc000) == 0xc000)
+            int nHitSprite = vdx & 0x1fff;
+            if ((vdx&0xe000) == 0xc000)
             {
                 gHitInfo.hitsprite = nHitSprite;
                 vdi = 3;
             }
-            else if ((vdx & 0xc000) == 0x8000)
+            else if ((vdx & 0xe000) == 0x8000)
             {
                 gHitInfo.hitwall = nHitSprite;
                 if (wall[nHitSprite].nextsector == -1)
@@ -5636,7 +5636,7 @@ void actProcessSprites(void)
                 }
             }
             actAirDrag(pSprite, 128);
-            if (((pSprite->index>>8)&15) == (gFrame&15) && (pSprite->hitag&2))
+            if (((pSprite->index>>8)) == (gFrame&15) && (pSprite->hitag&2))
                 pSprite->hitag |= 4;
             if ((pSprite->hitag&4) || xvel[nSprite] || yvel[nSprite] || zvel[nSprite] ||
                 velFloor[pSprite->sectnum] || velCeil[pSprite->sectnum])
@@ -5658,11 +5658,11 @@ void actProcessSprites(void)
                             break;
                         case kGDXThingThrowableRock:
                             seqSpawn(24, 3, nXSprite, -1);
-                            if ((hit & 0xc000) == 0xc000)
+                            if ((hit & 0xe000) == 0xc000)
                             {
                                 pSprite->xrepeat = 32;
                                 pSprite->yrepeat = 32;
-                                int nObject = hit & 0x3fff;
+                                int nObject = hit & 0x1fff;
                                 dassert(nObject >= 0 && nObject < kMaxSprites);
                                 spritetype * pObject = &sprite[nObject];
                                 actDamageSprite(actSpriteOwnerToSpriteId(pSprite), pObject, DAMAGE_TYPE_0, pXSprite->data1);
@@ -5670,24 +5670,24 @@ void actProcessSprites(void)
                             break;
                         case 421:
                             seqSpawn(24, 3, nXSprite, -1);
-                            if ((hit&0xc000) == 0xc000)
+                            if ((hit&0xe000) == 0xc000)
                             {
-                                int nObject = hit & 0x3fff;
+                                int nObject = hit & 0x1fff;
                                 dassert(nObject >= 0 && nObject < kMaxSprites);
                                 spritetype *pObject = &sprite[nObject];
                                 actDamageSprite(actSpriteOwnerToSpriteId(pSprite), pObject, DAMAGE_TYPE_0, 12);
                             }
                             break;
                         case 430:
-                            if ((hit&0xc000) == 0x4000)
+                            if ((hit&0xe000) == 0x4000)
                             {
                                 sub_2A620(actSpriteOwnerToSpriteId(pSprite), pSprite->x, pSprite->y, pSprite->z, pSprite->sectnum, 200, 1, 20, DAMAGE_TYPE_3, 6, 0, 0, 0);
                                 evPost(pSprite->index, 3, 0, CALLBACK_ID_19);
                             }
                             else
                             {
-                                int nObject = hit & 0x3fff;
-                                if ((hit&0xc000) != 0xc000 && (nObject < 0 || nObject >= 4096))
+                                int nObject = hit & 0x1fff;
+                                if ((hit&0xe000) != 0xc000 && (nObject < 0 || nObject >= 4096))
                                     break;
                                 dassert(nObject >= 0 && nObject < kMaxSprites);
                                 spritetype *pObject = &sprite[nObject];
@@ -5697,8 +5697,8 @@ void actProcessSprites(void)
                             break;
                         case 429:
                         {
-                            int nObject = hit & 0x3fff;
-                            if ((hit&0xc000) != 0xc000 && (nObject < 0 || nObject >= 4096))
+                            int nObject = hit & 0x1fff;
+                            if ((hit&0xe000) != 0xc000 && (nObject < 0 || nObject >= 4096))
                                 break;
                             dassert(nObject >= 0 && nObject < kMaxSprites);
                             int UNUSED(nOwner) = actSpriteOwnerToSpriteId(pSprite);

--- a/source/blood/src/gameutil.cpp
+++ b/source/blood/src/gameutil.cpp
@@ -682,9 +682,9 @@ void GetZRange(spritetype *pSprite, int *ceilZ, int *ceilHit, int *floorZ, int *
     int32_t nTemp1, nTemp2;
     pSprite->cstat &= ~257;
     getzrange_old(pSprite->x, pSprite->y, pSprite->z, pSprite->sectnum, (int32_t*)ceilZ, (int32_t*)ceilHit, (int32_t*)floorZ, (int32_t*)floorHit, nDist, nMask);
-    if (((*floorHit) & 0xc000) == 0x4000)
+    if (((*floorHit) & 0xe000) == 0x4000)
     {
-        int nSector = (*floorHit) & 0x3fff;
+        int nSector = (*floorHit) & 0x1fff;
         if ((nMask & 0x2000) == 0 && (sector[nSector].floorstat & 1))
             *floorZ = 0x7fffffff;
         if (sector[nSector].extra > 0)
@@ -702,9 +702,9 @@ void GetZRange(spritetype *pSprite, int *ceilZ, int *ceilHit, int *floorZ, int *
             *floorZ -= sprite[nLink].z - sprite[nSprite].z;
         }
     }
-    if (((*ceilHit) & 0xc000) == 0x4000)
+    if (((*ceilHit) & 0xe000) == 0x4000)
     {
-        int nSector = (*ceilHit) & 0x3fff;
+        int nSector = (*ceilHit) & 0x1fff;
         if ((nMask & 0x1000) == 0 && (sector[nSector].ceilingstat & 1))
             *ceilZ = 0x80000000;
         if (gLowerLink[nSector] >= 0)
@@ -724,9 +724,9 @@ void GetZRangeAtXYZ(int x, int y, int z, int nSector, int *ceilZ, int *ceilHit, 
 {
     int32_t nTemp1, nTemp2;
     getzrange_old(x, y, z, nSector, (int32_t*)ceilZ, (int32_t*)ceilHit, (int32_t*)floorZ, (int32_t*)floorHit, nDist, nMask);
-    if (((*floorHit) & 0xc000) == 0x4000)
+    if (((*floorHit) & 0xe000) == 0x4000)
     {
-        int nSector = (*floorHit) & 0x3fff;
+        int nSector = (*floorHit) & 0x1fff;
         if ((nMask & 0x2000) == 0 && (sector[nSector].floorstat & 1))
             *floorZ = 0x7fffffff;
         if (sector[nSector].extra > 0)
@@ -744,9 +744,9 @@ void GetZRangeAtXYZ(int x, int y, int z, int nSector, int *ceilZ, int *ceilHit, 
             *floorZ -= sprite[nLink].z - sprite[nSprite].z;
         }
     }
-    if (((*ceilHit) & 0xc000) == 0x4000)
+    if (((*ceilHit) & 0xe000) == 0x4000)
     {
-        int nSector = (*ceilHit) & 0x3fff;
+        int nSector = (*ceilHit) & 0x1fff;
         if ((nMask & 0x1000) == 0 && (sector[nSector].ceilingstat & 1))
             *ceilZ = 0x80000000;
         if (gLowerLink[nSector] >= 0)

--- a/source/blood/src/map2d.cpp
+++ b/source/blood/src/map2d.cpp
@@ -150,7 +150,7 @@ void sub_2541C(int x, int y, int z, short a)
             {
                 int nTile = pSprite->picnum;
                 int ceilZ, ceilHit, floorZ, floorHit;
-                GetZRange(pSprite, &ceilZ, &ceilHit, &floorZ, &floorHit, (pSprite->clipdist<<2)+16, CLIPMASK0);
+                GetZRange(pSprite, &ceilZ, &ceilHit, &floorZ, &floorHit, (pSprite->clipdist<<2)+16, 0x13001);
                 int nTop, nBottom;
                 GetSpriteExtents(pSprite, &nTop, &nBottom);
                 int nScale = mulscale((pSprite->yrepeat+((floorZ-nBottom)>>8))*z, yxaspect, 16);

--- a/source/blood/src/player.cpp
+++ b/source/blood/src/player.cpp
@@ -1775,7 +1775,7 @@ void ProcessInput(PLAYER *pPlayer)
         pPlayer->q16horiz = fix16_from_float(100.f*tanf(fix16_to_float(pPlayer->q16look)*fPI/1024.f));
     }
     int nSector = pSprite->sectnum;
-    int florhit = gSpriteHit[pSprite->extra].florhit & 0xc000;
+    int florhit = gSpriteHit[pSprite->extra].florhit & 0xe000;
     char va;
     if (pXSprite->height < 16 && (florhit == 0x4000 || florhit == 0))
         va = 1;

--- a/source/blood/src/tile.cpp
+++ b/source/blood/src/tile.cpp
@@ -265,8 +265,8 @@ void tilePrecacheTile(int nTile, int nType)
 
 char tileGetSurfType(int hit)
 {
-    int n = hit & 0x3fff;
-    switch (hit&0xc000)
+    int n = hit & 0x1fff;
+    switch (hit&0xe000)
     {
     case 0x4000:
         return surfType[sector[n].floorpicnum];

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -449,7 +449,7 @@ void fakeProcessInput(PLAYER *pPlayer, GINPUT *pInput)
     predict.at24 = fix16_from_float(100.f*tanf(fix16_to_float(predict.at20)*fPI/1024.f));
 
     int nSector = predict.at68;
-    int florhit = predict.at75.florhit & 0xc000;
+    int florhit = predict.at75.florhit & 0xe000;
     char va;
     if (predict.at6a < 16 && (florhit == 0x4000 || florhit == 0))
         va = 1;
@@ -600,7 +600,7 @@ void fakeMoveDude(spritetype *pSprite)
         {
             short bakCstat = pSprite->cstat;
             pSprite->cstat &= ~257;
-            predict.at75.hit = ClipMove(&predict.at50, &predict.at54, &predict.at58, &nSector, predict.at5c >> 12, predict.at60 >> 12, wd, tz, bz, CLIPMASK0);
+            predict.at75.hit = ClipMove(&predict.at50, &predict.at54, &predict.at58, &nSector, predict.at5c >> 12, predict.at60 >> 12, wd, tz, bz, 0x13001);
             if (nSector == -1)
                 nSector = predict.at68;
                     
@@ -616,11 +616,11 @@ void fakeMoveDude(spritetype *pSprite)
 
             pSprite->cstat = bakCstat;
         }
-        switch (predict.at75.hit&0xc000)
+        switch (predict.at75.hit&0xe000)
         {
         case 0x8000:
         {
-            int nHitWall = predict.at75.hit&0x3fff;
+            int nHitWall = predict.at75.hit&0x1fff;
             walltype *pHitWall = &wall[nHitWall];
             if (pHitWall->nextsector != -1)
             {
@@ -710,7 +710,7 @@ void fakeMoveDude(spritetype *pSprite)
     {
         int floorZ2 = floorZ;
         int floorHit2 = floorHit;
-        GetZRange(pTempSprite, &ceilZ, &ceilHit, &floorZ, &floorHit, pSprite->clipdist<<2, CLIPMASK0);
+        GetZRange(pTempSprite, &ceilZ, &ceilHit, &floorZ, &floorHit, pSprite->clipdist<<2, 0x13001);
         if (bottom <= floorZ && predict.at58-floorZ2 < bz)
         {
             floorZ = floorZ2;
@@ -758,9 +758,9 @@ void fakeMoveDude(spritetype *pSprite)
     predict.at6a = ClipLow(floorZ-bottom, 0)>>8;
     if (predict.at5c || predict.at60)
     {
-        if ((floorHit & 0xc000) == 0xc000)
+        if ((floorHit & 0xe000) == 0xc000)
         {
-            int nHitSprite = floorHit & 0x3fff;
+            int nHitSprite = floorHit & 0x1fff;
             if ((sprite[nHitSprite].cstat & 0x30) == 0)
             {
                 predict.at5c += mulscale(4, predict.at50 - sprite[nHitSprite].x, 2);
@@ -3321,7 +3321,7 @@ RORHACK:
         GetZRange(gView->pSprite, &vf4, &vf0, &vec, &ve8, nClipDist, 0);
 #if 0
         int tmpSect = nSectnum;
-        if ((vf0 & 0xc000) == 0x4000)
+        if ((vf0 & 0xe000) == 0x4000)
         {
             tmpSect = vf0 & (kMaxWalls-1);
         }

--- a/source/build/src/2d.cpp
+++ b/source/build/src/2d.cpp
@@ -912,7 +912,7 @@ static void editorDraw2dWall(int32_t i, int32_t posxe, int32_t posye, int32_t po
             col += M32_THROB>>2;
     }
 
-    if (bloodhack && (cstat&0xc000))
+    if (bloodhack && (cstat&0xc000)) // should be 0xe000?
     {
         if (cstat&0x8000)
             col = editorcolors[10];


### PR DESCRIPTION
I don't know what these numbers mean, but I reverted them and it fixed both of these issues:
https://github.com/nukeykt/NBlood/issues/147
https://github.com/nukeykt/NBlood/issues/142

I reverted the ceiling and floor hit related constants which were modified by 00b94cd.

I don't know what the value should be in 2d.cpp since that is new code and I also don't know what does it do:
https://github.com/nukeykt/NBlood/compare/mapedit...CommonLoon102:jumpbug?expand=1#diff-2dd42d3488848376205f3c0f165e3257R915
