### PR TITLE
Blood: change fallthrough annotations to fix clang build

### DIFF
--- a/source/blood/src/aiunicult.cpp
+++ b/source/blood/src/aiunicult.cpp
@@ -1980,7 +1980,6 @@ bool genDudePrepare(spritetype* pSprite, int propId) {
 
             pSprite->clipdist = ClipRange((pSprite->xrepeat + pSprite->yrepeat) >> 1, 4, 120);           
             if (propId) break;
-            fallthrough__;
         }
     }
 

--- a/source/blood/src/triggers.cpp
+++ b/source/blood/src/triggers.cpp
@@ -1042,7 +1042,6 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT event)
                             case 4:
                                 for (int i = 0; i < 8; i++) pPlayer->hasKey[i] = false;
                                 if (pXSprite->data2) break;
-                                fallthrough__;
                         }
                         break;
 


### PR DESCRIPTION
Remove some fallthrough annotations so clang does not fatally error:

source/blood/src/aiunicult.cpp:1983:13: error: fallthrough annotation does not
      directly precede switch label

source/blood/src/triggers.cpp:1045:33: error: fallthrough annotation does not
      directly precede switch label