### PR TITLE
Blood: Check if sound is enabled for sndStartWavDisk()

### DIFF
--- a/source/blood/src/sound.cpp
+++ b/source/blood/src/sound.cpp
@@ -365,6 +365,8 @@ void sndKillSound(SAMPLE2D *pChannel)
 
 void sndStartWavDisk(const char *pzFile, int nVolume, int nChannel)
 {
+    if (!SoundToggle)
+        return;
     dassert(nChannel >= -1 && nChannel < kChannelMax);
     SAMPLE2D *pChannel;
     if (nChannel == -1)


### PR DESCRIPTION
This PR will fix a bug where sound will play for sndStartWavDisk() even if the player has sound muted.