### PR TITLE
Blood: add missing gViewInterpolate checks

### DIFF
--- a/source/blood/src/mirrors.cpp
+++ b/source/blood/src/mirrors.cpp
@@ -291,11 +291,14 @@ void sub_557C4(int x, int y, int interpolation)
                             pTSprite->owner = pSprite->index;
                             pTSprite->extra = pSprite->extra;
                             pTSprite->flags = pSprite->hitag|0x200;
-                            LOCATION *pLocation = &gPrevSpriteLoc[pSprite->index];
-                            pTSprite->x = dx+interpolate(pLocation->x, pSprite->x, interpolation);
-                            pTSprite->y = dy+interpolate(pLocation->y, pSprite->y, interpolation);
-                            pTSprite->z = dz+interpolate(pLocation->z, pSprite->z, interpolation);
-                            pTSprite->ang = pLocation->ang+mulscale16(((pSprite->ang-pLocation->ang+1024)&2047)-1024,interpolation);
+                            if (gViewInterpolate)
+                            {
+                                LOCATION *pLocation = &gPrevSpriteLoc[pSprite->index];
+                                pTSprite->x = dx+interpolate(pLocation->x, pSprite->x, interpolation);
+                                pTSprite->y = dy+interpolate(pLocation->y, pSprite->y, interpolation);
+                                pTSprite->z = dz+interpolate(pLocation->z, pSprite->z, interpolation);
+                                pTSprite->ang = pLocation->ang+mulscale16(((pSprite->ang-pLocation->ang+1024)&2047)-1024,interpolation);
+                            }
                             spritesortcnt++;
                         }
                     }

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -3438,7 +3438,7 @@ void viewDrawScreen(void)
             CalcPosition(gView->pSprite, (int*)&cX, (int*)&cY, (int*)&cZ, &nSectnum, fix16_to_int(cA), q16horiz);
         }
         CheckLink((int*)&cX, (int*)&cY, (int*)&cZ, &nSectnum);
-        int v78 = interpolateang(gScreenTiltO, gScreenTilt, gInterpolate);
+        int v78 = gViewInterpolate ? interpolateang(gScreenTiltO, gScreenTilt, gInterpolate) : gScreenTilt;
         char v14 = 0;
         char v10 = 0;
         bool bDelirium = powerupCheck(gView, kPwUpDeliriumShroom) > 0;
@@ -3608,7 +3608,14 @@ RORHACKOTHER:
             nSprite = nextspritestat[nSprite];
         }
         g_visibility = (int32_t)(ClipLow(gVisibility - 32 * gView->visibility - unk, 0) * (numplayers > 1 ? 1.f : r_ambientlightrecip));
-        cA = (cA + interpolateangfix16(fix16_from_int(deliriumTurnO), fix16_from_int(deliriumTurn), gInterpolate)) & 0x7ffffff;
+        if (!gViewInterpolate) 
+        {
+            cA += fix16_from_int(deliriumTurn);
+        }
+        else
+        {
+            cA = (cA + interpolateangfix16(fix16_from_int(deliriumTurnO), fix16_from_int(deliriumTurn), gInterpolate)) & 0x7ffffff;
+        }
         int vfc, vf8;
         getzsofslope(nSectnum, cX, cY, &vfc, &vf8);
         if (cZ >= vf8)
@@ -3624,7 +3631,7 @@ RORHACK:
         int ror_status[16];
         for (int i = 0; i < 16; i++)
             ror_status[i] = TestBitString(gotpic, 4080+i);
-        fix16_t deliriumPitchI = interpolate(fix16_from_int(deliriumPitchO), fix16_from_int(deliriumPitch), gInterpolate);
+        fix16_t deliriumPitchI = gViewInterpolate ? interpolate(fix16_from_int(deliriumPitchO), fix16_from_int(deliriumPitch), gInterpolate) : fix16_from_int(deliriumPitch);
         DrawMirrors(cX, cY, cZ, cA, q16horiz + fix16_from_int(defaultHoriz) + deliriumPitchI, gInterpolate, gViewIndex);
         int bakCstat = gView->pSprite->cstat;
         if (gViewPos == 0)

--- a/source/blood/src/view.h
+++ b/source/blood/src/view.h
@@ -163,7 +163,7 @@ void viewPrecacheTiles(void);
 
 inline void viewInterpolateSector(int nSector, sectortype *pSector)
 {
-    if (!TestBitString(gInterpolateSector, nSector))
+    if (gViewInterpolate && !TestBitString(gInterpolateSector, nSector))
     {
         viewAddInterpolation(&pSector->floorz, INTERPOLATE_TYPE_INT);
         viewAddInterpolation(&pSector->ceilingz, INTERPOLATE_TYPE_INT);
@@ -174,7 +174,7 @@ inline void viewInterpolateSector(int nSector, sectortype *pSector)
 
 inline void viewInterpolateWall(int nWall, walltype *pWall)
 {
-    if (!TestBitString(gInterpolateWall, nWall))
+    if (gViewInterpolate && !TestBitString(gInterpolateWall, nWall))
     {
         viewAddInterpolation(&pWall->x, INTERPOLATE_TYPE_INT);
         viewAddInterpolation(&pWall->y, INTERPOLATE_TYPE_INT);
@@ -184,7 +184,7 @@ inline void viewInterpolateWall(int nWall, walltype *pWall)
 
 inline void viewBackupSpriteLoc(int nSprite, spritetype *pSprite)
 {
-    if (!TestBitString(gInterpolateSprite, nSprite))
+    if (gViewInterpolate && !TestBitString(gInterpolateSprite, nSprite))
     {
         LOCATION *pPrevLoc = &gPrevSpriteLoc[nSprite];
         pPrevLoc->x = pSprite->x;


### PR DESCRIPTION
Even with gViewInterpolate off the game still performed interpolation at many places, just without any visible effect. I added gViewInterpolate checks so there are no unnecessary interpolation calculated in this case.