### PR TITLE
BLOOD: fix bad menu states by clearing after reset to single player

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,8 @@ xcuserdata/
 project.xcworkspace/
 *.dSYM/
 
+.vscode
+
 .DS_Store
 ._*
 /source/voidwrap/sdk/

--- a/source/blood/src/network.cpp
+++ b/source/blood/src/network.cpp
@@ -163,6 +163,7 @@ void netResetToSinglePlayer(void)
     gGameOptions.nGameType = 0;
     gNetMode = NETWORK_NONE;
     UpdateNetworkMenus();
+    gGameMenuMgr.Deactivate();
 }
 
 void netSendPacket(int nDest, char *pBuffer, int nSize)


### PR DESCRIPTION
If a host or client had menus open when the host killed the game or the last player left, the menu would be the multiplayer menu, but it was no longer valid, and you had to press esc or End Game to get to a legit menu. Similar situation occurred if the host or all players quit while on the multiplayer game configuration menu before starting.

This deactivates the menu when the multiplayer game is reset to single player.  Very useful with [PR 544](https://github.com/nukeykt/NBlood/pull/544) and [PR 543](https://github.com/nukeykt/NBlood/pull/543) applied so client executables don't exit on host game end, and loading the demo doesn't crash.