### PR TITLE
Blood: fix delirium being twice as fast

### DIFF
--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -3233,7 +3233,7 @@ void viewUpdateDelirium(void)
     if ((powerCount = powerupCheck(gView, kPwUpDeliriumShroom)) != 0)
     {
         int tilt1 = 170, tilt2 = 170, pitch = 20;
-        int timer = (int)gFrameClock*4;
+        int timer = (int)gFrameClock << 1;
         if (powerCount < 512)
         {
             int powerScale = (powerCount<<16) / 512;


### PR DESCRIPTION
Meant to address issue #494. I compared the original DOS executable and confirmed it is indeed faster. This change does not change the overall duration of the effect (still about ~8 seconds), just the speed of it.