### PR TITLE
Bgetsysmemsize 64-bit fix

### DIFF
--- a/source/build/src/compat.cpp
+++ b/source/build/src/compat.cpp
@@ -642,7 +642,7 @@ size_t Bgetsysmemsize(void)
     int64_t const scphyspages = sysconf(_SC_PHYS_PAGES);
 
     if (scpagesiz >= 0 && scphyspages >= 0)
-        siz = (uint32_t)min<uint64_t>(SIZE_MAX, scpagesiz * scphyspages);
+        siz = (size_t)min<uint64_t>(SIZE_MAX, scpagesiz * scphyspages);
 
     //initprintf("Bgetsysmemsize(): %d pages of %d bytes, %d bytes of system memory\n",
     //		scphyspages, scpagesiz, siz);


### PR DESCRIPTION
Changed a cast in Bgetsysmemsize() from uint32_t to size_t. If size_t is 64-bit and the system has more than 4 GB of memory then this casting it to uint32_t can result in a bogus value (e.g. 0 on macOS).