### PR TITLE
Reindex external resources too

### DIFF
--- a/source/blood/src/resource.cpp
+++ b/source/blood/src/resource.cpp
@@ -347,7 +347,7 @@ void Resource::Reindex(void)
     memset(indexId, 0, buffSize * sizeof(DICTNODE*));
     for (unsigned int i = 0; i < count; i++)
     {
-        if (dict[i].flags & DICT_ID)
+        if (dict[i].flags & (DICT_ID|DICT_EXTERNAL))
         {
             DICTNODE **node = Probe(dict[i].id, dict[i].type);
             *node = &dict[i];


### PR DESCRIPTION
Not doing so will cause problems for example when custom SEQs are defined in blood.def and then loading custom maps. When loading custom maps, the custom map will be removed from the resource dictionary (and then re-inserted), after removing a node a reindex operation happens but that was not reindexing the external resources, therefore custom SEQs stopped working.