### PR TITLE
Blood: fix delete event not being accepted in edit and bitmap fields

### DIFF
--- a/source/blood/src/gamemenu.cpp
+++ b/source/blood/src/gamemenu.cpp
@@ -1907,6 +1907,7 @@ bool CGameMenuItemZEdit::Event(CGameMenuEvent &event)
         return false;
     case kMenuEventKey:
     case kMenuEventSpace:
+    case kMenuEventDelete:
     {
         char key;
         if (event.at2 < 128)
@@ -2105,6 +2106,7 @@ bool CGameMenuItemZEditBitmap::Event(CGameMenuEvent &event)
         return false;
     case kMenuEventKey:
     case kMenuEventSpace:
+    case kMenuEventDelete:
     {
         char key;
         if (bScan && event.at2 < 128)


### PR DESCRIPTION
This is meant to address issue #487. 

For the edit and bitmap menu field types, it looks like we don't accept delete events that are emitted (the numpad [.] technically doubles as delete key as well so it emits a delete event).

This affects menu items that are edit/text fields or ones that are linked to bitmaps (when typing in a save file name). Note that this fix appears to work fine with the actual non-numpad delete key as well (it does nothing rather than breaking).