### PR TITLE
Blood: Don't process already free'd fx sprites

### DIFF
--- a/source/blood/src/fx.cpp
+++ b/source/blood/src/fx.cpp
@@ -205,6 +205,8 @@ void CFX::fxProcess(void)
     for (int nSprite = headspritestat[kStatFX]; nSprite >= 0; nSprite = nextspritestat[nSprite])
     {
         spritetype *pSprite = &sprite[nSprite];
+        if (pSprite->statnum == kStatFree) // skip free'd fx sprite
+            continue;
         viewBackupSpriteLoc(nSprite, pSprite);
         short nSector = pSprite->sectnum;
         dassert(nSector >= 0 && nSector < kMaxSectors);


### PR DESCRIPTION
This PR fixes a rare edge case where it'll try to process sprites that are set to be free'd. This can occur when triggering too many blood sprites on a single tick, which this will cause the game to crash on next tick.