### PR TITLE
PCExhumed: improved precache

### DIFF
--- a/source/exhumed/src/enginesubs.cpp
+++ b/source/exhumed/src/enginesubs.cpp
@@ -148,14 +148,32 @@ void precache()
     {
         short j = sector[i].ceilingpicnum;
         if (waloff[j] == 0) tileLoad(j);
+        if (picanm[j].sf & PICANM_ANIMTYPE_MASK)
+        {
+            int k;
+            for (k = 1; k <= picanm[j].num; k++)
+                if (waloff[j+k] == 0) tileLoad(j+k);
+        }
         j = sector[i].floorpicnum;
         if (waloff[j] == 0) tileLoad(j);
+        if (picanm[j].sf & PICANM_ANIMTYPE_MASK)
+        {
+            int k;
+            for (k = 1; k <= picanm[j].num; k++)
+                if (waloff[j+k] == 0) tileLoad(j+k);
+        }
     }
 
     for (i = 0; i < numwalls; i++)
     {
         short j = wall[i].picnum;
         if (waloff[j] == 0) tileLoad(j);
+        if (picanm[j].sf & PICANM_ANIMTYPE_MASK)
+        {
+            int k;
+            for (k = 1; k <= picanm[j].num; k++)
+                if (waloff[j+k] == 0) tileLoad(j+k);
+        }
     }
 
     for (i = 0; i < kMaxSprites; i++)
@@ -164,6 +182,12 @@ void precache()
         {
             short j = sprite[i].picnum;
             if (waloff[j] == 0) tileLoad(j);
+            if (picanm[j].sf & PICANM_ANIMTYPE_MASK)
+            {
+                int k;
+                for (k = 1; k <= picanm[j].num; k++)
+                    if (waloff[j+k] == 0) tileLoad(j+k);
+            }
         }
     }
 }

--- a/source/exhumed/src/menu.cpp
+++ b/source/exhumed/src/menu.cpp
@@ -142,6 +142,11 @@ int menu_RandomLong2()
 void InitEnergyTile()
 {
     memset(energytile, 96, sizeof(energytile));
+    for (int i = 0; i < 16; i++)
+    {
+        int nTile = kClockSymbol1 + i;
+        if (waloff[nTile] == 0) tileLoad(nTile);
+    }
 }
 
 void DoEnergyTile()

--- a/source/exhumed/src/sequence.cpp
+++ b/source/exhumed/src/sequence.cpp
@@ -298,6 +298,12 @@ int seq_ReadSequence(const char *seqName)
 #endif
         ChunkXpos[chunks + i] -= centerx;
         ChunkYpos[chunks + i] -= centery;
+
+        short nTile = ChunkPict[chunks + i];
+        if (waloff[nTile] == 0)
+        {
+            tileLoad(nTile);
+        }
     }
 
     sequences += nSeqs;


### PR DESCRIPTION
I made some additions to the precache:
- animated tiles
- sequence pictures
- numbers for the countdown on the last level

This pretty much eliminates the tile loading during normal gameplay as long as everything fits in the cache. 