### PR TITLE
PCExhumed: added waloff checks before tileLoad calls

### DIFF
--- a/source/exhumed/src/exhumed.cpp
+++ b/source/exhumed/src/exhumed.cpp
@@ -1541,6 +1541,7 @@ void DoRedAlert(int nVal)
     }
 }
 
+/*
 void LockEnergyTiles()
 {
     // old	loadtilelockmode = 1;
@@ -1549,12 +1550,13 @@ void LockEnergyTiles()
     tileLoad(kEnergy2);
     // old  loadtilelockmode = 0;
 }
+*/
 
 void DrawClock()
 {
     int ebp = 49;
 
-    tileLoad(kTile3603);
+    if (!waloff[kTile3603]) tileLoad(kTile3603);
 
     memset((void*)waloff[kTile3603], -1, 4096);
 
@@ -1669,7 +1671,7 @@ static void GameDisplay(void)
 
     if (levelnum == kMap20)
     {
-        LockEnergyTiles();
+        //LockEnergyTiles();
         DoEnergyTile();
         DrawClock();
     }
@@ -3087,7 +3089,7 @@ void CopyTileToBitmap(short nSrcTile,  short nDestTile, int xPos, int yPos)
     uint8_t *pDest = (uint8_t*)waloff[nDestTile] + nOffs + yPos;
     uint8_t *pDestB = pDest;
 
-    tileLoad(nSrcTile);
+    if (!waloff[nSrcTile]) tileLoad(nSrcTile);
 
     int destYSize = tilesiz[nDestTile].y;
     int srcYSize = tilesiz[nSrcTile].y;

--- a/source/exhumed/src/menu.cpp
+++ b/source/exhumed/src/menu.cpp
@@ -146,8 +146,8 @@ void InitEnergyTile()
 
 void DoEnergyTile()
 {
-    tileLoad(kEnergy1);
-    tileLoad(kEnergy2);
+    if (!waloff[kEnergy1]) tileLoad(kEnergy1);
+    if (!waloff[kEnergy2]) tileLoad(kEnergy2);
 
     nButtonColor += nButtonColor < 0 ? 8 : 0;
 
@@ -469,7 +469,7 @@ void menu_DoPlasma()
         r_ebx += 2;
     }
 
-    tileLoad(nLogoTile);
+    if (!waloff[nLogoTile]) tileLoad(nLogoTile);
 
     for (int j = 0; j < 5; j++)
     {

--- a/source/exhumed/src/movie.cpp
+++ b/source/exhumed/src/movie.cpp
@@ -242,7 +242,7 @@ void PlayMovie(const char* fileName)
     uint8_t* pMovieFile = NULL;
     int fileSize = 0;
 
-    tileLoad(kMovieTile);
+    if (!waloff[kMovieTile]) tileLoad(kMovieTile);
     CurFrame = (uint8_t*)waloff[kMovieTile];
 
     // try for a loose BOOK.MOV first

--- a/source/exhumed/src/player.cpp
+++ b/source/exhumed/src/player.cpp
@@ -690,9 +690,11 @@ void InitPlayerInventory(short nPlayer)
 
     nPlayerScore[nPlayer] = 0;
 
-    tileLoad(kTile3571 + nPlayer);
+    short nTile = kTile3571 + nPlayer;
 
-    nPlayerColor[nPlayer] = *(uint8_t*)(waloff[nPlayer + kTile3571] + tilesiz[nPlayer + kTile3571].x * tilesiz[nPlayer + kTile3571].y / 2);
+    if (!waloff[nTile]) tileLoad(nTile);
+
+    nPlayerColor[nPlayer] = *(uint8_t*)(waloff[nTile] + tilesiz[nTile].x * tilesiz[nTile].y / 2);
 }
 
 short GetPlayerFromSprite(short nSprite)

--- a/source/exhumed/src/ramses.cpp
+++ b/source/exhumed/src/ramses.cpp
@@ -78,7 +78,7 @@ void InitSpiritHead()
     nSpiritRepeatX = sprite[nSpiritSprite].xrepeat;
     nSpiritRepeatY = sprite[nSpiritSprite].yrepeat;
 
-    tileLoad(kTileRamsesNormal); // Ramses Normal Head
+    if (!waloff[kTileRamsesNormal]) tileLoad(kTileRamsesNormal); // Ramses Normal Head
 
     for (int i = 0; i < kMaxSprites; i++)
     {
@@ -200,7 +200,7 @@ void DimSector(short nSector)
 
 void CopyHeadToWorkTile(short nTile)
 {
-    tileLoad(nTile);
+    if (!waloff[nTile]) tileLoad(nTile);
 
     uint8_t* pSrc = (uint8_t*)waloff[nTile];
     uint8_t* pDest = (uint8_t*)&worktile[212 * 49 + 53];
@@ -518,7 +518,7 @@ int DoSpiritHead()
 
         ebx += word_964EA;
 
-        tileLoad(ebx);
+        if (!waloff[ebx]) tileLoad(ebx);
 
         uint8_t* pDest = (uint8_t*)&worktile[10441];
         uint8_t* pSrc = (uint8_t*)waloff[ebx];
@@ -544,13 +544,15 @@ int DoSpiritHead()
 
         if (nMouthTile)
         {
-            tileLoad(nMouthTile + 598);
+            short nTile = nMouthTile + 598;
 
-            short nTileSizeX = tilesiz[nMouthTile + 598].x;
-            short nTileSizeY = tilesiz[nMouthTile + 598].y;
+            if (!waloff[nTile]) tileLoad(nTile);
+
+            short nTileSizeX = tilesiz[nTile].x;
+            short nTileSizeY = tilesiz[nTile].y;
 
             uint8_t* pDest = (uint8_t*)&worktile[212 * (kSpiritY - nTileSizeX / 2)] + (159 - nTileSizeY);
-            uint8_t* pSrc = (uint8_t*)waloff[nMouthTile + 598];
+            uint8_t* pSrc = (uint8_t*)waloff[nTile];
 
             while (nTileSizeX > 0)
             {


### PR DESCRIPTION
The game kept hitting the texture cache, especially in the menus, so I added the missing waloff checks where necessary. I left DoLastLevelCinema and DoStatic as these do in-place animations on the Lobotomy laptop tile, so it needs to be cleared.