### PR TITLE
Exhumed: fix USE_OPENGL=0 build

### DIFF
--- a/source/exhumed/src/engine.h
+++ b/source/exhumed/src/engine.h
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "pragmas.h"
 #include "typedefs.h"
 #include "trigdat.h"
+#include "osd.h"
 
 #define kMaxTiles	6144
 #define kMaxSprites 4096


### PR DESCRIPTION
Error when building with `USE_OPENGL=0`:
```
source/exhumed/src/gun.cpp:309:67: error: ‘OSD_Printf’ was not declared in this scope
         OSD_Printf("%s %d: overflow\n", EDUKE32_FUNCTION, __LINE__);
                                                                   ^
Failed building obj/exhumed/gun.o from source/exhumed/src/gun.cpp!
GNUmakefile:1495: recipe for target 'obj/exhumed/gun.o' failed
make: *** [obj/exhumed/gun.o] Error 1
```

Maybe the include is not placed into the perfect place, but it solves the issue. I'm not familiar with the codebase.
Fixes #395 
