### PR TITLE
Blood: Don't show keys on HUD for bloodbath/teams mode

### DIFF
--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -1616,10 +1616,13 @@ void UpdateStatusBar(ClockTicks arg)
             DrawStatNumber("%3d", num, kSBarNumberAmmo, 267, 187, 0, 0, 512);
         }
 
-        for (int i = 0; i < 6; i++)
+        if (gGameOptions.nGameType < 2) // don't show keys for bloodbath/teams as all players have every key
         {
-            if (pPlayer->hasKey[i+1])
-                DrawStatMaskedSprite(2552+i, 260+10*i, 170, 0, 0, 512, (int)(65536*0.25));
+            for (int i = 0; i < 6; i++)
+            {
+                if (pPlayer->hasKey[i+1])
+                    DrawStatMaskedSprite(2552+i, 260+10*i, 170, 0, 0, 512, (int)(65536*0.25));
+            }
         }
 
         if (pPlayer->throwPower && pXSprite->health > 0)
@@ -1668,27 +1671,30 @@ void UpdateStatusBar(ClockTicks arg)
         }
         DrawPackItemInStatusBar(pPlayer, 286, 186, 302, 183, 512);
 
-        for (int i = 0; i < 6; i++)
+        if (gGameOptions.nGameType < 2) // don't show keys for bloodbath/teams as all players have every key
         {
-            int nTile = 2220+i;
-            int x, nStat = 0;
-            int y = 200-6;
-            if (i&1)
+            for (int i = 0; i < 6; i++)
             {
-                x = 320-(78+(i>>1)*10);
-                nStat |= 512;
-            }
-            else
-            {
-                x = 73+(i>>1)*10;
-                nStat |= 256;
-            }
-            if (pPlayer->hasKey[i+1])
-                DrawStatSprite(nTile, x, y, 0, 0, nStat);
+                int nTile = 2220+i;
+                int x, nStat = 0;
+                int y = 200-6;
+                if (i&1)
+                {
+                    x = 320-(78+(i>>1)*10);
+                    nStat |= 512;
+                }
+                else
+                {
+                    x = 73+(i>>1)*10;
+                    nStat |= 256;
+                }
+                if (pPlayer->hasKey[i+1])
+                    DrawStatSprite(nTile, x, y, 0, 0, nStat);
 #if 0
-            else
-                DrawStatSprite(nTile, x, y, 40, 5, nStat);
+                else
+                    DrawStatSprite(nTile, x, y, 40, 5, nStat);
 #endif
+            }
         }
         viewDrawStats(pPlayer, 2, 140);
         viewDrawPowerUps(pPlayer);


### PR DESCRIPTION
This PR will add a check to key icon drawing for gViewSize 1/2. Because bloodbath/teams mode equips all key on spawn, there is no reason to show the keys on the HUD. So if the player is using gViewSize 1/2, and is currently in a bloodbath/teams match, it will not draw currently held keys. gViewSize 3 and above (full size HUD) will still draw the currently collected keys.