### PR TITLE
maphacks: mdzoff for voxels WIP!

### DIFF
--- a/source/build/src/engine.cpp
+++ b/source/build/src/engine.cpp
@@ -6203,13 +6203,17 @@ draw_as_face_sprite:
             }
         }
 
+        x = tspr->x + spriteext[spritenum].offset.x;
+        y = tspr->y + spriteext[spritenum].offset.y;
+        z = tspr->z + spriteext[spritenum].offset.z;
+
         i = (int32_t)tspr->ang+1536;
         i += spriteext[spritenum].angoff;
 
         const int32_t ceilingz = (sec->ceilingstat&3) == 0 ? sec->ceilingz : INT32_MIN;
         const int32_t floorz = (sec->floorstat&3) == 0 ? sec->floorz : INT32_MAX;
 
-        classicDrawVoxel(tspr->x,tspr->y,tspr->z,i,daxrepeat,(int32_t)tspr->yrepeat,vtilenum,
+        classicDrawVoxel(x,y,z,i,daxrepeat,(int32_t)tspr->yrepeat,vtilenum,
             tspr->shade,tspr->pal,lwall,swall,tspr->cstat,(tspr->cstat&48)!=48,floorz,ceilingz);
     }
 

--- a/source/build/src/voxmodel.cpp
+++ b/source/build/src/voxmodel.cpp
@@ -1143,7 +1143,7 @@ int32_t polymost_voxdraw(voxmodel_t *m, tspriteptr_t const tspr)
     f = (float) tspr->yrepeat * k0;
     m0.z *= f; a0.z *= f;
 
-    k0 = (float) tspr->z;
+    k0 = (float) (tspr->z+spriteext[tspr->owner].offset.z);
     f = ((globalorientation&8) && (sprite[tspr->owner].cstat&48)!=0) ? -4.f : 4.f;
     k0 -= (tspr->yoffset*tspr->yrepeat)*f*m->bscale;
     zoff = m->siz.z*.5f;
@@ -1161,8 +1161,8 @@ int32_t polymost_voxdraw(voxmodel_t *m, tspriteptr_t const tspr)
 
     int const shadowHack = !!(tspr->extra&TSPR_EXTRA_MDHACK);
 
-    m0.y *= f; a0.y = (((float)(tspr->x-globalposx)) * (1.f/1024.f) + a0.y) * f;
-    m0.x *=-f; a0.x = (((float)(tspr->y-globalposy)) * -(1.f/1024.f) + a0.x) * -f;
+    m0.y *= f; a0.y = (((float)(tspr->x-globalposx)) * (1.f/1024.f) + a0.y + (spriteext[tspr->owner].offset.y * -(1.f/1024.f))) * f;
+    m0.x *=-f; a0.x = (((float)(tspr->y-globalposy)) * -(1.f/1024.f) + a0.x + (spriteext[tspr->owner].offset.x * (1.f/1024.f))) * -f;
     m0.z *= g; a0.z = (((float)(k0     -globalposz - shadowHack)) * -(1.f/16384.f) + a0.z) * g;
 
     float mat[16];


### PR DESCRIPTION
Do not merge this yet.
For the z direction (height) it works both for classic and OpenGL renderer, but there is something wrong with x and y because they give different results between classic and OpenGL. Don't try to find logic in OpenGL code related to x and y, because I was just trying by trial and error :)

Do you have any idea how to make it work for x and y too? I'm trying to add this feature because the misaligned fire armor on E3E2, but that only requires the z direction which is OK with this change.