### PR TITLE
Blood: Fix ceiling panning angle

### DIFF
--- a/source/blood/src/sectorfx.cpp
+++ b/source/blood/src/sectorfx.cpp
@@ -298,9 +298,9 @@ void DoSectorPanning(void)
                 if (pSector->ceilingstat&64)
                     angle -= 512;
                 int xBits = (picsiz[nTile]&15)-((pSector->ceilingstat&8)!=0);
-                px += mulscale30(speed<<2, Cos(angle))>>xBits;
+                px += mulscale30(speed<<2, Cos(-angle))>>xBits;
                 int yBits = (picsiz[nTile]/16)-((pSector->ceilingstat&8)!=0);
-                py -= mulscale30(speed<<2, Sin(angle))>>yBits;
+                py -= mulscale30(speed<<2, Sin(-angle))>>yBits;
                 pSector->ceilingxpanning = px>>8;
                 pSector->ceilingypanning = py>>8;
                 pXSector->ceilXPanFrac = px&255;


### PR DESCRIPTION
This PR fixes ceiling panning direction when not using the relative flag as seen [in this issue](https://github.com/nukeykt/NBlood/issues/569).