### PR TITLE
Fix for duplicate INI files showing in launch screen when sending CMD Params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,8 @@ project.xcworkspace/
 /platform/Windows/*.cfg_orig
 /platform/Windows/*.DEM
 /platform/Windows/*.DEM_
+/eduke32.exe.lastcodeanalysissucceeded
+/mapster32.exe.lastcodeanalysissucceeded
+/nblood.exe.lastcodeanalysissucceeded
+/pcexhumed.exe.lastcodeanalysissucceeded
+/rednukem.exe.lastcodeanalysissucceeded


### PR DESCRIPTION
Fix for duplicate INI files showing in screen when sending CMD Parameter nblood -ini <fileName>.ini and the INI already exists in the Nblood folder. It will keep the Nblood folder file name  in case its not spelled exactly the same in the input CMD -ini for (Linux Case Sensitivity Compatibility)
