### PR TITLE
Blood: Fix shadow offset when rendering through room over room

### DIFF
--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -2289,19 +2289,21 @@ tspritetype *viewAddEffect(int nTSprite, VIEW_EFFECT nViewEffect)
         pNSprite->z = getflorzofslope(pTSprite->sectnum, pNSprite->x, pNSprite->y);
         if ((sector[pNSprite->sectnum].floorpicnum >= 4080) && (sector[pNSprite->sectnum].floorpicnum <= 4095) && !VanillaMode()) // if floor has ror, find actual floor
         {
-            int cX = pNSprite->x, cY = pNSprite->y, cZ = pNSprite->z, nSectnum = pNSprite->sectnum;
+            int cX = pNSprite->x, cY = pNSprite->y, cZ = pNSprite->z, cZrel = pNSprite->z, nSectnum = pNSprite->sectnum;
             for (int i = 0; i < 16; i++) // scan through max stacked sectors
             {
                 if (!CheckLink(&cX, &cY, &cZ, &nSectnum)) // if no more floors underneath, abort
                     break;
-                cZ = getflorzofslope(nSectnum, cX, cY);
+                const int newFloorZ = getflorzofslope(nSectnum, cX, cZ);
+                cZrel += newFloorZ - cZ; // get height difference for next sector's ceiling/floor, and add to relative height for shadow
                 if ((sector[nSectnum].floorpicnum < 4080) || (sector[nSectnum].floorpicnum > 4095)) // if current sector is not open air, use as floor for shadow casting, otherwise continue to next sector
                     break;
+                cZ = newFloorZ;
             }
-            pNSprite->x = cX, pNSprite->y = cY, pNSprite->z = cZ, pNSprite->sectnum = nSectnum;
+            pNSprite->z = cZrel;
         }
         pNSprite->shade = 127;
-        pNSprite->cstat |= 2;
+        pNSprite->cstat |= CSTAT_SPRITE_TRANSLUCENT;
         pNSprite->xrepeat = pTSprite->xrepeat;
         pNSprite->yrepeat = pTSprite->yrepeat>>2;
         pNSprite->picnum = pTSprite->picnum;
@@ -2418,7 +2420,7 @@ tspritetype *viewAddEffect(int nTSprite, VIEW_EFFECT nViewEffect)
             pNSprite->picnum = nVoxel;
             if (pPlayer->curWeapon == 9) // position lifeleech behind player
             {
-                pNSprite->x +=  mulscale30(128, Cos(gView->pSprite->ang));
+                pNSprite->x += mulscale30(128, Cos(gView->pSprite->ang));
                 pNSprite->y += mulscale30(128, Sin(gView->pSprite->ang));
             }
             if ((pPlayer->curWeapon == 9) || (pPlayer->curWeapon == 10))  // make lifeleech/voodoo doll always face viewer like sprite


### PR DESCRIPTION
This PR fixes a calculation offset error introduced by commit https://github.com/nukeykt/NBlood/commit/df4778e5130df5c11dc1d6bbd387b13498e9b356 when rendering a shadow above a ror floor. Instead of applying the secondary room position offset it'll use the height of the secondary room - this will correctly draw the Z offset required by the shadow.