### PR TITLE
BLOOD: add option to share keys in multiplayer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,8 @@ xcuserdata/
 project.xcworkspace/
 *.dSYM/
 
+.vscode
+
 .DS_Store
 ._*
 /source/voidwrap/sdk/

--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -617,7 +617,7 @@ void StartLevel(GAMEOPTIONS *gameOptions)
         gGameOptions.nItemSettings = gPacketStartGame.itemSettings;
         gGameOptions.nRespawnSettings = gPacketStartGame.respawnSettings;
         gGameOptions.bFriendlyFire = gPacketStartGame.bFriendlyFire;
-        gGameOptions.bKeepKeysOnRespawn = gPacketStartGame.bKeepKeysOnRespawn;
+        gGameOptions.bPlayerKeys = gPacketStartGame.bPlayerKeys;
         if (gPacketStartGame.userMap)
             levelAddUserMap(gPacketStartGame.userMapName);
         else
@@ -800,7 +800,7 @@ void StartNetworkLevel(void)
         gGameOptions.nItemSettings = gPacketStartGame.itemSettings;
         gGameOptions.nRespawnSettings = gPacketStartGame.respawnSettings;
         gGameOptions.bFriendlyFire = gPacketStartGame.bFriendlyFire;
-        gGameOptions.bKeepKeysOnRespawn = gPacketStartGame.bKeepKeysOnRespawn;
+        gGameOptions.bPlayerKeys = gPacketStartGame.bPlayerKeys;
         
         ///////
         gGameOptions.weaponsV10x = gPacketStartGame.weaponsV10x;

--- a/source/blood/src/levels.h
+++ b/source/blood/src/levels.h
@@ -56,7 +56,7 @@ struct GAMEOPTIONS {
     int nSpecialRespawnTime;
     int weaponsV10x;
     bool bFriendlyFire;
-    bool bKeepKeysOnRespawn;
+    PLAYERKEYSMODE bPlayerKeys;
     char szUserMap[BMAX_PATH];
 };
 

--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -164,6 +164,12 @@ const char *pzShowWeaponStrings[] = {
     "VOXEL"
 };
 
+const char *zPlayerKeysStrings[] = {
+    "LOST ON DEATH",
+    "KEPT ON RESPAWN",
+    "SHARED"
+};
+
 char zUserMapName[BMAX_PATH];
 const char *zEpisodeNames[6];
 const char *zLevelNames[6][16];
@@ -320,7 +326,7 @@ CGameMenuItemZCycle itemNetStart5("MONSTERS:", 3, 66, 100, 180, 0, 0, zMonsterSt
 CGameMenuItemZCycle itemNetStart6("WEAPONS:", 3, 66, 110, 180, 0, 0, zWeaponStrings, 4, 0);
 CGameMenuItemZCycle itemNetStart7("ITEMS:", 3, 66, 120, 180, 0, 0, zItemStrings, 3, 0);
 CGameMenuItemZBool itemNetStart8("FRIENDLY FIRE:", 3, 66, 130, 180, true, 0, NULL, NULL);
-CGameMenuItemZBool itemNetStart9("KEEP KEYS ON RESPAWN:", 3, 66, 140, 180, false, 0, NULL, NULL);
+CGameMenuItemZCycle itemNetStart9("PLAYER KEYS:", 3, 66, 140, 180, 0, 0, zPlayerKeysStrings, 3, 0);
 CGameMenuItemZBool itemNetStart10("V1.0x WEAPONS BALANCE:", 3, 66, 150, 180, false, 0, NULL, NULL);
 CGameMenuItemChain itemNetStart11("USER MAP", 3, 66, 160, 180, 0, &menuMultiUserMaps, 0, NULL, 0);
 CGameMenuItemChain itemNetStart12("START GAME", 1, 66, 175, 280, 0, 0, -1, StartNetGame, 0);
@@ -2240,7 +2246,7 @@ void StartNetGame(CGameMenuItemChain *pItem)
     gPacketStartGame.itemSettings = itemNetStart7.m_nFocus;
     gPacketStartGame.respawnSettings = 0;
     gPacketStartGame.bFriendlyFire = itemNetStart8.at20;
-    gPacketStartGame.bKeepKeysOnRespawn = itemNetStart9.at20;
+    gPacketStartGame.bPlayerKeys = (PLAYERKEYSMODE) itemNetStart9.m_nFocus;
     ////
     gPacketStartGame.weaponsV10x = itemNetStart10.at20;
     ////

--- a/source/blood/src/network.h
+++ b/source/blood/src/network.h
@@ -38,6 +38,12 @@ enum NETWORKMODE {
     NETWORK_CLIENT
 };
 
+enum PLAYERKEYSMODE {
+    LOSTONDEATH = 0,
+    KEPTONRESPAWN,
+    SHARED
+};
+
 #define kNetDefaultPort 23513
 
 extern char packet[576];
@@ -77,7 +83,7 @@ struct PKT_STARTGAME {
     char userMap, userMapName[BMAX_PATH];
     int weaponsV10x;
     bool bFriendlyFire;
-    bool bKeepKeysOnRespawn;
+    PLAYERKEYSMODE bPlayerKeys;
 };
 
 extern PKT_STARTGAME gPacketStartGame;

--- a/source/blood/src/player.cpp
+++ b/source/blood/src/player.cpp
@@ -739,7 +739,7 @@ void playerStart(int nPlayer, int bNewLevel)
     pPlayer->relAim.dz = 0;
     pPlayer->aimTarget = -1;
     pPlayer->zViewVel = pPlayer->zWeaponVel;
-    if (!(gGameOptions.nGameType == 1 && gGameOptions.bKeepKeysOnRespawn && !bNewLevel))
+    if (!(gGameOptions.nGameType == 1 && gGameOptions.bPlayerKeys > PLAYERKEYSMODE::LOSTONDEATH && !bNewLevel))
         for (int i = 0; i < 8; i++)
             pPlayer->hasKey[i] = gGameOptions.nGameType >= 2;
     pPlayer->hasFlag = 0;
@@ -1092,6 +1092,11 @@ char PickupItem(PLAYER *pPlayer, spritetype *pItem) {
             if (pPlayer->hasKey[pItem->type-99]) return 0;
             pPlayer->hasKey[pItem->type-99] = 1;
             pickupSnd = 781;
+            if (gGameOptions.bPlayerKeys == PLAYERKEYSMODE::SHARED) {
+                for (int i = connecthead; i != -1; i = connectpoint2[i]) {
+                    gPlayer[i].hasKey[pItem->type-99] = 1;
+                }
+            }
             break;
         case kItemHealthMedPouch:
         case kItemHealthLifeEssense:


### PR DESCRIPTION
Selecting the shared option means any player picking up a key gives it to all players. Zandronum has an option like this for Doom ([SV_ShareKeys](https://wiki.zandronum.com/DMFlags#ZaDMFlags)). Makes casual coop more fun when familiarity with the game varies in the group.

Thanks for NBlood. I've spent many hours playing the game solo and multiplayer with it.