### PR TITLE
Blood: Fix green/fire pod behavior

### DIFF
--- a/source/blood/src/actor.cpp
+++ b/source/blood/src/actor.cpp
@@ -5679,29 +5679,22 @@ void actProcessSprites(void)
                             if ((hit&0xc000) == 0x4000)
                             {
                                 actRadiusDamage(actSpriteOwnerToSpriteId(pSprite), pSprite->x, pSprite->y, pSprite->z, pSprite->sectnum, 200, 1, 20, kDamageExplode, 6, 0);
-                                evPost(pSprite->index, 3, 0, kCallbackFXPodBloodSplat);
                             }
                             else
                             {
                                 int nObject = hit & 0x3fff;
-                                if ((hit&0xc000) != 0xc000 && (nObject < 0 || nObject >= 4096))
-                                    break;
-                                dassert(nObject >= 0 && nObject < kMaxSprites);
-                                spritetype *pObject = &sprite[nObject];
-                                actDamageSprite(actSpriteOwnerToSpriteId(pSprite), pObject, kDamageFall, 12);
-                                evPost(pSprite->index, 3, 0, kCallbackFXPodBloodSplat);
+                                if (((hit&0xc000) == 0xc000) || (VanillaMode() && (nObject >= 0 && nObject < 4096)))
+                                {
+                                    dassert(nObject >= 0 && nObject < kMaxSprites);
+                                    spritetype *pObject = &sprite[nObject];
+                                    actDamageSprite(actSpriteOwnerToSpriteId(pSprite), pObject, kDamageFall, 12);
+                                }
                             }
+                            evPost(pSprite->index, 3, 0, kCallbackFXPodBloodSplat);
                             break;
                         case kThingPodFireBall:
-                        {
-                            int nObject = hit & 0x3fff;
-                            if ((hit&0xc000) != 0xc000 && (nObject < 0 || nObject >= 4096))
-                                break;
-                            dassert(nObject >= 0 && nObject < kMaxSprites);
-                            int UNUSED(nOwner) = actSpriteOwnerToSpriteId(pSprite);
                             actExplodeSprite(pSprite);
                             break;
-                        }
                         }
                     }
                 }


### PR DESCRIPTION
This fixes two issues with the current implementation for green/fire pods.

Fire pod:
Fixed issue where it always had to hit a floor surface in order to explode. 1.21 DOS has this set to always explode on any collision hit, which I have correctly matched.

Green pod:
1.21 would only do a range check for whatever it hit (0-4095), and introduced a bug where hitting a wall would then use that wall ID as the sprite index for damage. This has been preserved for vanilla mode flag, and for non-vanilla mode (NBlood) it will check if the hit object is a sprite before applying sprite damage.