### PR TITLE
Blood: fix map follow mode toggling outside map

### DIFF
--- a/source/blood/src/controls.cpp
+++ b/source/blood/src/controls.cpp
@@ -244,7 +244,7 @@ void ctrlGetInput(void)
         viewToggle(gViewMode);
     }
 
-    if (BUTTON(gamefunc_Map_Follow_Mode))
+    if (gViewMode == 4 && BUTTON(gamefunc_Map_Follow_Mode))
     {
         CONTROL_ClearButton(gamefunc_Map_Follow_Mode);
         gFollowMap = !gFollowMap;


### PR DESCRIPTION
This fixes the map follow mode key toggling the follow mode setting outside the map (the map isn't open).

To reproduce:
1. Open 2D map.
2. Take note of follow mode setting.
3. Close 2D map.
4. Press follow mode setting key.
5. Open 2D map, notice the follow mode toggled while map was closed.

I was able to reproduce this in the base game as well (One Unit Whole Blood in DosBox). Can't think of a use case for why this should be allowed.