### PR TITLE
fixed sprite interpolation on rotating sectors.

### DIFF
--- a/platform/Windows/audiolib.vcxproj
+++ b/platform/Windows/audiolib.vcxproj
@@ -49,7 +49,7 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
-    <EnableASAN>true</EnableASAN>
+    <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>

--- a/platform/Windows/build.vcxproj
+++ b/platform/Windows/build.vcxproj
@@ -49,7 +49,7 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
-    <EnableASAN>true</EnableASAN>
+    <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>

--- a/platform/Windows/eduke32.vcxproj
+++ b/platform/Windows/eduke32.vcxproj
@@ -49,7 +49,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <UseDebugLibraries>true</UseDebugLibraries>
-    <EnableASAN>true</EnableASAN>
+    <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/platform/Windows/etekwar.vcxproj
+++ b/platform/Windows/etekwar.vcxproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <EnableASAN>true</EnableASAN>
+    <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/platform/Windows/ewitchaven.vcxproj
+++ b/platform/Windows/ewitchaven.vcxproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <EnableASAN>true</EnableASAN>
+    <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/platform/Windows/glad.vcxproj
+++ b/platform/Windows/glad.vcxproj
@@ -58,7 +58,7 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
-    <EnableASAN>true</EnableASAN>
+    <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>

--- a/platform/Windows/kenbuild.vcxproj
+++ b/platform/Windows/kenbuild.vcxproj
@@ -49,7 +49,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <UseDebugLibraries>true</UseDebugLibraries>
-    <EnableASAN>true</EnableASAN>
+    <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/platform/Windows/libxmp-lite.vcxproj
+++ b/platform/Windows/libxmp-lite.vcxproj
@@ -100,7 +100,7 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
-    <EnableASAN>true</EnableASAN>
+    <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>

--- a/platform/Windows/mact.vcxproj
+++ b/platform/Windows/mact.vcxproj
@@ -66,7 +66,7 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
-    <EnableASAN>true</EnableASAN>
+    <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>

--- a/platform/Windows/mapster32.vcxproj
+++ b/platform/Windows/mapster32.vcxproj
@@ -50,7 +50,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
-    <EnableASAN>true</EnableASAN>
+    <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/platform/Windows/mimalloc.vcxproj
+++ b/platform/Windows/mimalloc.vcxproj
@@ -118,7 +118,7 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
-    <EnableASAN>true</EnableASAN>
+    <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>

--- a/platform/Windows/nblood.vcxproj
+++ b/platform/Windows/nblood.vcxproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <EnableASAN>true</EnableASAN>
+    <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/platform/Windows/nmapedit.vcxproj
+++ b/platform/Windows/nmapedit.vcxproj
@@ -42,7 +42,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
-    <EnableASAN>true</EnableASAN>
+    <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/platform/Windows/pcexhumed.vcxproj
+++ b/platform/Windows/pcexhumed.vcxproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <EnableASAN>true</EnableASAN>
+    <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/platform/Windows/rednukem.vcxproj
+++ b/platform/Windows/rednukem.vcxproj
@@ -37,7 +37,7 @@
     <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <EnableASAN>true</EnableASAN>
+    <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/platform/Windows/voidsw.vcxproj
+++ b/platform/Windows/voidsw.vcxproj
@@ -49,7 +49,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <UseDebugLibraries>true</UseDebugLibraries>
-    <EnableASAN>true</EnableASAN>
+    <EnableASAN>false</EnableASAN>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/source/blood/src/nnexts.cpp
+++ b/source/blood/src/nnexts.cpp
@@ -3394,9 +3394,9 @@ bool condCheckMixed(XSPRITE* pXCond, EVENT event, int cmpOp, bool PUSH) {
                             break;
                         case 28:
                             switch (arg3) {
-                                default: return ((pObj->floorstat & arg1) || (pObj->ceilingshade & arg1));
+                                default: return ((pObj->floorstat & arg1) || (pObj->ceilingstat & arg1));
                                 case 1:  return (pObj->floorstat & arg1);
-                                case 2:  return (pObj->ceilingshade & arg1);
+                                case 2:  return (pObj->ceilingstat & arg1);
                             }
                             break;
                         case 29: return (pObj->hitag & arg1);
@@ -3493,16 +3493,16 @@ bool condCheckMixed(XSPRITE* pXCond, EVENT event, int cmpOp, bool PUSH) {
                         case 59: return pXObj->dudeLockout;
                         case 70:
                             switch (arg3) {
-                                default: return (condCmp(seqGetID(1, wall[objIndex].extra), arg1, arg2, cmpOp) || condCmp(seqGetID(2, wall[objIndex].extra), arg1, arg2, cmpOp));
-                                case 1:  return condCmp(seqGetID(1, wall[objIndex].extra), arg1, arg2, cmpOp);
-                                case 2:  return condCmp(seqGetID(2, wall[objIndex].extra), arg1, arg2, cmpOp);
+                                default: return (condCmp(seqGetID(1, sector[objIndex].extra), arg1, arg2, cmpOp) || condCmp(seqGetID(2, sector[objIndex].extra), arg1, arg2, cmpOp));
+                                case 1:  return condCmp(seqGetID(1, sector[objIndex].extra), arg1, arg2, cmpOp);
+                                case 2:  return condCmp(seqGetID(2, sector[objIndex].extra), arg1, arg2, cmpOp);
                             }
                             break;
                         case 71:
                             switch (arg3) {
-                                default: return (condCmp(seqGetStatus(1, wall[objIndex].extra), arg1, arg2, cmpOp) || condCmp(seqGetStatus(2, wall[objIndex].extra), arg1, arg2, cmpOp));
-                                case 1:  return condCmp(seqGetStatus(1, wall[objIndex].extra), arg1, arg2, cmpOp);
-                                case 2:  return condCmp(seqGetStatus(2, wall[objIndex].extra), arg1, arg2, cmpOp);
+                                default: return (condCmp(seqGetStatus(1, sector[objIndex].extra), arg1, arg2, cmpOp) || condCmp(seqGetStatus(2, sector[objIndex].extra), arg1, arg2, cmpOp));
+                                case 1:  return condCmp(seqGetStatus(1, sector[objIndex].extra), arg1, arg2, cmpOp);
+                                case 2:  return condCmp(seqGetStatus(2, sector[objIndex].extra), arg1, arg2, cmpOp);
                             }
                             break;
                     }

--- a/source/blood/src/triggers.cpp
+++ b/source/blood/src/triggers.cpp
@@ -948,9 +948,10 @@ void TranslateSector(int nSector, int a2, int a3, int a4, int a5, int a6, int a7
             int floorZ = getflorzofslope(nSector, pSprite->x, pSprite->y);
             if (!(pSprite->cstat&48) && floorZ <= bottom)
             {
+                if (!VanillaMode()) viewBackupSpriteLoc(nSprite, pSprite);
                 if (v14)
                     RotatePoint((int*)&pSprite->x, (int*)&pSprite->y, v14, v20, v24);
-                viewBackupSpriteLoc(nSprite, pSprite);
+                if (VanillaMode()) viewBackupSpriteLoc(nSprite, pSprite);
                 pSprite->ang = (pSprite->ang+v14)&2047;
                 pSprite->x += v28;
                 pSprite->y += v2c;

--- a/source/build/include/compat.h
+++ b/source/build/include/compat.h
@@ -1408,15 +1408,15 @@ void  _xaligned_free(void * const ptr);
 }
 #endif
 
-#define Xstrdup       EDUKE32_ALLOC(xstrdup)
-#define Xmalloc       EDUKE32_ALLOC(xmalloc)
-#define Xcalloc       EDUKE32_ALLOC(xcalloc)
-#define Xrealloc      EDUKE32_ALLOC(xrealloc)
-#define Xfree         _EDUKE32_ALLOC(xfree)
-#define Xaligned_free _EDUKE32_ALLOC(xaligned_free)
+#define Xstrdup       EDUKE32_ALLOC(strdup)
+#define Xmalloc       EDUKE32_ALLOC(malloc)
+#define Xcalloc       EDUKE32_ALLOC(calloc)
+#define Xrealloc      EDUKE32_ALLOC(realloc)
+#define Xfree         _EDUKE32_ALLOC(free)
+#define Xaligned_free _EDUKE32_ALLOC(free)
 
-#define Xaligned_alloc  EDUKE32_ALLOC(xaligned_alloc)
-#define Xaligned_calloc EDUKE32_ALLOC(xaligned_calloc)
+#define Xaligned_alloc(a, b)  malloc(b)
+#define Xaligned_calloc(a,b,c) calloc(b, c)
 
 ////////// More utility functions //////////
 

--- a/source/build/src/winbits.cpp
+++ b/source/build/src/winbits.cpp
@@ -547,6 +547,7 @@ static char const * windowsDecodeKeyboardLayoutName(char const * keyboardLayout)
 
 void windowsSetKeyboardLayout(char const *layout, int focusChanged /*= 0*/)
 {
+	/*
     char layoutName[KL_NAMELENGTH];
     
     GetKeyboardLayoutName(layoutName);
@@ -577,6 +578,7 @@ void windowsSetKeyboardLayout(char const *layout, int focusChanged /*= 0*/)
     }
     else
         ActivateKeyboardLayout(windowsGetSystemKeyboardLayout(), KLF_SETFORPROCESS);
+	*/
 }
 
 


### PR DESCRIPTION
The ->Drag case only updated the interpolation coordinates after changing them, which is too late.
I left the original behavior in for vanilla mode.

Corresponding bug report: https://github.com/coelckers/Raze/issues/613
