### PR TITLE
RedNukem: fix broken kill counter for non-Redneck games.

### DIFF
--- a/source/rr/src/gameexec.cpp
+++ b/source/rr/src/gameexec.cpp
@@ -1851,9 +1851,14 @@ GAMEEXEC_STATIC void VM_Execute(native_t loop)
 
             case CON_ADDKILLS:
                 insptr++;
-                if ((g_spriteExtra[vm.spriteNum] < 1 || g_spriteExtra[vm.spriteNum] == 128)
-                    && A_CheckSpriteFlags(vm.spriteNum, SFLAG_KILLCOUNT))
-                    P_AddKills(pPlayer, *insptr);
+                if (g_gameType & GAMEFLAG_RR)
+                {
+                    // This check does not exist in Duke Nukem.
+                    if ((g_spriteExtra[vm.spriteNum] < 1 || g_spriteExtra[vm.spriteNum] == 128)
+                        && A_CheckSpriteFlags(vm.spriteNum, SFLAG_KILLCOUNT))
+                        P_AddKills(pPlayer, *insptr);
+                }
+                else P_AddKills(pPlayer, *insptr);
                 insptr++;
                 vm.pActor->actorstayput = -1;
                 continue;


### PR DESCRIPTION
Original DN3D code looks like this:

case 88:
	insptr++;
	ps[g_p].actors_killed += *insptr;
	hittype[g_i].actorstayput = -1;
	insptr++;
	break;