### PR TITLE
WW2GI: Fixed morale on large status bar

### DIFF
--- a/source/rr/src/sbar.cpp
+++ b/source/rr/src/sbar.cpp
@@ -1260,7 +1260,7 @@ void G_DrawStatusBar(int32_t snum)
         if (u != -1)
             G_PatchStatusBar(52, SBY+17, 75, SBY+17+11);
 
-        G_DrawDigiNum(64, SBY+17, p->inv_amount[GET_SHIELD], -16, 10+16);
+        G_DrawDigiNum(64, SBY+17, sbar.inv_amount[GET_SHIELD], -16, 10+16);
     }
 
     if (u&1024)


### PR DESCRIPTION
This change will use the the value of sbar.inv_amount[GET_SHIELD] when drawing armor/morale amount on the large status bar. This variable is already used by the mini-statusbar (ss == 4) when drawing the armor/morale amount.