### PR TITLE
PCExhumed: offset death arms for widescreen

### DIFF
--- a/source/exhumed/src/gun.cpp
+++ b/source/exhumed/src/gun.cpp
@@ -21,6 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 //-------------------------------------------------------------------------
 
+#include "build.h"
 #include "gun.h"
 #include "engine.h"
 #include "init.h"
@@ -1036,7 +1037,36 @@ void DrawWeapons(int smooth)
     }
 
     if (nWeapon == 3 && var_34 == 1) {
+        // If the weapon is the flamer, draw the pilot light that sits at the muzzle.
         seq_DrawPilotLightSeq(xOffset, yOffset);
+    }
+    else if ((nWeapon == 8 || nWeapon == 9) && windowxy2.y != 0)
+    {
+        // If the current "weapon" is either the normal or explosive death arm (which are treated as "weapons"),
+        // and the window's Y does not equal zero (to avoid inadvertent division by zero below), we determine
+        // special X offsets, since these two produce "gun sequences" that are cut off on the side for screen
+        // ratios that are wider than standard/4:3.
+        //
+        // Rot/mummy and burn death arm "weapons" don't suffer from this issue (they have intrinsically wider art).
+        //
+        // The xOffset calculated below is later added to the standard X offset of 160 when the "gun sequence"
+        // is being drawn.
+        float screenRatio = (float)windowxy2.x / windowxy2.y; // Safe from division by zero.
+        float newX        = ceil(120 * screenRatio);
+
+        // For standard 4:3 ratio (1.333333) or slimmer, we want to add nothing (take the max between zero and
+        // xOffset), all wider ratios must offset.
+        //
+        // Examples which result in no change:
+        // 120 * 1.25       == 150, so (150 - 160) == -10 offset (slimmer than 4:3)
+        // 120 * 1.333333   == 160, so (160 - 160) == 0 offset (this is 4:3)
+        //
+        // Examples which result in positive offsets (all wider than 4:3):
+        // 120 * 1.5        == 180, so (180 - 160) == +20 offset
+        // 120 * 1.6        == 192, so (192 - 160) == +32 offset
+        // 120 * 1.706667   == 205, so (205 - 160) == +45 offset
+        // 120 * 1.777778   == 214, so (214 - 160) == +54 offset
+        xOffset = max(0, int(newX) - 160);
     }
 
     if (nWeapon < 0) {


### PR DESCRIPTION
This is an attempt to address issue #536. I tested this in both windowed and fullscreen, OpenGL and software. Attached are screenshots I took of the fix at various screen ratios.

This fix affects the regular and explosive death arms, I tested and screenshotted both types but for brevity only included one screenshot of regular death arms at the end. The rot/mummy and burn death arms appear fine since the art is intrinsically wider for those. Sample easy places to test rot/mummy in the wild is level 6 since they appear right at start, level 4 for burn death arm (go forward and turn left to lava).

The resolutions I tested for each screen ratio:
* 720x576     = 1.25
* 640x480     = 1.333333
* 720x480     = 1.5
* 1440x900   = 1.6
* 1024x600   = 1.706667
* 1920x1080 = 1.777778

1.25 screen ratio screenshot:
![1 25 explosive](https://user-images.githubusercontent.com/44218183/149678648-8d83bd13-cf61-456c-a3c6-d750edd2ea6a.png)
1.333333 screen ratio screenshot:
![1 333333 explosive](https://user-images.githubusercontent.com/44218183/149678649-0ac92618-e000-451c-bfc9-7aaac037d4a8.png)
1.5 screen ratio screenshot:
![1 5 explosive](https://user-images.githubusercontent.com/44218183/149678645-a8dd3c32-30b7-4bca-b2e1-2c54b7ee7815.png)
1.6 screen ratio screenshot:
![1 6 explosive](https://user-images.githubusercontent.com/44218183/149678647-a703760e-1a73-4ed1-bf33-6e593833157a.png)
1.706667 screen ratio screenshot:
![1 706667 explosive](https://user-images.githubusercontent.com/44218183/149678650-7d1a9118-cddf-40a9-8317-cf6d6942fa73.png)
1.777778 screen ratio screenshot:
![1 777778 explosive](https://user-images.githubusercontent.com/44218183/149678643-d1574e29-42d2-41c4-9973-f8b7a8d2dcb0.png)
1.777778 screen ratio screenshot (regular death arm):
![1 777778 death](https://user-images.githubusercontent.com/44218183/149678651-f632166a-b4ee-4a61-a64c-543272020a03.png)
