### PR TITLE
NBlood: fix building without NOONE_EXTENSIONS

### DIFF
--- a/source/blood/src/common_game.h
+++ b/source/blood/src/common_game.h
@@ -435,6 +435,7 @@ kAiStateSearch          =  3,
 kAiStateChase           =  4,
 kAiStateRecoil          =  5,
 kAiStateAttack          =  6,
+#ifdef NOONE_EXTENSIONS
 kAiStatePatrolBase      =  7,
 kAiStatePatrolWaitL     =  kAiStatePatrolBase,
 kAiStatePatrolWaitC,
@@ -443,6 +444,7 @@ kAiStatePatrolMoveL,
 kAiStatePatrolMoveC,
 kAiStatePatrolMoveW,
 kAiStatePatrolMax,
+#endif
 };
 
 // sprite attributes

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -2018,6 +2018,7 @@ tspritetype *viewAddEffect(int nTSprite, VIEW_EFFECT nViewEffect)
     if (gDetail < effectDetail[nViewEffect] || nTSprite >= kMaxViewSprites) return NULL;
     switch (nViewEffect)
     {
+#ifdef NOONE_EXTENSIONS
     case kViewEffectSpotProgress: {
         XSPRITE* pXSprite = &xsprite[pTSprite->extra];
         int perc = (100 * pXSprite->data3) / kMaxPatrolSpotValue;
@@ -2068,6 +2069,7 @@ tspritetype *viewAddEffect(int nTSprite, VIEW_EFFECT nViewEffect)
         }
         break;
     }
+#endif
     case kViewEffectAtom:
         for (int i = 0; i < 16; i++)
         {

--- a/source/blood/src/view.h
+++ b/source/blood/src/view.h
@@ -49,7 +49,9 @@ enum VIEW_EFFECT {
     kViewEffectFlag,
     kViewEffectBigFlag,
     kViewEffectAtom,
+#ifdef NOONE_EXTENSIONS
     kViewEffectSpotProgress,
+#endif
 };
 
 enum VIEWPOS {


### PR DESCRIPTION
After the latest additions viewAddEffect failed to build without NOONE_EXTENSIONS. I also added ifdef guards at a couple of other places.