### PR TITLE
NBlood: fix a resource leak in netDeinitialize

### DIFF
--- a/source/blood/src/network.cpp
+++ b/source/blood/src/network.cpp
@@ -1159,8 +1159,6 @@ void netInitialize(bool bConsole)
 void netDeinitialize(void)
 {
 #ifndef NETCODE_DISABLE
-    if (!gNetENetInit)
-        return;
     gNetENetInit = false;
     if (gNetMode != NETWORK_NONE)
     {


### PR DESCRIPTION
The gNetENetInit check in netDeinitialize was redundant, and it could cause some resource leak (the socket not getting closed) when the network game was aborted early on the "waiting for players" screen. 