### PR TITLE
Blood: don't show vsync menu option in non-opengl builds fixes #282

### DIFF
--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -1210,7 +1210,9 @@ void SetupOptionsMenu(void)
     menuOptionsDisplayMode.Add(&itemOptionsDisplayModeRenderer, false);
 #endif
     menuOptionsDisplayMode.Add(&itemOptionsDisplayModeFullscreen, false);
+#ifdef USE_OPENGL
     menuOptionsDisplayMode.Add(&itemOptionsDisplayModeVSync, false);
+#endif
     menuOptionsDisplayMode.Add(&itemOptionsDisplayModeFrameLimit, false);
     menuOptionsDisplayMode.Add(&itemOptionsDisplayModeFPSOffset, false);
     menuOptionsDisplayMode.Add(&itemOptionsDisplayModeApply, false);


### PR DESCRIPTION
Fixes: https://github.com/nukeykt/NBlood/issues/282

There is only OpenGL implementation for v-sync in the game, so just hide this option.

I'm using the same approach as few lines above, the renderer selection is also missing in non-opengl builds.