### PR TITLE
Move SDL_Quit() call to engineUnInit() to prevent segfault on KMSDRM and Wayland SDL2 backends.

### DIFF
--- a/source/build/src/engine.cpp
+++ b/source/build/src/engine.cpp
@@ -8752,6 +8752,8 @@ void engineUnInit(void)
     pskynummultis = 0;
 
     DO_FREE_AND_NULL(g_defNamePtr);
+
+    SDL_Quit();
 }
 
 

--- a/source/build/src/sdlayer.cpp
+++ b/source/build/src/sdlayer.cpp
@@ -745,8 +745,6 @@ void uninitsystem(void)
     windowsPlatformCleanup();
 #endif
 
-    SDL_Quit();
-
 #ifdef USE_OPENGL
 # if SDL_MAJOR_VERSION >= 2
     SDL_GL_UnloadLibrary();


### PR DESCRIPTION
There's a well know and longstanding issue with MESA that causes a segfault if SDL_Quit() is called from atexit().
This affects the KMSDRM and WAYLAND SDL2 backends: when the game is run on KMSDRM or Wayland, it segfaults and locks the whole system on quit if SDL_Quit() is called from atexit().

This simple PR is a workaround for that.