### PR TITLE
Fix SDL1.2 Target Support

### DIFF
--- a/source/build/include/mutex.h
+++ b/source/build/include/mutex.h
@@ -48,16 +48,18 @@ static FORCE_INLINE void mutex_unlock(mutex_t *mutex)
 #endif
 }
 
+#if SDL_MAJOR_VERSION != 1
 static FORCE_INLINE bool mutex_try(mutex_t *mutex)
 {
 #if SDL_MAJOR_VERSION >= 2
     return SDL_AtomicTryLock(mutex);
 #elif defined _WIN32
     return TryEnterCriticalSection(mutex);
-#elif SDL_MAJOR_VERSION == 1
-    return SDL_TryLockMutex(*mutex);
+#else
+# error No mutex try implementation provided.
 #endif
 }
+#endif
 
 #ifdef __cplusplus
 }

--- a/source/build/src/sdlayer.cpp
+++ b/source/build/src/sdlayer.cpp
@@ -1396,6 +1396,8 @@ void videoGetModes(int display)
 
     modeschecked = 1;
 }
+#else
+void videoGetModes(int display);
 #endif
 
 //
@@ -1457,7 +1459,11 @@ int32_t videoCheckMode(int32_t *x, int32_t *y, int32_t c, int32_t fs, int32_t fo
 
 char const *videoGetDisplayName(int display)
 {
+#if SDL_MAJOR_VERSION >= 2
     return SDL_GetDisplayName(display);
+#else
+    return "Primary display";
+#endif
 }
 
 static void destroy_window_resources()
@@ -1645,7 +1651,9 @@ void setvideomode_sdlcommonpost(int32_t x, int32_t y, int32_t c, int32_t fs, int
     if (regrab)
         mouseGrabInput(g_mouseLockedToWindow);
 
+#if SDL_MAJOR_VERSION >= 2
     g_displayindex = newdisplayindex;
+#endif
 }
 
 #if SDL_MAJOR_VERSION >= 2
@@ -2571,12 +2579,14 @@ int32_t handleevents(void)
     }
 #endif
 
+#if SDL_MAJOR_VERSION >= 2
     if (g_mouseBits & 2 && osd->flags & OSD_CAPTURE && SDL_HasClipboardText())
     {
         auto text = SDL_GetClipboardText();
         OSD_HandleClipboard(text);
         SDL_free(text);
     }
+#endif
 
     if (inputchecked && g_mouseEnabled)
     {
@@ -2633,6 +2643,7 @@ int32_t handleevents(void)
     }
 #endif
 
+#if SDL_MAJOR_VERSION >= 2
     if (!frameplace && sdl_resize.x)
     {
         if (in3dmode())
@@ -2642,6 +2653,7 @@ int32_t handleevents(void)
 
         sdl_resize = {};
     }
+#endif
 
 #ifndef _WIN32
     startwin_idle(NULL);

--- a/source/build/src/sdlayer.cpp
+++ b/source/build/src/sdlayer.cpp
@@ -1396,8 +1396,6 @@ void videoGetModes(int display)
 
     modeschecked = 1;
 }
-#else
-void videoGetModes(int display);
 #endif
 
 //

--- a/source/build/src/sdlayer12.cpp
+++ b/source/build/src/sdlayer12.cpp
@@ -168,7 +168,7 @@ static inline char grabmouse_low(char a)
 #endif
 }
 
-void videoGetModes(void)
+void videoGetModes(int display)
 {
     int32_t i, maxx = 0, maxy = 0;
     int32_t j;


### PR DESCRIPTION
As there is still SDL 1.2 bindings currently present in the codebase this PR will enable the ability to target 1.2 again. While SDL1 has been given EoL status it is still useful for porting to older platforms such as the original Xbox or SGI systems.