### PR TITLE
PCExhumed: Add a crosshair

### DIFF
--- a/source/exhumed/src/view.cpp
+++ b/source/exhumed/src/view.cpp
@@ -720,6 +720,10 @@ void DrawView(int smoothRatio)
             if (nSnakeCam < 0)
             {
                 DrawWeapons(smoothRatio);
+                if (gShowCrosshair) {
+                    if (!waloff[kTile1579]) tileLoad(kTile1579);
+                    rotatesprite(160<<16, 92<<16, 65536, 0, kTile1579, 0, 0, 1+2, windowxy1.x, windowxy1.y, windowxy2.x, windowxy2.y);
+                }
                 DrawMap();
                 DrawStatus();
             }


### PR DESCRIPTION
I noticed a rather funky looking crosshair sprite among the game's tiles, so I added it to the game. The position could probably be tweaked a bit, but it's more or less where it should be.