### PR TITLE
NBlood: Fix the NETCODE_DISABLE build

### DIFF
--- a/source/blood/src/network.cpp
+++ b/source/blood/src/network.cpp
@@ -1151,6 +1151,8 @@ void netInitialize(bool bConsole)
     }
     gNetENetInit = true;
     gGameOptions.nGameType = 2;
+#else
+    netResetToSinglePlayer();
 #endif
 }
 


### PR DESCRIPTION
If NETCODE_DISABLE was defined netResetToSinglePlayer never got called, which left the player number uninitialized. 