### PR TITLE
Blood: proper use of the NOONE_EXTENSIONS preprocessor definition

### DIFF
--- a/Common.mak
+++ b/Common.mak
@@ -346,6 +346,7 @@ POLYMER ?= 1
 USE_OPENGL := 1
 LUNATIC := 0
 USE_LUAJIT_2_1 := 0
+NOONE_EXTENSIONS ?= 1
 
 # Library toggles
 HAVE_GTK2 := 1
@@ -865,6 +866,9 @@ ifneq (0,$(USE_OPENGL))
 endif
 ifneq (0,$(POLYMER))
     COMPILERFLAGS += -DPOLYMER
+endif
+ifneq (0,$(NOONE_EXTENSIONS))
+    COMPILERFLAGS += -DNOONE_EXTENSIONS
 endif
 
 

--- a/platform/Windows/nblood.vcxproj
+++ b/platform/Windows/nblood.vcxproj
@@ -117,7 +117,7 @@
       <Optimization>Disabled</Optimization>
       <ExceptionHandling>SyncCThrow</ExceptionHandling>
       <BufferSecurityCheck>false</BufferSecurityCheck>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;RENDERTYPESDL=1;MIXERTYPEWIN=1;SDL_USEFOLDER;SDL_TARGET=2;USE_OPENGL=1;POLYMER=1;STARTUP_WINDOW;USE_LIBVPX;HAVE_VORBIS;HAVE_XMP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;RENDERTYPESDL=1;MIXERTYPEWIN=1;SDL_USEFOLDER;SDL_TARGET=2;USE_OPENGL=1;POLYMER=1;STARTUP_WINDOW;USE_LIBVPX;HAVE_VORBIS;HAVE_XMP;NOONE_EXTENSIONS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/source/blood/src/common_game.h
+++ b/source/blood/src/common_game.h
@@ -93,10 +93,6 @@ void _consoleSysMsg(const char* pMessage, ...);
 // defined by NoOne:
 // -------------------------------
 
-/////////////////////////////////////////////////////////////
-#define NOONE_EXTENSIONS 1
-////////////////////////////////////////////////////////////
-
 #define kMaxPAL 5
 #define kUserPLUStart  15
 


### PR DESCRIPTION
This way Visual Studio can properly colorize the source code.
Also, it is possible to turn it on/off when building, no source code modification is required.