### PR TITLE
Remove atexit from everywhere

### DIFF
--- a/source/audiolib/src/driver_sdl.cpp
+++ b/source/audiolib/src/driver_sdl.cpp
@@ -63,7 +63,7 @@ static SDL_AudioDeviceID audio_dev;
 
 #if SDL_MAJOR_VERSION >= 2
 char SDLAudioDriverName[16];
-char *SDLAudioDriverNameEnv;
+char *SDLAudioDriverNameEnv = NULL;
 #endif
 
 static void fillData(void * userdata, Uint8 * ptr, int remaining)
@@ -150,18 +150,10 @@ int SDLDrv_PCM_Init(int *mixrate, int *numchannels, void * initdata)
     if (Initialised)
         SDLDrv_PCM_Shutdown();
 #if SDL_MAJOR_VERSION >= 2
-    else if (SDLAudioDriverNameEnv == nullptr)
+    if (!SDLAudioDriverNameEnv)
     {
-        static int done;
-
-        if (!done)
-        {
-            if (auto s = SDL_getenv("SDL_AUDIODRIVER"))
-                SDLAudioDriverNameEnv = Xstrdup(s);
-
-            atexit(SDLDrv_Cleanup);
-            done = true;
-        }
+        if (auto s = SDL_getenv("SDL_AUDIODRIVER"))
+            SDLAudioDriverNameEnv = Xstrdup(s);
     }
 
     if (SDLAudioDriverName[0])
@@ -286,6 +278,9 @@ void SDLDrv_PCM_Shutdown(void)
 
     StartedSDL = 0;
     Initialised = 0;
+#if SDL_MAJOR_VERSION >= 2
+    SDLDrv_Cleanup();
+#endif
 }
 
 int SDLDrv_PCM_BeginPlayback(char *BufferStart, int BufferSize,

--- a/source/blood/src/sound.cpp
+++ b/source/blood/src/sound.cpp
@@ -512,6 +512,5 @@ void sndInit(void)
     nWaveMusicHandle = -1;
     InitSoundDevice();
     InitMusicDevice();
-    //atexit(sndTerm);
     sndActive = true;
 }

--- a/source/build/include/enet.h
+++ b/source/build/include/enet.h
@@ -5364,7 +5364,7 @@ extern "C" {
 
     #ifdef _WIN32
 
-
+    static int is_enet_initialized = 0;
 
     int enet_initialize(void) {
         WORD versionRequested = MAKEWORD(1, 1);
@@ -5380,12 +5380,15 @@ extern "C" {
         }
 
         timeBeginPeriod(1);
+        is_enet_initialized = 1;
         return 0;
     }
 
     void enet_deinitialize(void) {
-        timeEndPeriod(1);
-        WSACleanup();
+        if (is_enet_initialized) {
+            timeEndPeriod(1);
+            WSACleanup();
+        }
     }
 
     enet_uint64 enet_host_random_seed(void) {

--- a/source/build/include/enet.h
+++ b/source/build/include/enet.h
@@ -5388,6 +5388,7 @@ extern "C" {
         if (is_enet_initialized) {
             timeEndPeriod(1);
             WSACleanup();
+            is_enet_initialized = 0;
         }
     }
 

--- a/source/build/src/engine.cpp
+++ b/source/build/src/engine.cpp
@@ -37,6 +37,9 @@
 # endif
 # include "polymost.h"
 #endif
+#ifndef NETCODE_DISABLE
+# include "enet.h"
+#endif
 
 //////////
 // Compilation switches for optional/extended engine features
@@ -8754,6 +8757,9 @@ void engineUnInit(void)
     DO_FREE_AND_NULL(g_defNamePtr);
 
     uninitsystem();
+#ifndef NETCODE_DISABLE
+    enet_deinitialize();
+#endif
 }
 
 

--- a/source/build/src/engine.cpp
+++ b/source/build/src/engine.cpp
@@ -8752,6 +8752,8 @@ void engineUnInit(void)
     pskynummultis = 0;
 
     DO_FREE_AND_NULL(g_defNamePtr);
+
+    uninitsystem();
 }
 
 

--- a/source/build/src/osd.cpp
+++ b/source/build/src/osd.cpp
@@ -768,8 +768,6 @@ void OSD_Init(void)
     OSD_RegisterFunction("listsymbols", "listsymbols: lists all registered functions, cvars and aliases", osdfunc_listsymbols);
     OSD_RegisterFunction("toggle", "toggle: toggles the value of a boolean cvar", osdfunc_toggle);
     OSD_RegisterFunction("unalias", "unalias: removes a command alias", osdfunc_unalias);
-
-    //    atexit(OSD_Cleanup);
 }
 
 

--- a/source/build/src/sdlayer.cpp
+++ b/source/build/src/sdlayer.cpp
@@ -689,8 +689,6 @@ int32_t initsystem(void)
     SDL_SetThreadPriority(SDL_THREAD_PRIORITY_HIGH);
 #endif
 
-    atexit(uninitsystem);
-
     timerInit(CLOCKTICKSPERSECOND);
 
     frameplace = 0;

--- a/source/build/src/sdlayer12.cpp
+++ b/source/build/src/sdlayer12.cpp
@@ -84,8 +84,6 @@ int32_t initsystem(void)
 #endif
     }
 
-    atexit(uninitsystem);
-
     frameplace = 0;
     lockcount = 0;
 

--- a/source/build/src/winlayer.cpp
+++ b/source/build/src/winlayer.cpp
@@ -471,8 +471,6 @@ int32_t initsystem(void)
 
     memset(curpalette, 0, sizeof(palette_t) * 256);
 
-    atexit(uninitsystem);
-
     timerInit(CLOCKTICKSPERSECOND);
 
     frameplace=0;

--- a/source/duke3d/src/game.cpp
+++ b/source/duke3d/src/game.cpp
@@ -6387,7 +6387,6 @@ int app_main(int argc, char const* const* argv)
 #ifndef NETCODE_DISABLE
     if (enet_initialize() != 0)
         initprintf("An error occurred while initializing ENet.\n");
-    else atexit(enet_deinitialize);
 #endif
 
 #ifdef _WIN32

--- a/source/rr/src/game.cpp
+++ b/source/rr/src/game.cpp
@@ -8121,7 +8121,6 @@ int app_main(int argc, char const * const * argv)
 #ifndef NETCODE_DISABLE
     if (enet_initialize() != 0)
         initprintf("An error occurred while initializing ENet.\n");
-    else atexit(enet_deinitialize);
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
This also moves the SDL_Quit() call to engineUnInit() to prevent segfault on KMSDRM and Wayland SDL2 backends.
Fixes https://github.com/nukeykt/NBlood/issues/470