### PR TITLE
PCExhumed: Don't try to open the CD track every frame

### DIFF
--- a/source/exhumed/src/cd.cpp
+++ b/source/exhumed/src/cd.cpp
@@ -74,6 +74,7 @@ bool playCDtrack(int nTrack, bool bLoop)
     }
   
     if (hFile < 0) {
+        OSD_Printf("Error opening music track %02d", nTrack);
         return false;
     }
 

--- a/source/exhumed/src/exhumed.cpp
+++ b/source/exhumed/src/exhumed.cpp
@@ -2378,7 +2378,7 @@ STARTGAME1:
         FadeOut(0);
     }
 STARTGAME2:
-
+    bool cdSuccess;
     bCamera = kFalse;
     ClearCinemaSeen();
     PlayerCount = 0;
@@ -2525,6 +2525,7 @@ LOOP3:
     tclocks2 = totalclock;
     CONTROL_BindsEnabled = 1;
 
+    cdSuccess = true;
     // Game Loop
     while (1)
     {
@@ -2538,14 +2539,14 @@ LOOP3:
         OSD_DispatchQueued();
 
         // Section B
-        if (!CDplaying() && !nFreeze && !nNetPlayerCount)
+        if (cdSuccess && !CDplaying() && !nFreeze && !nNetPlayerCount)
         {
             int nTrack = levelnum;
             if (nTrack != 0) {
                 nTrack--;
             }
 
-            playCDtrack((nTrack % 8) + 11, true);
+            cdSuccess = playCDtrack((nTrack % 8) + 11, true);
         }
 
 // TODO		CONTROL_GetButtonInput();


### PR DESCRIPTION
If the CD track file didn't exist the game loop kept calling playCDtrack every iteration without checking the return value. Now it only tries to play the track once if the file doesn't exist. 