### PR TITLE
Rednukem: fix building with NETCODE_DISABLE

### DIFF
--- a/source/rr/src/game.cpp
+++ b/source/rr/src/game.cpp
@@ -8366,22 +8366,22 @@ MAIN_LOOP_RESTART:
         {
             do
             {
-                //if (g_networkMode != NET_DEDICATED_SERVER)
-                //{
-                //    if (RRRA && g_player[myconnectindex].ps->on_motorcycle)
-                //        P_GetInputMotorcycle(myconnectindex);
-                //    else if (RRRA && g_player[myconnectindex].ps->on_boat)
-                //        P_GetInputBoat(myconnectindex);
-                //    else
-                //        P_GetInput(myconnectindex);
-                //}
-
-                //Bmemcpy(&inputfifo[0][myconnectindex], &localInput, sizeof(input_t));
-
                 if (!frameJustDrawn)
                     break;
 
                 frameJustDrawn = false;
+
+#ifdef NETCODE_DISABLE
+                if (RRRA && g_player[myconnectindex].ps->on_motorcycle)
+                    P_GetInputMotorcycle(myconnectindex);
+                else if (RRRA && g_player[myconnectindex].ps->on_boat)
+                    P_GetInputBoat(myconnectindex);
+                else
+                    P_GetInput(myconnectindex);
+
+                inputfifo[g_player[myconnectindex].movefifoend&(MOVEFIFOSIZ-1)][myconnectindex] = localInput;
+                g_player[myconnectindex].movefifoend++;
+#endif
 
                 do
                 {

--- a/source/rr/src/net.h
+++ b/source/rr/src/net.h
@@ -390,6 +390,13 @@ void    faketimerhandler(void);
 
 #define Net_NotifyNewGame(...) ((void)0)
 
+#define Net_WaitForEverybody(...) ((void)0)
+#define initsynccrc(...) ((void)0)
+#define Net_GetSyncStat(...) ((void)0)
+#define Net_DisplaySyncMsg(...) ((void)0)
+#define Net_ClearFIFO(...) ((void)0)
+#define Net_GetInput(...) ((void)0)
+
 #endif
 
 #endif // netplay_h_


### PR DESCRIPTION
A few Redneck Rampage specific Net_* functions weren't stubbed out, and the ingame input was broken as it was only handled in Net_GetInput. 