### PR TITLE
Blood: Add User Map menu to episode select

### DIFF
--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -594,7 +594,7 @@ void StartLevel(GAMEOPTIONS *gameOptions)
         if (gEpisodeInfo[gGameOptions.nEpisode].cutALevel == gGameOptions.nLevel
             && gEpisodeInfo[gGameOptions.nEpisode].cutsceneASmkPath)
             gGameOptions.uGameFlags |= 4;
-        if ((gGameOptions.uGameFlags&4) && gDemo.at1 == 0)
+        if ((gGameOptions.uGameFlags&4) && gDemo.at1 == 0 && !Bstrlen(gGameOptions.szUserMap))
             levelPlayIntroScene(gGameOptions.nEpisode);
 
         ///////

--- a/source/blood/src/gamemenu.cpp
+++ b/source/blood/src/gamemenu.cpp
@@ -3007,18 +3007,7 @@ bool CGameMenuItemPassword::Event(CGameMenuEvent &event)
     return CGameMenuItem::Event(event);
 }
 
-CGameMenuFileSelect::CGameMenuFileSelect(const char* _pzText, int _nFont, int _x, int _y, int _nWidth, const char* _startdir, const char* _pattern, char* _destination)
-{
-    InitObject(_pzText, _nFont, _x, _y, _nWidth, _startdir, _pattern, _destination);
-}
-
 CGameMenuFileSelect::CGameMenuFileSelect(const char* _pzText, int _nFont, int _x, int _y, int _nWidth, const char* _startdir, const char* _pattern, char* _destination, void(*_onFileSelectedEventHandler)() )
-{
-    InitObject(_pzText, _nFont, _x, _y, _nWidth, _startdir, _pattern, _destination);
-    onFileSelectedEventHandler = _onFileSelectedEventHandler;
-}
-
-void CGameMenuFileSelect::InitObject(const char *_pzText, int _nFont, int _x, int _y, int _nWidth, const char *_startdir, const char *_pattern, char *_destination)
 {
     m_pzText = _pzText;
     m_nFont = _nFont;
@@ -3028,6 +3017,7 @@ void CGameMenuFileSelect::InitObject(const char *_pzText, int _nFont, int _x, in
     startdir = _startdir;
     pattern = _pattern;
     destination = _destination;
+    onFileSelectedEventHandler = _onFileSelectedEventHandler;
 }
 
 static int32_t xdim_from_320_16(int32_t x)

--- a/source/blood/src/gamemenu.cpp
+++ b/source/blood/src/gamemenu.cpp
@@ -3257,8 +3257,17 @@ bool CGameMenuFileSelect::Select(void)
     if (!findhigh[currentList])
         return false;
 
-    if (IsDestinationEndsWithSlash())
-        Bstrcat(destination, findhigh[currentList]->name);
+    char name[MAX_PATH];
+    Bstrcpy(name, findhigh[currentList]->name);
+    if (!Bstrcmp(name, ".."))
+    {
+        SetDestinationToParentDir();
+    }
+    else
+    {
+        RemoveFilenameFromDestination();
+        Bstrcat(destination, name);
+    }
 
     if (currentList == 0)
     {
@@ -3352,14 +3361,51 @@ bool CGameMenuFileSelect::MouseEvent(CGameMenuEvent &event)
     return event.at0 != kMenuEventNone;
 }
 
-bool CGameMenuFileSelect::IsDestinationEndsWithSlash(void)
+void CGameMenuFileSelect::RemoveFilenameFromDestination(void)
 {
+    int lastSlashIndex = -1;
     int i = 0;
-    char c = 0;
-
     while (destination[i] != 0)
-        c = destination[i++];
+    {
+        if (destination[i] == '/')
+            lastSlashIndex = i;
+        i++;
+    }
 
-    return '/' == c;
+    char newDestination[MAX_PATH];
+    for (i = 0; i <= lastSlashIndex; i++)
+        newDestination[i] = destination[i];
+    newDestination[i] = 0;
+
+    Bstrcpy(destination, newDestination);
 }
 
+void CGameMenuFileSelect::SetDestinationToParentDir(void)
+{
+    int lastSlashIndex = -1;
+    int previousSlashIndex = -1;
+    int i = 0;
+    while (destination[i] != 0)
+    {
+        if (destination[i] == '/')
+        {
+            if (lastSlashIndex != -1)
+            {
+                previousSlashIndex = lastSlashIndex;
+                lastSlashIndex = i;
+            }
+            else
+            {
+                lastSlashIndex = i;
+            }
+        }
+        i++;
+    }
+
+    char newDestination[MAX_PATH];
+    for (i = 0; i <= previousSlashIndex; i++)
+        newDestination[i] = destination[i];
+    newDestination[i] = 0;
+
+    Bstrcpy(destination, newDestination);
+}

--- a/source/blood/src/gamemenu.cpp
+++ b/source/blood/src/gamemenu.cpp
@@ -984,7 +984,10 @@ bool CGameMenuItemChain7F2F0::Event(CGameMenuEvent &event)
     {
     case kMenuEventEnter:
         if (at34 > -1)
+        {
             gGameOptions.nEpisode = at34;
+            Bstrcpy(gGameOptions.szUserMap, "\0");
+        }
         return CGameMenuItemChain::Event(event);
     }
     return CGameMenuItem::Event(event);
@@ -3006,6 +3009,17 @@ bool CGameMenuItemPassword::Event(CGameMenuEvent &event)
 
 CGameMenuFileSelect::CGameMenuFileSelect(const char* _pzText, int _nFont, int _x, int _y, int _nWidth, const char* _startdir, const char* _pattern, char* _destination)
 {
+    InitObject(_pzText, _nFont, _x, _y, _nWidth, _startdir, _pattern, _destination);
+}
+
+CGameMenuFileSelect::CGameMenuFileSelect(const char* _pzText, int _nFont, int _x, int _y, int _nWidth, const char* _startdir, const char* _pattern, char* _destination, void(*_onFileSelectedEventHandler)() )
+{
+    InitObject(_pzText, _nFont, _x, _y, _nWidth, _startdir, _pattern, _destination);
+    onFileSelectedEventHandler = _onFileSelectedEventHandler;
+}
+
+void CGameMenuFileSelect::InitObject(const char *_pzText, int _nFont, int _x, int _y, int _nWidth, const char *_startdir, const char *_pattern, char *_destination)
+{
     m_pzText = _pzText;
     m_nFont = _nFont;
     m_nX = _x;
@@ -3182,7 +3196,7 @@ bool CGameMenuFileSelect::Event(CGameMenuEvent &event)
             findhigh[currentList] = findhigh[currentList]->userb;
             break;
         }
-        MovementVefiry();
+        MovementVerify();
         return false;
     case kMenuEventUp:
         if (findhigh[currentList] != NULL)
@@ -3192,7 +3206,7 @@ bool CGameMenuFileSelect::Event(CGameMenuEvent &event)
             else
                 findhigh[currentList] = findhigh[currentList]->userb;
         }
-        MovementVefiry();
+        MovementVerify();
         return false;
     case kMenuEventDown:
         if (findhigh[currentList] != NULL)
@@ -3202,13 +3216,13 @@ bool CGameMenuFileSelect::Event(CGameMenuEvent &event)
             else
                 findhigh[currentList] = findhigh[currentList]->usera;
         }
-        MovementVefiry();
+        MovementVerify();
         return false;
     case kMenuEventLeft:
     case kMenuEventRight:
         if ((currentList ? fnlist.numdirs : fnlist.numfiles) > 0)
             currentList = !currentList;
-        MovementVefiry();
+        MovementVerify();
         return false;
     case kMenuEventScrollUp:
         if (findhigh[currentList] != NULL)
@@ -3219,7 +3233,7 @@ bool CGameMenuFileSelect::Event(CGameMenuEvent &event)
                 nTopDelta[currentList]--;
             }
         }
-        MovementVefiry();
+        MovementVerify();
         return false;
     case kMenuEventScrollDown:
         if (findhigh[currentList] != NULL)
@@ -3230,7 +3244,7 @@ bool CGameMenuFileSelect::Event(CGameMenuEvent &event)
                 nTopDelta[currentList]++;
             }
         }
-        MovementVefiry();
+        MovementVerify();
         return false;
     default:
         break;
@@ -3243,7 +3257,8 @@ bool CGameMenuFileSelect::Select(void)
     if (!findhigh[currentList])
         return false;
 
-    Bstrcat(destination, findhigh[currentList]->name);
+    if (IsDestinationEndsWithSlash())
+        Bstrcat(destination, findhigh[currentList]->name);
 
     if (currentList == 0)
     {
@@ -3253,6 +3268,10 @@ bool CGameMenuFileSelect::Select(void)
         FileSelectInit();
         return false;
     }
+
+    if (onFileSelectedEventHandler)
+        onFileSelectedEventHandler();
+
     return true;
 }
 
@@ -3291,7 +3310,7 @@ void CGameMenuFileSelect::FileSelectInit(void)
     KB_FlushKeyboardQueueScans();
 }
 
-void CGameMenuFileSelect::MovementVefiry(void)
+void CGameMenuFileSelect::MovementVerify(void)
 {
     int height;
     if (!findhigh[currentList])
@@ -3332,3 +3351,15 @@ bool CGameMenuFileSelect::MouseEvent(CGameMenuEvent &event)
         return CGameMenuItem::MouseEvent(event);
     return event.at0 != kMenuEventNone;
 }
+
+bool CGameMenuFileSelect::IsDestinationEndsWithSlash(void)
+{
+    int i = 0;
+    char c = 0;
+
+    while (destination[i] != 0)
+        c = destination[i++];
+
+    return '/' == c;
+}
+

--- a/source/blood/src/gamemenu.cpp
+++ b/source/blood/src/gamemenu.cpp
@@ -3007,7 +3007,7 @@ bool CGameMenuItemPassword::Event(CGameMenuEvent &event)
     return CGameMenuItem::Event(event);
 }
 
-CGameMenuFileSelect::CGameMenuFileSelect(const char* _pzText, int _nFont, int _x, int _y, int _nWidth, const char* _startdir, const char* _pattern, char* _destination, void(*_onFileSelectedEventHandler)() )
+CGameMenuFileSelect::CGameMenuFileSelect(const char* _pzText, int _nFont, int _x, int _y, int _nWidth, const char* _startdir, const char* _pattern, char* _destination, void(*_onFileSelectedEventHandler)(), const char _doPop)
 {
     m_pzText = _pzText;
     m_nFont = _nFont;
@@ -3018,6 +3018,7 @@ CGameMenuFileSelect::CGameMenuFileSelect(const char* _pzText, int _nFont, int _x
     pattern = _pattern;
     destination = _destination;
     onFileSelectedEventHandler = _onFileSelectedEventHandler;
+    doPop = _doPop;
 }
 
 static int32_t xdim_from_320_16(int32_t x)
@@ -3270,6 +3271,9 @@ bool CGameMenuFileSelect::Select(void)
 
     if (onFileSelectedEventHandler)
         onFileSelectedEventHandler();
+
+    if (!doPop)
+        return false;
 
     return true;
 }

--- a/source/blood/src/gamemenu.h
+++ b/source/blood/src/gamemenu.h
@@ -447,7 +447,8 @@ private:
     void FileSelectInit(void);
     void MovementVerify(void);
     void InitObject(const char *_pzText, int _nFont, int _x, int _y, int _nWidth, const char *_startdir, const char *_pattern, char *_destination);
-    bool IsDestinationEndsWithSlash(void);
+    void RemoveFilenameFromDestination(void);
+    void SetDestinationToParentDir(void);
 public:
     CGameMenuFileSelect(const char *_pzText, int _nFont, int _x, int _y, int _nWidth, const char *_startdir, const char *_pattern, char *_destination);
     CGameMenuFileSelect(const char *_pzText, int _nFont, int _x, int _y, int _nWidth, const char *_startdir, const char *_pattern, char *_destination, void(*)());

--- a/source/blood/src/gamemenu.h
+++ b/source/blood/src/gamemenu.h
@@ -438,15 +438,19 @@ private:
     const char *startdir;
     const char *pattern;
     char *destination;
+    void (*onFileSelectedEventHandler)();
     BUILDVFS_FIND_REC *findhigh[2];
     int32_t nTopDelta[2];
     fnlist_t fnlist;
     int32_t currentList;
     bool Select(void);
     void FileSelectInit(void);
-    void MovementVefiry(void);
+    void MovementVerify(void);
+    void InitObject(const char *_pzText, int _nFont, int _x, int _y, int _nWidth, const char *_startdir, const char *_pattern, char *_destination);
+    bool IsDestinationEndsWithSlash(void);
 public:
     CGameMenuFileSelect(const char *_pzText, int _nFont, int _x, int _y, int _nWidth, const char *_startdir, const char *_pattern, char *_destination);
+    CGameMenuFileSelect(const char *_pzText, int _nFont, int _x, int _y, int _nWidth, const char *_startdir, const char *_pattern, char *_destination, void(*)());
     virtual void Draw(void);
     virtual bool Event(CGameMenuEvent&);
     virtual bool MouseEvent(CGameMenuEvent &);

--- a/source/blood/src/gamemenu.h
+++ b/source/blood/src/gamemenu.h
@@ -439,6 +439,7 @@ private:
     const char *pattern;
     char *destination;
     void (*onFileSelectedEventHandler)();
+    char doPop;
     BUILDVFS_FIND_REC *findhigh[2];
     int32_t nTopDelta[2];
     fnlist_t fnlist;
@@ -449,7 +450,7 @@ private:
     void RemoveFilenameFromDestination(void);
     void SetDestinationToParentDir(void);
 public:
-    CGameMenuFileSelect(const char *_pzText, int _nFont, int _x, int _y, int _nWidth, const char *_startdir, const char *_pattern, char *_destination, void(*)() = nullptr);
+    CGameMenuFileSelect(const char *_pzText, int _nFont, int _x, int _y, int _nWidth, const char *_startdir, const char *_pattern, char *_destination, void(*)() = nullptr, const char doPop = 1);
     virtual void Draw(void);
     virtual bool Event(CGameMenuEvent&);
     virtual bool MouseEvent(CGameMenuEvent &);

--- a/source/blood/src/gamemenu.h
+++ b/source/blood/src/gamemenu.h
@@ -446,12 +446,10 @@ private:
     bool Select(void);
     void FileSelectInit(void);
     void MovementVerify(void);
-    void InitObject(const char *_pzText, int _nFont, int _x, int _y, int _nWidth, const char *_startdir, const char *_pattern, char *_destination);
     void RemoveFilenameFromDestination(void);
     void SetDestinationToParentDir(void);
 public:
-    CGameMenuFileSelect(const char *_pzText, int _nFont, int _x, int _y, int _nWidth, const char *_startdir, const char *_pattern, char *_destination);
-    CGameMenuFileSelect(const char *_pzText, int _nFont, int _x, int _y, int _nWidth, const char *_startdir, const char *_pattern, char *_destination, void(*)());
+    CGameMenuFileSelect(const char *_pzText, int _nFont, int _x, int _y, int _nWidth, const char *_startdir, const char *_pattern, char *_destination, void(*)() = nullptr);
     virtual void Draw(void);
     virtual bool Event(CGameMenuEvent&);
     virtual bool MouseEvent(CGameMenuEvent &);

--- a/source/blood/src/levels.h
+++ b/source/blood/src/levels.h
@@ -57,6 +57,7 @@ struct GAMEOPTIONS {
     int weaponsV10x;
     bool bFriendlyFire;
     bool bKeepKeysOnRespawn;
+    char szUserMap[BMAX_PATH];
 };
 
 #pragma pack(pop)

--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -234,7 +234,7 @@ CGameMenuItemChain7F2F0 itemEpisodes[kMaxEpisodes-1];
 CGameMenu menuUserMap;
 CGameMenuItemChain itemUserMap("USER MAP", 1, 0, 60, 320, 1, &menuUserMap, 0, NULL, 0);
 CGameMenuItemTitle itemUserMapTitle("USER MAP", 1, 160, 20, 2038);
-CGameMenuFileSelect itemUserMapList("", 3, 0, 0, 0, "./", "*.map", gGameOptions.szUserMap, ShowDifficulties);
+CGameMenuFileSelect itemUserMapList("", 3, 0, 0, 0, "./", "*.map", gGameOptions.szUserMap, ShowDifficulties, 0);
 
 CGameMenuItemTitle itemDifficultyTitle("DIFFICULTY", 1, 160, 20, 2038);
 CGameMenuItemChain itemDifficulty1("STILL KICKING", 1, 0, 60, 320, 1, NULL, -1, SetDifficultyAndStart, 0);
@@ -1573,10 +1573,6 @@ extern bool gStartNewGame;
 
 void ShowDifficulties()
 {
-    gGameMenuMgr.Push(&menuDifficulty, 3);
-
-    // Need to push twice because parent menu item will do
-    // gGameMenuMgr.Pop() once after selecting the user map
     gGameMenuMgr.Push(&menuDifficulty, 3);
 }
 

--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -43,6 +43,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 void SaveGame(CGameMenuItemZEditBitmap *, CGameMenuEvent *);
 
 void SaveGameProcess(CGameMenuItemChain *);
+void ShowDifficulties();
 void SetDifficultyAndStart(CGameMenuItemChain *);
 void SetDetail(CGameMenuItemSlider *);
 void SetGamma(CGameMenuItemSlider *);
@@ -228,7 +229,12 @@ CGameMenuItemChain itemMainSave7("END GAME", 1, 0, 135, 320, 1, &menuRestart, -1
 CGameMenuItemChain itemMainSave8("QUIT", 1, 0, 150, 320, 1, &menuQuit, -1, NULL, 0);
 
 CGameMenuItemTitle itemEpisodesTitle("EPISODES", 1, 160, 20, 2038);
-CGameMenuItemChain7F2F0 itemEpisodes[6];
+CGameMenuItemChain7F2F0 itemEpisodes[kMaxEpisodes-1];
+
+CGameMenu menuUserMap;
+CGameMenuItemChain itemUserMap("USER MAP", 1, 0, 60, 320, 1, &menuUserMap, 0, NULL, 0);
+CGameMenuItemTitle itemUserMapTitle("USER MAP", 1, 160, 20, 2038);
+CGameMenuFileSelect itemUserMapList("", 3, 0, 0, 0, "./", "*.map", gGameOptions.szUserMap, ShowDifficulties);
 
 CGameMenuItemTitle itemDifficultyTitle("DIFFICULTY", 1, 160, 20, 2038);
 CGameMenuItemChain itemDifficulty1("STILL KICKING", 1, 0, 60, 320, 1, NULL, -1, SetDifficultyAndStart, 0);
@@ -830,7 +836,7 @@ void SetupEpisodeMenu(void)
     int height;
     gMenuTextMgr.GetFontInfo(1, NULL, NULL, &height);
     int j = 0;
-    for (int i = 0; i < 6; i++)
+    for (int i = 0; i < kMaxEpisodes-1; i++)
     {
         EPISODEINFO *pEpisode = &gEpisodeInfo[i];
         if (!pEpisode->bloodbath || gGameOptions.nGameType != 0)
@@ -867,7 +873,13 @@ void SetupEpisodeMenu(void)
             j++;
         }
     }
+
+    itemUserMap.m_nY = 55+(height+8)*(gEpisodeCount-1);
+    menuEpisode.Add(&itemUserMap, false);
     menuEpisode.Add(&itemBloodQAV, false);
+
+    menuUserMap.Add(&itemUserMapTitle, true);
+    menuUserMap.Add(&itemUserMapList, true);
 }
 
 void SetupMainMenu(void)
@@ -1559,6 +1571,15 @@ void SetWeaponSwitch(CGameMenuItemZCycle *pItem)
 
 extern bool gStartNewGame;
 
+void ShowDifficulties()
+{
+    gGameMenuMgr.Push(&menuDifficulty, 3);
+
+    // Need to push twice because parent menu item will do
+    // gGameMenuMgr.Pop() once after selecting the user map
+    gGameMenuMgr.Push(&menuDifficulty, 3);
+}
+
 void SetDifficultyAndStart(CGameMenuItemChain *pItem)
 {
     gGameOptions.nDifficulty = pItem->at30;
@@ -1568,6 +1589,13 @@ void SetDifficultyAndStart(CGameMenuItemChain *pItem)
         gDemo.StopPlayback();
     gStartNewGame = true;
     gCheatMgr.sub_5BCF4();
+    if (Bstrlen(gGameOptions.szUserMap))
+    {
+        levelAddUserMap(gGameOptions.szUserMap);
+        levelSetupOptions(gGameOptions.nEpisode, gGameOptions.nLevel);
+        StartLevel(&gGameOptions);
+        viewResizeView(gViewSize);
+    }
     gGameMenuMgr.Deactivate();
 }
 


### PR DESCRIPTION
Currently the users are only able to play custom maps (if they don't have an .ini file) by entering commands into the console. Selecting the difficulty is not possible this way, the previously used difficulty will be used (by default Lightly Broiled). This is not really intuitive for users.

Fixes #202