### PR TITLE
Blood: Add rotate token for models too in defs (similar to voxels)

### DIFF
--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -2468,13 +2468,17 @@ void viewProcessSprites(int32_t cX, int32_t cY, int32_t cZ, int32_t cA, int32_t 
         if ((pTSprite->cstat&48) != 48 && usemodels && !(spriteext[nSprite].flags&SPREXT_NOTMD))
         {
             int nAnimTile = pTSprite->picnum + animateoffs_replace(pTSprite->picnum, 32768+pTSprite->owner);
+            auto modelid = tile2model[Ptile2tile(nAnimTile, pTSprite->pal)].modelid;
 
-            if (usemodels && tile2model[Ptile2tile(nAnimTile, pTSprite->pal)].modelid >= 0 &&
+            if (usemodels && modelid >= 0 &&
                 tile2model[Ptile2tile(nAnimTile, pTSprite->pal)].framenum >= 0)
             {
                 pTSprite->yoffset += picanm[nAnimTile].yofs;
                 pTSprite->xoffset += picanm[nAnimTile].xofs;
             }
+
+            if (modelid != -1 && (modelrotate[modelid>>3]&pow2char[modelid&7]) != 0)
+                pTSprite->ang = (pTSprite->ang+((int)totalclock<<3))&2047;
         }
 
         sectortype *pSector = &sector[pTSprite->sectnum];

--- a/source/build/include/build.h
+++ b/source/build/include/build.h
@@ -1537,6 +1537,7 @@ typedef struct
 
 EXTERN int32_t mdinited;
 EXTERN tile2model_t tile2model[MAXTILES+EXTRATILES];
+EXTERN int8_t modelrotate[(MAXTILES+EXTRATILES+7)>>3];
 
 static FORCE_INLINE int32_t md_tilehasmodel(int32_t const tilenume, int32_t const pal)
 {

--- a/source/build/src/defs.cpp
+++ b/source/build/src/defs.cpp
@@ -1440,6 +1440,7 @@ static int32_t defsparser(scriptfile *script)
                 { "normal",   T_NORMAL   },
                 { "hud",      T_HUD      },
                 { "flags",    T_FLAGS    },
+                { "rotate",   T_ROTATE   },
             };
 
             Bmemset(usedframebitmap, 0, sizeof(usedframebitmap));
@@ -1844,6 +1845,13 @@ static int32_t defsparser(scriptfile *script)
 
                         model_ok &= happy;
                     }
+#endif
+                }
+                break;
+                case T_ROTATE:
+                {
+#ifdef USE_OPENGL
+                    modelrotate[lastmodelid>>3] |= pow2char[lastmodelid&7];
 #endif
                 }
                 break;

--- a/source/build/src/engine.cpp
+++ b/source/build/src/engine.cpp
@@ -8304,6 +8304,9 @@ int32_t engineInit(void)
         tiletovox[i] = -1;
     clearbuf(voxscale, sizeof(voxscale)>>2, 65536);
     clearbufbyte(voxrotate, sizeof(voxrotate), 0);
+#ifdef USE_OPENGL
+    clearbufbyte(modelrotate, sizeof(modelrotate), 0);
+#endif
 
     paletteloaded = 0;
 

--- a/source/build/src/mdsprite.cpp
+++ b/source/build/src/mdsprite.cpp
@@ -549,6 +549,8 @@ int32_t md_undefinetile(int32_t tile)
     if (!mdinited) return 0;
     if ((unsigned)tile >= (unsigned)MAXTILES) return -1;
 
+    auto modelid = tile2model[tile].modelid;
+    modelrotate[modelid>>3] &= ~pow2char[modelid&7];
     tile2model[tile].modelid = -1;
     tile2model[tile].nexttile = -1;
     DO_FREE_AND_NULL(tile2model[tile].hudmem[0]);


### PR DESCRIPTION
Voxels already had this feature, now models have it too. Keys now can rotate in the BloodXHD pack, need to add `rotate` to their defs.