### PR TITLE
Blood: Restore custom fov after rendering crystal ball powerup

### DIFF
--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -3350,7 +3350,8 @@ void viewDrawScreen(void)
             newaspect_enable = 1;
             videoSetCorrectedAspect();
         }
-        renderSetAspect(Blrintf(float(viewingrange) * tanf(gFov * (PI/360.f))), yxaspect);
+        const int viewingRange_fov = Blrintf(float(viewingrange) * tanf(gFov * (PI/360.f)));
+        renderSetAspect(viewingRange_fov, yxaspect);
         int cX = gView->pSprite->x;
         int cY = gView->pSprite->y;
         int cZ = gView->zView;
@@ -3568,6 +3569,7 @@ RORHACKOTHER:
             viewProcessSprites(vd8, vd4, vd0, v50, gInterpolate);
             renderDrawMasks();
             renderRestoreTarget();
+            renderSetAspect(viewingRange_fov, yxaspect);
         }
         else
         {


### PR DESCRIPTION
This PR will fix the fov bug where using the crystal ball powerup will force the default fov to be rendered for the player's current view. After rendering the crystal ball powerup window it'll reset to the current fov.