### PR TITLE
Blood: Add User Map menu to episode select

### DIFF
--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -586,7 +586,7 @@ void StartLevel(GAMEOPTIONS *gameOptions)
         if (gEpisodeInfo[gGameOptions.nEpisode].cutALevel == gGameOptions.nLevel
             && gEpisodeInfo[gGameOptions.nEpisode].at8f08)
             gGameOptions.uGameFlags |= 4;
-        if ((gGameOptions.uGameFlags&4) && gDemo.at1 == 0)
+        if ((gGameOptions.uGameFlags&4) && gDemo.at1 == 0 && !Bstrlen(gGameOptions.szUserMap))
             levelPlayIntroScene(gGameOptions.nEpisode);
 
         ///////

--- a/source/blood/src/gamemenu.cpp
+++ b/source/blood/src/gamemenu.cpp
@@ -984,7 +984,10 @@ bool CGameMenuItemChain7F2F0::Event(CGameMenuEvent &event)
     {
     case kMenuEventEnter:
         if (at34 > -1)
+        {
             gGameOptions.nEpisode = at34;
+            Bstrcpy(gGameOptions.szUserMap, "\0");
+        }
         return CGameMenuItemChain::Event(event);
     }
     return CGameMenuItem::Event(event);
@@ -2470,12 +2473,16 @@ void CGameMenuItemZCycle::Draw(void)
     int x = m_nX;
     int y = m_nY;
 
+    bool isUserMapMenuItem = !Bstrcmp("USER MAP", m_pzText) && m_nWidth == 321 && m_pCallback; // shameful hax
+
     if (m_nMenuSelectReturn != -1)
     {
         m_nFocus = m_nMenuSelectReturn;
         if (m_pCallback)
             m_pCallback(this);
         m_nMenuSelectReturn = -1;
+        if (isUserMapMenuItem)
+            gGameMenuMgr.Push(&menuDifficulty, 3);
     }
 
     if (m_pzText)
@@ -2493,7 +2500,7 @@ void CGameMenuItemZCycle::Draw(void)
         default:
             break;
         }
-        gMenuTextMgr.DrawText(m_pzText, m_nFont, x, y, shade, pal, false);
+        gMenuTextMgr.DrawText(m_pzText, m_nFont, x, y, shade, pal, isUserMapMenuItem);
     }
     const char *pzText;
     if (!m_nItems)
@@ -2502,7 +2509,8 @@ void CGameMenuItemZCycle::Draw(void)
         pzText = m_pzStrings[m_nFocus];
     dassert(pzText != NULL);
     gMenuTextMgr.GetFontInfo(m_nFont, pzText, &width, NULL);
-    gMenuTextMgr.DrawText(pzText, m_nFont, m_nX + m_nWidth - 1 - width, y, shade, pal, false);
+    if (!isUserMapMenuItem)
+        gMenuTextMgr.DrawText(pzText, m_nFont, m_nX + m_nWidth - 1 - width, y, shade, pal, false);
     if (bEnable && MOUSEACTIVECONDITIONAL(!gGameMenuMgr.MouseOutsideBounds(&gGameMenuMgr.m_mousepos, x<<16, y<<16, m_nWidth<<16, height<<16)))
     {
         if (MOUSEWATCHPOINTCONDITIONAL(!gGameMenuMgr.MouseOutsideBounds(&gGameMenuMgr.m_prevmousepos, x<<16, y<<16, m_nWidth<<16, height<<16)))

--- a/source/blood/src/gamemenu.h
+++ b/source/blood/src/gamemenu.h
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define M_MOUSETIMEOUT 210
 
 #define kMaxGameMenuItems 128
-#define kMaxGameCycleItems 128
+#define kMaxGameCycleItems 1280
 #define kMaxPicCycleItems 128
 #define kMaxTitleLength 32
 

--- a/source/blood/src/levels.h
+++ b/source/blood/src/levels.h
@@ -57,6 +57,7 @@ struct GAMEOPTIONS {
     int weaponsV10x;
     bool bFriendlyFire;
     bool bKeepKeysOnRespawn;
+    char szUserMap[BMAX_PATH];
 };
 
 #pragma pack(pop)


### PR DESCRIPTION
Currently the users are only able to play custom maps (if they don't have an .ini file) by entering commands into the console. Selecting the difficulty is not possible this way, the previously used difficulty will be used (by default Lightly Broiled). This is not really intuitive for users.

Fixes #202 