### PR TITLE
Build fix for big endian and USE_OPENGL=0

### DIFF
--- a/source/blood/src/resource.cpp
+++ b/source/blood/src/resource.cpp
@@ -771,7 +771,9 @@ void Resource::Read(DICTNODE *n, void *p)
                 swapFrame.at6_3 = bitReader.readBit();
                 swapFrame.at6_4 = bitReader.readBit();
                 swapFrame.tile2 = bitReader.readUnsigned(4);
-                swapFrame.pad = bitReader.readUnsigned(7);
+                swapFrame.soundRange = bitReader.readUnsigned(4);
+                swapFrame.surfaceSound = bitReader.readBit();
+                swapFrame.reserved = bitReader.readUnsigned(2);
                 *pFrame = swapFrame;
             }
         }

--- a/source/build/include/build.h
+++ b/source/build/include/build.h
@@ -1458,6 +1458,10 @@ extern GrowArray<char *> g_defModules;
 extern GrowArray<char *> g_clipMapFiles;
 #endif
 
+EXTERN intptr_t voxoff[MAXVOXELS][MAXVOXMIPS]; // used in KenBuild
+EXTERN int8_t voxreserve[(MAXVOXELS+7)>>3];
+EXTERN int8_t voxrotate[(MAXVOXELS+7)>>3];
+
 #ifdef USE_OPENGL
 // TODO: dynamically allocate this
 
@@ -1477,9 +1481,6 @@ typedef struct
 
 # define EXTRATILES (MAXTILES/8)
 
-EXTERN intptr_t voxoff[MAXVOXELS][MAXVOXMIPS]; // used in KenBuild
-EXTERN int8_t voxreserve[(MAXVOXELS+7)>>3];
-EXTERN int8_t voxrotate[(MAXVOXELS+7)>>3];
 EXTERN int32_t mdinited;
 EXTERN tile2model_t tile2model[MAXTILES+EXTRATILES];
 


### PR DESCRIPTION
Fixed the byte swapping for the extended SEQFRAME structure and moved some voxel declarations out of the USE_OPENGL block.