### PR TITLE
NBlood: fix some UI elements affected by the screen size

### DIFF
--- a/source/blood/src/endgame.cpp
+++ b/source/blood/src/endgame.cpp
@@ -47,7 +47,7 @@ void CEndGameMgr::Draw(void)
     viewLoadingScreenWide();
     int nHeight;
     gMenuTextMgr.GetFontInfo(1, NULL, NULL, &nHeight);
-    rotatesprite(160<<16, 20<<16, 65536, 0, 2038, -128, 0, 6, 0, 0, xdim-1, ydim-1);
+    rotatesprite(160<<16, 20<<16, 65536, 0, 2038, -128, 0, 6|8, 0, 0, xdim-1, ydim-1);
     int nY = 20 - nHeight / 2;
     if (gGameOptions.nGameType == 0)
     {

--- a/source/blood/src/gamemenu.cpp
+++ b/source/blood/src/gamemenu.cpp
@@ -1022,7 +1022,7 @@ void CGameMenuItemBitmap::Draw(void)
         gMenuTextMgr.GetFontInfo(m_nFont, NULL, NULL, &height);
         y += height + 2;
     }
-    rotatesprite(x<<15,y<<15, 65536, 0, at20, 0, 0, 82, 0, 0, xdim-1,ydim-1);
+    rotatesprite(x<<15,y<<15, 65536, 0, at20, 0, 0, 82|8, 0, 0, xdim-1,ydim-1);
 }
 
 bool CGameMenuItemBitmap::Event(CGameMenuEvent &event)
@@ -1077,7 +1077,7 @@ void CGameMenuItemBitmapLS::Draw(void)
         stat = 70;
         picnum = at24;
     }
-    rotatesprite(200<<15,215<<15,32768, ang, picnum, 0, 0, stat, 0, 0, xdim-1, ydim-1);
+    rotatesprite(200<<15,215<<15,32768, ang, picnum, 0, 0, stat|8, 0, 0, xdim-1, ydim-1);
 }
 
 bool CGameMenuItemBitmapLS::Event(CGameMenuEvent &event)


### PR DESCRIPTION
A few UI elements shrunk when the screen size as reduced, for example the images next to the save/load list, or the background of the "LEVEL STATS" text. This is a vanilla bug, but it's just a visual glitch on the UI, so I added the missing cstat flags where I saw this issue.