### PR TITLE
BLOOD: fix last user map to not override menu map selected for new game

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,8 @@ xcuserdata/
 project.xcworkspace/
 *.dSYM/
 
+.vscode
+
 .DS_Store
 ._*
 /source/voidwrap/sdk/

--- a/source/blood/src/gamemenu.cpp
+++ b/source/blood/src/gamemenu.cpp
@@ -565,6 +565,19 @@ CGameMenuItemTitle::CGameMenuItemTitle(const char *a1, int a2, int a3, int a4, i
     bEnable = 0;
 }
 
+CGameMenuItemMultiplayerTitle::CGameMenuItemMultiplayerTitle(const char *a1, int a2, int a3, int a4, int a5) : CGameMenuItemTitle(a1, a2, a3, a4, a5)
+{
+}
+
+bool CGameMenuItemMultiplayerTitle::Event(CGameMenuEvent &event)
+{
+    if (event.at0 == kMenuEventInit) {
+        memset(zUserMapName, 0, sizeof(zUserMapName));
+    }
+
+    return CGameMenuItem::Event(event);
+}
+
 void CGameMenuItemTitle::Draw(void)
 {
     if (m_pzText)

--- a/source/blood/src/gamemenu.h
+++ b/source/blood/src/gamemenu.h
@@ -134,6 +134,13 @@ public:
     //virtual bool Event(CGameMenuEvent &);
 };
 
+class CGameMenuItemMultiplayerTitle : public CGameMenuItemTitle
+{
+public:
+    CGameMenuItemMultiplayerTitle(const char *, int, int, int, int);
+    virtual bool Event(CGameMenuEvent &);
+};
+
 class CGameMenuItemZBool : public CGameMenuItem
 {
 public:

--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -81,6 +81,7 @@ void UpdateVideoModeMenuFrameLimit(CGameMenuItemZCycle *pItem);
 //void UpdateVideoModeMenuFPSOffset(CGameMenuItemSlider *pItem);
 void UpdateVideoColorMenu(CGameMenuItemSliderFloat *);
 void ResetVideoColor(CGameMenuItemChain *);
+void ClearUserMapNameOnLevelChange(CGameMenuItemZCycle *);
 #ifdef USE_OPENGL
 void SetupVideoPolymostMenu(CGameMenuItemChain *);
 #endif
@@ -311,10 +312,10 @@ CGameMenu menuMultiUserMaps;
 CGameMenuItemTitle itemNetStartUserMapTitle("USER MAP", 1, 160, 20, 2038);
 CGameMenuFileSelect menuMultiUserMap("", 3, 0, 0, 0, "./", "*.map", zUserMapName);
 
-CGameMenuItemTitle itemNetStartTitle("MULTIPLAYER", 1, 160, 20, 2038);
+CGameMenuItemMultiplayerTitle itemNetStartTitle("MULTIPLAYER", 1, 160, 20, 2038);
 CGameMenuItemZCycle itemNetStart1("GAME:", 3, 66, 60, 180, 0, 0, zNetGameTypes, 3, 0);
 CGameMenuItemZCycle itemNetStart2("EPISODE:", 3, 66, 70, 180, 0, SetupNetLevels, NULL, 0, 0);
-CGameMenuItemZCycle itemNetStart3("LEVEL:", 3, 66, 80, 180, 0, NULL, NULL, 0, 0);
+CGameMenuItemZCycle itemNetStart3("LEVEL:", 3, 66, 80, 180, 0, ClearUserMapNameOnLevelChange, NULL, 0, 0);
 CGameMenuItemZCycle itemNetStart4("DIFFICULTY:", 3, 66, 90, 180, 0, 0, zDiffStrings, 5, 0);
 CGameMenuItemZCycle itemNetStart5("MONSTERS:", 3, 66, 100, 180, 0, 0, zMonsterStrings, 3, 0);
 CGameMenuItemZCycle itemNetStart6("WEAPONS:", 3, 66, 110, 180, 0, 0, zWeaponStrings, 4, 0);
@@ -2215,6 +2216,11 @@ void QuickLoadGame(void)
     gGameMenuMgr.Deactivate();
 }
 
+void ClearUserMapNameOnLevelChange(CGameMenuItemZCycle *pItem)
+{
+    memset(zUserMapName, 0, sizeof(zUserMapName));
+}
+
 void SetupLevelMenuItem(int nEpisode)
 {
     dassert(nEpisode >= 0 && nEpisode < gEpisodeCount);
@@ -2223,6 +2229,7 @@ void SetupLevelMenuItem(int nEpisode)
 
 void SetupNetLevels(CGameMenuItemZCycle *pItem)
 {
+    memset(zUserMapName, 0, sizeof(zUserMapName));
     SetupLevelMenuItem(pItem->m_nFocus);
 }
 
@@ -2245,7 +2252,7 @@ void StartNetGame(CGameMenuItemChain *pItem)
     gPacketStartGame.weaponsV10x = itemNetStart10.at20;
     ////
     gPacketStartGame.unk = 0;
-    Bstrncpy(gPacketStartGame.userMapName, zUserMapName, Bstrlen(zUserMapName));
+    Bstrncpy(gPacketStartGame.userMapName, zUserMapName, sizeof(gPacketStartGame.userMapName));
     gPacketStartGame.userMap = gPacketStartGame.userMapName[0] != 0;
 
     netBroadcastNewGame();

--- a/source/blood/src/menu.h
+++ b/source/blood/src/menu.h
@@ -54,6 +54,7 @@ extern short gQuickSaveSlot;
 extern char strRestoreGameStrings[][16];
 extern char restoreGameDifficulty[];
 extern const char *zDiffStrings[];
+extern char zUserMapName[BMAX_PATH];
 void drawLoadingScreen(void);
 void SetupMenus(void);
 void UpdateNetworkMenus(void);


### PR DESCRIPTION
After a user map has been chosen the map that appears selected on the multiplayer config menu is never used again, even when the multiplayer menu is re-loaded for a New Game.  This makes it impossible to play the built in maps without restarting the executable.

The problem relates to StartNetGame and zUserMapName

    Bstrncpy(gPacketStartGame.userMapName, zUserMapName, sizeof(gPacketStartGame.userMapName));
    gPacketStartGame.userMap = gPacketStartGame.userMapName[0] != 0;

Nothing ever resets zUserMapName to an empty string. This means after any user map is chosen, gPacketStartGame.userMapName is always populated, and gPacketStartGame.userMap is always true.

I added a custom CGameMenuItem for the multiplayer menu title text with an Event method that clears zUserMapName on kMenuEventInit, which is only sent when the menu is re-loaded.