### PR TITLE
continue searching for paths even after one was found

### DIFF
--- a/source/blood/src/common.cpp
+++ b/source/blood/src/common.cpp
@@ -350,27 +350,24 @@ void G_AddSearchPaths(void)
 #elif defined (_WIN32)
     char buf[BMAX_PATH] = {0};
     DWORD bufsize;
-    bool found = false;
 
     // Blood: One Unit Whole Blood - Steam
     bufsize = sizeof(buf);
-    if (!found && Paths_ReadRegistryValue(R"(SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 299030)", "InstallLocation", buf, &bufsize))
+    if (Paths_ReadRegistryValue(R"(SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 299030)", "InstallLocation", buf, &bufsize))
     {
         addsearchpath(buf);
-        found = true;
     }
 
     // Blood: One Unit Whole Blood - GOG.com
     bufsize = sizeof(buf);
-    if (!found && Paths_ReadRegistryValue("SOFTWARE\\GOG.com\\GOGONEUNITONEBLOOD", "PATH", buf, &bufsize))
+    if (Paths_ReadRegistryValue("SOFTWARE\\GOG.com\\GOGONEUNITONEBLOOD", "PATH", buf, &bufsize))
     {
         addsearchpath(buf);
-        found = true;
     }
 
     // Blood: Fresh Supply - Steam
     bufsize = sizeof(buf);
-    if (!found && Paths_ReadRegistryValue(R"(SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 1010750)", "InstallLocation", buf, &bufsize))
+    if (Paths_ReadRegistryValue(R"(SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 1010750)", "InstallLocation", buf, &bufsize))
     {
         char * const suffix = buf + bufsize - 1;
         DWORD const remaining = sizeof(buf) - bufsize;
@@ -378,12 +375,11 @@ void G_AddSearchPaths(void)
         addsearchpath(buf);
         strncpy(suffix, "/addons/Cryptic Passage", remaining);
         addsearchpath(buf);
-        found = true;
     }
 
     // Blood: Fresh Supply - GOG.com
     bufsize = sizeof(buf);
-    if (!found && Paths_ReadRegistryValue(R"(SOFTWARE\GOG.com\Games\1374469660)", "path", buf, &bufsize))
+    if (Paths_ReadRegistryValue(R"(SOFTWARE\GOG.com\Games\1374469660)", "path", buf, &bufsize))
     {
         char * const suffix = buf + bufsize - 1;
         DWORD const remaining = sizeof(buf) - bufsize;
@@ -391,7 +387,6 @@ void G_AddSearchPaths(void)
         addsearchpath(buf);
         strncpy(suffix, "/addons/Cryptic Passage", remaining);
         addsearchpath(buf);
-        found = true;
     }
 #endif
 #endif


### PR DESCRIPTION
This is another PR to address #352 but instead of changing the behavior of the `-j` flag the logic to find game data has been changed to continue searching even after one was found.