### PR TITLE
Engine: move SDL_Quit() call to engineUnInit() to prevent segfault on KMSDRM and Wayland SDL2 backends

### DIFF
--- a/source/build/src/engine.cpp
+++ b/source/build/src/engine.cpp
@@ -8753,7 +8753,9 @@ void engineUnInit(void)
 
     DO_FREE_AND_NULL(g_defNamePtr);
 
+#if SDL_MAJOR_VERSION >= 1
     SDL_Quit();
+#endif
 }
 
 

--- a/source/build/src/engine.cpp
+++ b/source/build/src/engine.cpp
@@ -8752,6 +8752,8 @@ void engineUnInit(void)
     pskynummultis = 0;
 
     DO_FREE_AND_NULL(g_defNamePtr);
+
+    SDL_Quit();
 }
 
 

--- a/source/build/src/sdlayer.cpp
+++ b/source/build/src/sdlayer.cpp
@@ -745,8 +745,6 @@ void uninitsystem(void)
     windowsPlatformCleanup();
 #endif
 
-    SDL_Quit();
-
 #ifdef USE_OPENGL
 # if SDL_MAJOR_VERSION >= 2
     SDL_GL_UnloadLibrary();


### PR DESCRIPTION
Fixes https://github.com/nukeykt/NBlood/issues/470