### PR TITLE
Fix the SDL 1.2 and USE_OPENGL=0 build

### DIFF
--- a/source/build/include/palette.h
+++ b/source/build/include/palette.h
@@ -49,8 +49,10 @@ typedef struct {
 extern palette_t curpalette[256], curpalettefaded[256], palfadergb;
 
 extern char palfadedelta;
+#ifdef USE_OPENGL
 extern void fullscreen_tint_gl(uint8_t r, uint8_t g, uint8_t b, uint8_t f);
 extern void fullscreen_tint_gl_blood(void);
+#endif
 extern void videoFadeToBlack(int32_t moreopaquep);
 void paletteMakeLookupTable(int32_t palnum, const char *remapbuf, uint8_t r, uint8_t g, uint8_t b, char noFloorPal);
 void paletteSetColorTable(int32_t id, uint8_t const *table);

--- a/source/build/src/mutex.cpp
+++ b/source/build/src/mutex.cpp
@@ -34,7 +34,7 @@ void mutex_destroy(mutex_t *mutex)
 #elif SDL_MAJOR_VERSION == 1
     if (mutex)
     {
-        SDL_DestroyMutex(mutex);
+        SDL_DestroyMutex(*mutex);
         *mutex = nullptr;
     }
 #endif

--- a/source/build/src/palette.cpp
+++ b/source/build/src/palette.cpp
@@ -359,8 +359,10 @@ void paletteLoadFromDisk(void)
 
     kclose(fil);
 
+#ifdef USE_OPENGL
     for (int i = 0; i < MAXPALOOKUPS; i++)
         palookupfogfactor[i] = 1.f;
+#endif
 }
 
 uint8_t PaletteIndexFullbrights[32];

--- a/source/build/src/sdlayer.cpp
+++ b/source/build/src/sdlayer.cpp
@@ -1197,11 +1197,13 @@ void mouseLockToWindow(char a)
 
 void mouseMoveToCenter(void)
 {
+#if SDL_MAJOR_VERSION != 1
     if (sdl_window)
     {
         g_mouseAbs = { xdim >> 1, ydim >> 1 };
         SDL_WarpMouseInWindow(sdl_window, g_mouseAbs.x, g_mouseAbs.y);
     }
+#endif
 }
 
 //

--- a/source/exhumed/src/exhumed.cpp
+++ b/source/exhumed/src/exhumed.cpp
@@ -3210,6 +3210,7 @@ void DoGameOverScene()
     SetOverscan(BASEPAL);
 }
 
+#ifdef USE_OPENGL
 void FadeOutScreen(int nTile)
 {
     int f = 0;
@@ -3249,6 +3250,7 @@ void FadeInScreen(int nTile)
         videoNextPage();
     }
 }
+#endif
 
 // TODO - missing some values?
 short word_10010[] = {6, 25, 43, 50, 68, 78, 101, 111, 134, 158, 173, 230, 6000};
@@ -3263,9 +3265,11 @@ void DoTitle()
 //  if (videoGetRenderMode() == REND_CLASSIC)
 //     BlackOut();
 
+#ifdef USE_OPENGL
     // for OpenGL, fade from black to the publisher logo
     if (videoGetRenderMode() > REND_CLASSIC)
         FadeInScreen(EXHUMED ? kTileBMGLogo : kTilePIELogo);
+#endif
 
     overwritesprite(0, 0, EXHUMED ? kTileBMGLogo : kTilePIELogo, 0, 2, kPalNormal);
     videoNextPage();
@@ -3279,15 +3283,19 @@ void DoTitle()
 
     if (videoGetRenderMode() == REND_CLASSIC)
         FadeOut(0);
+#ifdef USE_OPENGL
     else
         FadeOutScreen(EXHUMED ? kTileBMGLogo : kTilePIELogo);
+#endif
 
     SetOverscan(BASEPAL);
 
     int nScreenTile = seq_GetSeqPicnum(kSeqScreens, 0, 0);
 
+#ifdef USE_OPENGL
     if (videoGetRenderMode() > REND_CLASSIC)
         FadeInScreen(nScreenTile);
+#endif
 
     overwritesprite(0, 0, nScreenTile, 0, 2, kPalNormal);
     videoNextPage();
@@ -3301,8 +3309,10 @@ void DoTitle()
 
     if (videoGetRenderMode() == REND_CLASSIC)
         FadeOut(0);
+#ifdef USE_OPENGL
     else
         FadeOutScreen(nScreenTile);
+#endif
 
     ClearAllKeys();
 

--- a/source/exhumed/src/light.cpp
+++ b/source/exhumed/src/light.cpp
@@ -22,6 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "view.h"
 #include "cd.h"
 #include "lighting.h"
+#include "baselayer.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/source/exhumed/src/movie.cpp
+++ b/source/exhumed/src/movie.cpp
@@ -285,14 +285,16 @@ void PlayMovie(const char* fileName)
                     bDoFade = DoFadeIn();
                 }
             }
+#ifdef USE_OPENGL
             else
             {
                 if (f >= 0)
                 {
                     fullscreen_tint_gl(0, 0, 0, f);
-                    f -= 8;
+                   f -= 8;
                 }
             }
+#endif
 
             videoNextPage();
 
@@ -312,6 +314,7 @@ void PlayMovie(const char* fileName)
 
     fclose(fp);
 
+#ifdef USE_OPENGL
     // need to do OpenGL fade out here
     f = 0;
 
@@ -328,4 +331,5 @@ void PlayMovie(const char* fileName)
 
         videoNextPage();
     }
+#endif
 }

--- a/source/exhumed/src/movie.cpp
+++ b/source/exhumed/src/movie.cpp
@@ -291,7 +291,7 @@ void PlayMovie(const char* fileName)
                 if (f >= 0)
                 {
                     fullscreen_tint_gl(0, 0, 0, f);
-                   f -= 8;
+                    f -= 8;
                 }
             }
 #endif

--- a/source/exhumed/src/sequence.cpp
+++ b/source/exhumed/src/sequence.cpp
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "view.h"
 #include "init.h"
 #include "light.h"
+#include "baselayer.h"
 #ifndef __WATCOMC__
 #include <cstring>
 #include <cstdio> // for printf


### PR DESCRIPTION
Building with SDL 1.2 and without OpenGL was broken in Exhumed. Some of the fixes are inside Build and could apply to other games.