### PR TITLE
Blood: Prevent accidental skipping of cinematics

### DIFF
--- a/source/blood/src/credits.cpp
+++ b/source/blood/src/credits.cpp
@@ -249,7 +249,8 @@ void credPlaySmk(const char *_pzSMK, const char *_pzWAV, int nWav)
     ClockTicks nStartTime = totalclock;
 
     ctrlClearAllInput();
-    
+
+    CONSTEXPR kb_scancode escape = 0x1;
     int nFrame = 0;
     do
     {
@@ -257,7 +258,7 @@ void credPlaySmk(const char *_pzSMK, const char *_pzWAV, int nWav)
         if (scale((int)(totalclock-nStartTime), nFrameRate, kTicRate) < nFrame)
             continue;
 
-        if (ctrlCheckAllInput())
+        if (KB_KeyPressed(escape) || (nFrame > nFrameRate<<1 && ctrlCheckAllInput()))
             break;
 
         videoClearScreen(0);

--- a/source/blood/src/credits.cpp
+++ b/source/blood/src/credits.cpp
@@ -250,7 +250,6 @@ void credPlaySmk(const char *_pzSMK, const char *_pzWAV, int nWav)
 
     ctrlClearAllInput();
 
-    CONSTEXPR kb_scancode escape = 0x1;
     int nFrame = 0;
     do
     {
@@ -258,7 +257,7 @@ void credPlaySmk(const char *_pzSMK, const char *_pzWAV, int nWav)
         if (scale((int)(totalclock-nStartTime), nFrameRate, kTicRate) < nFrame)
             continue;
 
-        if (KB_KeyPressed(escape) || (nFrame > nFrameRate<<1 && ctrlCheckAllInput()))
+        if (KB_KeyPressed(sc_Escape) || (nFrame > nFrameRate && ctrlCheckAllInput()))
             break;
 
         videoClearScreen(0);


### PR DESCRIPTION
Cinematics still can be skipped instantly by pressing Escape. But pressing any other button will have effect only after 2 seconds.

In the original game it is only possible to skip the video with the `Escape` key.

Fixes https://github.com/nukeykt/NBlood/issues/285