### PR TITLE
PCExhumed: Add Caps lock as the auto run toggle key

### DIFF
--- a/source/exhumed/src/config.cpp
+++ b/source/exhumed/src/config.cpp
@@ -80,6 +80,7 @@ const char gamefunctions[kMaxGameFunctions][kMaxGameFuncLen] =
     "Toggle_Crosshair",
     "Next_Weapon",
     "Previous_Weapon",
+    "AutoRun",
 };
 
 const char keydefaults[kMaxGameFunctions * 2][kMaxGameFuncLen] =
@@ -127,6 +128,7 @@ const char keydefaults[kMaxGameFunctions * 2][kMaxGameFuncLen] =
     "I", "",
     "'", "",
     ";", "",
+    "CapLck", "",
 };
 
 const char oldkeydefaults[kMaxGameFunctions * 2][kMaxGameFuncLen] =
@@ -174,6 +176,7 @@ const char oldkeydefaults[kMaxGameFunctions * 2][kMaxGameFuncLen] =
     "I", "",
     "'", "",
     ";", "",
+    "CapLck", "",
 };
 
 static const char *mousedefaults[MAXMOUSEBUTTONS] =
@@ -289,6 +292,7 @@ void SetupGameButtons()
     CONTROL_DefineFlag(gamefunc_Toggle_Crosshair,       kFalse);
     CONTROL_DefineFlag(gamefunc_Next_Weapon,            kFalse);
     CONTROL_DefineFlag(gamefunc_Previous_Weapon,        kFalse);
+    CONTROL_DefineFlag(gamefunc_AutoRun,                kFalse);
 }
 
 hashtable_t h_gamefuncs    = { kMaxGameFunctions<<1, NULL };

--- a/source/exhumed/src/config.h
+++ b/source/exhumed/src/config.h
@@ -91,6 +91,7 @@ enum {
 	gamefunc_Toggle_Crosshair,
     gamefunc_Next_Weapon,
     gamefunc_Previous_Weapon,
+	gamefunc_AutoRun,
 	kMaxGameFunctions
 };
 

--- a/source/exhumed/src/player.cpp
+++ b/source/exhumed/src/player.cpp
@@ -212,6 +212,16 @@ void PlayerInterruptKeys()
         bLookCentre = true;
     }
 
+    if (BUTTON(gamefunc_AutoRun))
+    {
+        CONTROL_ClearButton(gamefunc_AutoRun);
+        auto_run = !auto_run;
+        if (auto_run)
+            StatusMessage(150, "Auto run ON");
+        else
+            StatusMessage(150, "Auto run OFF");
+    }
+
     if (MouseDeadZone)
     {
         if (info.mousey > 0)


### PR DESCRIPTION
I noticed that auto run could only be changed via the cvar, so I added the Caps Lock key for it similar to other Build games.