### PR TITLE
Blood: Fix voxel maphacks desyncing when load save

### DIFF
--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -645,6 +645,7 @@ void StartLevel(GAMEOPTIONS *gameOptions)
     bVanilla = gDemo.at1 && gDemo.m_bLegacy;
     memset(xsprite,0,sizeof(xsprite));
     memset(sprite,0,kMaxSprites*sizeof(spritetype));
+    memset(spriteext,0,kMaxSprites*sizeof(spriteext_t));
     drawLoadingScreen();
     if (dbLoadMap(gameOptions->zLevelName,(int*)&startpos.x,(int*)&startpos.y,(int*)&startpos.z,&startang,&startsectnum,(unsigned int*)&gameOptions->uMapCRC))
     {

--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -643,9 +643,6 @@ void StartLevel(GAMEOPTIONS *gameOptions)
         }
     }
     bVanilla = gDemo.at1 && gDemo.m_bLegacy;
-    memset(xsprite,0,sizeof(xsprite));
-    memset(sprite,0,kMaxSprites*sizeof(spritetype));
-    memset(spriteext,0,kMaxSprites*sizeof(spriteext_t));
     drawLoadingScreen();
     if (dbLoadMap(gameOptions->zLevelName,(int*)&startpos.x,(int*)&startpos.y,(int*)&startpos.z,&startang,&startsectnum,(unsigned int*)&gameOptions->uMapCRC))
     {

--- a/source/blood/src/common_game.h
+++ b/source/blood/src/common_game.h
@@ -40,7 +40,7 @@ extern int g_useCwd;
 
 #define BLOODWIDESCREENDEF "blood_widescreen.def"
 
-#define BYTEVERSION 103
+#define BYTEVERSION 104
 #define EXEVERSION 101
 
 void _SetErrorLoc(const char *pzFile, int nLine);

--- a/source/blood/src/db.cpp
+++ b/source/blood/src/db.cpp
@@ -739,9 +739,18 @@ const int nXWallSize = 24;
 
 int dbLoadMap(const char *pPath, int *pX, int *pY, int *pZ, short *pAngle, short *pSector, unsigned int *pCRC) {
     char name2[BMAX_PATH]; int16_t tpskyoff[256];
-    memset(show2dsector, 0, sizeof(show2dsector));
-    memset(show2dwall, 0, sizeof(show2dwall));
-    memset(show2dsprite, 0, sizeof(show2dsprite));
+
+    memset(show2dsector,0,sizeof(show2dsector));
+    memset(show2dwall,0,sizeof(show2dwall));
+    memset(show2dsprite,0,sizeof(show2dsprite));
+    memset(spriteext,0,kMaxSprites*sizeof(spriteext_t));
+
+    memset(xvel,0,sizeof(xvel));
+    memset(yvel,0,sizeof(yvel));
+    memset(zvel,0,sizeof(zvel));
+    memset(xsprite,0,sizeof(xsprite));
+    memset(sprite,0,kMaxSprites*sizeof(spritetype));
+
     #ifdef NOONE_EXTENSIONS
     gModernMap = false;
     #endif

--- a/source/blood/src/loadsave.cpp
+++ b/source/blood/src/loadsave.cpp
@@ -272,9 +272,11 @@ void MyLoadSave::Load(void)
     memset(sector, 0, sizeof(sector[0])*kMaxSectors);
     memset(wall, 0, sizeof(wall[0])*kMaxWalls);
     memset(sprite, 0, sizeof(sprite[0])*kMaxSprites);
+    memset(spriteext, 0, sizeof(spriteext[0])*kMaxSprites);
     Read(sector, sizeof(sector[0])*numsectors);
     Read(wall, sizeof(wall[0])*numwalls);
     Read(sprite, sizeof(sprite[0])*kMaxSprites);
+    Read(spriteext, sizeof(spriteext[0])*kMaxSprites);
     Read(qsector_filler, sizeof(qsector_filler[0])*numsectors);
     Read(qsprite_filler, sizeof(qsprite_filler[0])*kMaxSprites);
     Read(&randomseed, sizeof(randomseed));
@@ -391,6 +393,7 @@ void MyLoadSave::Save(void)
     Write(sector, sizeof(sector[0])*numsectors);
     Write(wall, sizeof(wall[0])*numwalls);
     Write(sprite, sizeof(sprite[0])*kMaxSprites);
+    Write(spriteext, sizeof(spriteext[0])*kMaxSprites);
     Write(qsector_filler, sizeof(qsector_filler[0])*numsectors);
     Write(qsprite_filler, sizeof(qsprite_filler[0])*kMaxSprites);
     Write(&randomseed, sizeof(randomseed));


### PR DESCRIPTION
This PR adds spriteext array to file save format, and fixes the maphacks getting desynced when loading saves (e.g: blood voxel pack). For example, loading a save to a different level will carry over the current level maphacks.