### PR TITLE
Blood: Don't play credit logos when joining or starting a multiplayer…

### DIFF
--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -1899,8 +1899,6 @@ RESTART:
             if (!gDemo.at0 && gDemo.at59ef > 0 && gGameOptions.nGameType == 0 && !bNoDemo)
                 gDemo.NextDemo();
             videoSetViewableArea(0,0,xdim-1,ydim-1);
-            if (!bQuickStart)
-                credLogosDos();
             scrSetDac();
         }
         goto RESTART;


### PR DESCRIPTION
… game

When joining/starting a multiplayer game from the game menu (when the game is already running) the credit logos are being played, but it doesn't make any sense to play them in this case. 