### PR TITLE
Fix spray can weapon switching

### DIFF
--- a/source/blood/src/weapon.cpp
+++ b/source/blood/src/weapon.cpp
@@ -635,7 +635,20 @@ void WeaponLower(PLAYER *pPlayer)
         switch (prevState)
         {
         case 1:
-            StartQAV(pPlayer, 7, -1, 0);
+            if (VanillaMode())
+            {
+                StartQAV(pPlayer, 7, -1, 0);
+            }
+            else
+            {
+                if (pPlayer->input.newWeapon == 6)
+                {
+                    pPlayer->weaponState = 2;
+                    StartQAV(pPlayer, 11, -1, 0);
+                    WeaponRaise(pPlayer);
+                    return;
+                }
+            }
             break;
         case 2:
             pPlayer->weaponState = 1;

--- a/source/blood/src/weapon.cpp
+++ b/source/blood/src/weapon.cpp
@@ -644,8 +644,23 @@ void WeaponLower(PLAYER *pPlayer)
         case 4:
             pPlayer->weaponState = 1;
             StartQAV(pPlayer, 11, -1, 0);
-            pPlayer->input.newWeapon = 0;
-            WeaponLower(pPlayer);
+            if (VanillaMode())
+            {
+                pPlayer->input.newWeapon = 0;
+            }
+            else
+            {
+                if (pPlayer->input.newWeapon == 6)
+                {
+                    pPlayer->weaponState = 2;
+                    StartQAV(pPlayer, 11, -1, 0);
+                    return;
+                }
+                else
+                {
+                    WeaponLower(pPlayer);
+                }
+            }
             break;
         case 3:
             if (pPlayer->input.newWeapon == 6)

--- a/source/blood/src/weapon.cpp
+++ b/source/blood/src/weapon.cpp
@@ -688,7 +688,20 @@ void WeaponLower(PLAYER *pPlayer)
         switch (prevState)
         {
         case 1:
-            StartQAV(pPlayer, 7, -1, 0);
+            if (VanillaMode())
+            {
+                StartQAV(pPlayer, 7, -1, 0);
+            }
+            else
+            {
+                if (pPlayer->input.newWeapon == 7)
+                {
+                    pPlayer->weaponState = 2;
+                    StartQAV(pPlayer, 17, -1, 0);
+                    WeaponRaise(pPlayer);
+                    return;
+                }
+            }
             break;
         case 2:
             WeaponRaise(pPlayer);

--- a/source/blood/src/weapon.cpp
+++ b/source/blood/src/weapon.cpp
@@ -660,6 +660,7 @@ void WeaponLower(PLAYER *pPlayer)
             if (VanillaMode())
             {
                 pPlayer->input.newWeapon = 0;
+                WeaponLower(pPlayer);
             }
             else
             {


### PR DESCRIPTION
This is a bug in the original too.

Fixes the bug when cannot switch from spray can to anything else. While you are firing with spray can primary and meanwhile pressing another weapon's button, it will switch to nothing and nothing will be equipped. Need to select another weapon again to have a weapon in hand.

Also fixes the cases when Caleb puts away the lighter and raises it again (switching from TNT to spray or the other way while firing/throwing).

This PR does NOT fixes the case though when the player is using the next weapon and/or the previous weapon button. The code is too much of a mess (for me) to figure out what is happening. Maybe another time.