### PR TITLE
Blood: guard gameplay changes by ifdefs

### DIFF
--- a/source/blood/src/aigarg.cpp
+++ b/source/blood/src/aigarg.cpp
@@ -204,7 +204,11 @@ static void BlastSSeqCallback(int, int nXSprite)
             }
         }
     }
-    if (IsPlayerSprite(pTarget) || !VanillaMode()) // By NoOne: allow to fire missile in non-player targets
+    if (IsPlayerSprite(pTarget)
+#ifdef NOONE_EXTENSIONS
+        || !VanillaMode() // By NoOne: allow to fire missile in non-player targets
+#endif
+       )
     {
         actFireMissile(pSprite, -120, 0, aim.dx, aim.dy, aim.dz, kMissileArcGargoyle);
         actFireMissile(pSprite, 120, 0, aim.dx, aim.dy, aim.dz, kMissileArcGargoyle);

--- a/source/blood/src/aighost.cpp
+++ b/source/blood/src/aighost.cpp
@@ -187,7 +187,11 @@ static void BlastSeqCallback(int, int nXSprite)
             }
         }
     }
-    if (IsPlayerSprite(pTarget) || !VanillaMode()) // By NoOne: allow fire missile in non-player targets if not a demo
+    if (IsPlayerSprite(pTarget)
+#ifdef NOONE_EXTENSIONS
+        || !VanillaMode() // By NoOne: allow fire missile in non-player targets if not a demo
+#endif
+       )
     {
         sfxPlay3DSound(pSprite, 489, 0, 0);
         actFireMissile(pSprite, 0, 0, aim.dx, aim.dy, aim.dz, kMissileEctoSkull);

--- a/source/blood/src/aihound.cpp
+++ b/source/blood/src/aihound.cpp
@@ -77,7 +77,11 @@ static void BiteSeqCallback(int, int nXSprite)
         return;
     }
     spritetype *pTarget = &sprite[pXSprite->target];
-    if (IsPlayerSprite(pTarget) || !VanillaMode()) // allow to hit non-player targets if not a demo
+    if (IsPlayerSprite(pTarget)
+#ifdef NOONE_EXTENSIONS
+        || !VanillaMode() // By NoOne: allow to hit non-player targets if not a demo
+#endif
+       )
         actFireVector(pSprite, 0, 0, dx, dy, pTarget->z-pSprite->z, VECTOR_TYPE_15);
 }
 


### PR DESCRIPTION
Since these behaviors were not part of the original game, I'm not sure if they should be enabled by default even if vanilla mode is off. These are not obvious bugs, but they exist like this to prevent infighting between monsters, I guess.