### PR TITLE
Blood: show "game saved" message

### DIFF
--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -2168,6 +2168,7 @@ void SaveGame(CGameMenuItemZEditBitmap *pItem, CGameMenuEvent *event)
     LoadSave::SaveGame(strSaveGameName);
     gQuickSaveSlot = nSlot;
     gGameMenuMgr.Deactivate();
+    viewSetMessage("Game saved");
 }
 
 void QuickSaveGame(void)
@@ -2192,6 +2193,7 @@ void QuickSaveGame(void)
     gSaveGameOptions[gQuickSaveSlot] = gGameOptions;
     UpdateSavedInfo(gQuickSaveSlot);
     gGameMenuMgr.Deactivate();
+    viewSetMessage("Game saved");
 }
 
 void LoadGame(CGameMenuItemZEditBitmap *pItem, CGameMenuEvent *event)


### PR DESCRIPTION
Saving happens so quick, that the user cannot see that anything happened at all or not. The loading screen is not even visible sometimes.