### PR TITLE
Blood: fix map scroll mode allows player forward movement

### DIFF
--- a/source/blood/src/controls.cpp
+++ b/source/blood/src/controls.cpp
@@ -418,10 +418,10 @@ void ctrlGetInput(void)
     if (gInput.forward < keyMove && gInput.forward > -keyMove)
     {
         if (BUTTON(gamefunc_Move_Forward))
-            gInput.forward += keyMove;
+            input.forward += keyMove;
 
         if (BUTTON(gamefunc_Move_Backward))
-            gInput.forward -= keyMove;
+            input.forward -= keyMove;
     }
 
     if (gInput.strafe < keyMove && gInput.strafe > -keyMove)


### PR DESCRIPTION
This fixes a bug I noticed in 2D map scroll mode. The forward, backward and strafe keys are supposed to move the view around only, but for forward and backward this actually moves the player as well. This bug does not appear to be in the base game (I ran One Unit Whole Blood in DosBox and the bug was not there).

This leads to incredibly annoying deaths (at edge of pit, open 2D map in scroll mode, scroll the map up, player walks forward off pit and dies).

It appears the bug occurs because we're writing the `forward` value to `gInput` instead of `input`, which defeats the later attempt to set `input` to zero in code specifically meant for scroll mode with 2D map open.

In `controls.cpp:[501-511]`:
```
 if (!gViewMap.bFollowMode && gViewMode == 4)
 {
    ...
    input.q16turn = 0;
    input.forward = 0; // This effect is lost since `gInput.forward` is non-zero.
    input.strafe = 0;
}
gInput.forward = clamp(gInput.forward + input.forward, -2048, 2048);
gInput.strafe = clamp(gInput.strafe + input.strafe, -2048, 2048);
```

Note that strafe does not suffer from this bug and that's because strafe already writes to `input` as opposed to `gInput`.
```
if (gInput.strafe < keyMove && gInput.strafe > -keyMove)
{
    if (BUTTON(gamefunc_Strafe_Left))
        input.strafe += keyMove;
    if (BUTTON(gamefunc_Strafe_Right))
        input.strafe -= keyMove;
}
```