### PR TITLE
Blood: stop music after loading a game with a map without music

### DIFF
--- a/source/blood/src/loadsave.cpp
+++ b/source/blood/src/loadsave.cpp
@@ -196,7 +196,7 @@ void LoadSave::LoadGame(char *pzFile)
         || demoWasPlayed
         || (gMusicPrevLoadedEpisode != gGameOptions.nEpisode || gMusicPrevLoadedLevel != gGameOptions.nLevel))
     {
-        levelTryPlayMusic(gGameOptions.nEpisode, gGameOptions.nLevel);
+        levelTryPlayMusicOrNothing(gGameOptions.nEpisode, gGameOptions.nLevel);
     }
     gMusicPrevLoadedEpisode = gGameOptions.nEpisode;
     gMusicPrevLoadedLevel = gGameOptions.nLevel;


### PR DESCRIPTION
Related issue: https://github.com/nukeykt/NBlood/issues/277