### PR TITLE
BLOOD: fix host end game causing clients to ShutDown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,8 @@ xcuserdata/
 project.xcworkspace/
 *.dSYM/
 
+.vscode
+
 .DS_Store
 ._*
 /source/voidwrap/sdk/

--- a/source/blood/src/network.cpp
+++ b/source/blood/src/network.cpp
@@ -1338,7 +1338,7 @@ void netPlayerQuit(int nPlayer)
             gQuitGame = true;
             gRestartGame = true;
             gNetPlayers = 1;
-            //gQuitRequest = 1;
+            gQuitRequest = gNetMode == NETWORK_SERVER ? gQuitRequest : 2;
         }
     }
     else


### PR DESCRIPTION
Currently, when the host ends a game, all the clients ShutDown, which is frustrating, and seems like a bug. (I thought they were crashing, but they just make it to the end of app_main). This PR sets the gQuitRequest to 2, so ProcessFrame's gRestartGame = gQuitRequest == 2 will set gRestartGame true.

Note, that without the [gPost fix](https://github.com/nukeykt/NBlood/pull/543) the client has post action sprite deletion problems, leading to a fairly quick crash during demo playback.