### PR TITLE
Blood: Dim menu background while menu is active and add cryptic menu tile support

### DIFF
--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -1880,7 +1880,7 @@ RESTART:
             if (bDraw)
             {
                 videoClearScreen(0);
-                rotatesprite(160<<16,100<<16,65536,0,2518,0,0,0x4a,0,0,xdim-1,ydim-1);
+                rotatesprite(160<<16,100<<16,65536,0,2518,gGameMenuMgr.m_bActive ? 40 : 0,0,0x4a,0,0,xdim-1,ydim-1);
             }
             if (gQuitRequest && !gQuitGame)
                 netBroadcastMyLogoff(gQuitRequest == 2);

--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -125,6 +125,7 @@ int gQuitRequest;
 bool gPaused;
 bool gSaveGameActive;
 int gCacheMiss;
+int gMenuPicnum = 2518; // default menu picnum
 
 enum gametokens
 {
@@ -1690,6 +1691,9 @@ int app_main(int argc, char const * const * argv)
 
     levelLoadDefaults();
 
+    if (!Bstrcmp(pINISelected->zName, "CRYPTIC.INI")) // if currently selected cryptic passage
+        gMenuPicnum = 2046;
+
     loaddefinitionsfile(BLOODWIDESCREENDEF);
     loaddefinitions_game(BLOODWIDESCREENDEF, FALSE);
 
@@ -1880,7 +1884,7 @@ RESTART:
             if (bDraw)
             {
                 videoClearScreen(0);
-                rotatesprite(160<<16,100<<16,65536,0,2518,gGameMenuMgr.m_bActive ? 40 : 0,0,0x4a,0,0,xdim-1,ydim-1);
+                rotatesprite(160<<16,100<<16,65536,0,gMenuPicnum,gGameMenuMgr.m_bActive ? 40 : 0,0,0x4a,0,0,xdim-1,ydim-1);
             }
             if (gQuitRequest && !gQuitGame)
                 netBroadcastMyLogoff(gQuitRequest == 2);

--- a/source/blood/src/blood.h
+++ b/source/blood/src/blood.h
@@ -70,6 +70,7 @@ extern bool gQuitGame;
 extern int gQuitRequest;
 extern int gCacheMiss;
 extern int gDoQuickSave;
+extern int gMenuPicnum;
 
 void QuitGame(void);
 void PreloadCache(void);

--- a/source/blood/src/credits.cpp
+++ b/source/blood/src/credits.cpp
@@ -119,7 +119,7 @@ void credLogosDos(void)
 
     credReset();
 
-    rotatesprite(160<<16, 100<<16, 65536, 0, 2518, 0, 0, 0x4a, 0, 0, xdim-1, ydim-1);
+    rotatesprite(160<<16, 100<<16, 65536, 0, gMenuPicnum, 0, 0, 0x4a, 0, 0, xdim-1, ydim-1);
     scrNextPage();
     sndStartSample("THUNDER2", 128, -1);
     sndPlaySpecialMusicOrNothing(MUS_INTRO);

--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -1032,6 +1032,7 @@ void SetupLoadGameMenu(void)
     menuLoadGame.Add(&itemLoadGame9, false);
     menuLoadGame.Add(&itemLoadGame10, false);
     menuLoadGame.Add(&itemLoadGamePic, false);
+    itemLoadGamePic.at28 = gMenuPicnum;
     itemLoadGame1.at35 = 0;
     itemLoadGame2.at35 = 0;
     itemLoadGame3.at35 = 0;
@@ -2157,7 +2158,7 @@ void SaveGame(CGameMenuItemZEditBitmap *pItem, CGameMenuEvent *event)
     sprintf(gGameOptions.szSaveGameName, "%s", strSaveGameName);
     restoreGameDifficulty[nSlot] = gGameOptions.nDifficulty;
     gGameOptions.nSaveGameSlot = nSlot;
-    viewLoadingScreen(2518, "Saving", "Saving Your Game", strRestoreGameStrings[nSlot]);
+    viewLoadingScreen(gMenuPicnum, "Saving", "Saving Your Game", strRestoreGameStrings[nSlot]);
     videoNextPage();
     gSaveGameNum = nSlot;
     LoadSave::SaveGame(strSaveGameName);
@@ -2181,7 +2182,7 @@ void QuickSaveGame(void)
     sprintf(gGameOptions.szSaveGameName, "%s", strSaveGameName);
     restoreGameDifficulty[gQuickSaveSlot] = gGameOptions.nDifficulty;
     gGameOptions.nSaveGameSlot = gQuickSaveSlot;
-    viewLoadingScreen(2518, "Saving", "Saving Your Game", strRestoreGameStrings[gQuickSaveSlot]);
+    viewLoadingScreen(gMenuPicnum, "Saving", "Saving Your Game", strRestoreGameStrings[gQuickSaveSlot]);
     videoNextPage();
     LoadSave::SaveGame(strSaveGameName);
     gGameOptions.picEntry = gSavedOffset;
@@ -2201,7 +2202,7 @@ void LoadGame(CGameMenuItemZEditBitmap *pItem, CGameMenuEvent *event)
     G_ModDirSnprintf(strLoadGameName, BMAX_PATH, "game00%02d.sav", nSlot);
     if (!testkopen(strLoadGameName, 0))
         return;
-    viewLoadingScreen(2518, "Loading", "Loading Saved Game", strRestoreGameStrings[nSlot]);
+    viewLoadingScreen(gMenuPicnum, "Loading", "Loading Saved Game", strRestoreGameStrings[nSlot]);
     videoNextPage();
     LoadSave::LoadGame(strLoadGameName);
     gGameMenuMgr.Deactivate();
@@ -2216,7 +2217,7 @@ void QuickLoadGame(void)
     G_ModDirSnprintf(strLoadGameName, BMAX_PATH, "game00%02d.sav", gQuickLoadSlot);
     if (!testkopen(strLoadGameName, 0))
         return;
-    viewLoadingScreen(2518, "Loading", "Loading Saved Game", strRestoreGameStrings[gQuickLoadSlot]);
+    viewLoadingScreen(gMenuPicnum, "Loading", "Loading Saved Game", strRestoreGameStrings[gQuickLoadSlot]);
     videoNextPage();
     LoadSave::LoadGame(strLoadGameName);
     gGameMenuMgr.Deactivate();

--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -2139,6 +2139,45 @@ void TenProcess(CGameMenuItem7EA1C *pItem)
     UNREFERENCED_PARAMETER(pItem);
 }
 
+static void UpdateSaveGameItemText(int nSlot)
+{
+    switch (nSlot) // set save slot text flag
+    {
+    case 0:
+        itemSaveGame1.at37 = 0;
+        break;
+    case 1:
+        itemSaveGame2.at37 = 0;
+        break;
+    case 2:
+        itemSaveGame3.at37 = 0;
+        break;
+    case 3:
+        itemSaveGame4.at37 = 0;
+        break;
+    case 4:
+        itemSaveGame5.at37 = 0;
+        break;
+    case 5:
+        itemSaveGame6.at37 = 0;
+        break;
+    case 6:
+        itemSaveGame7.at37 = 0;
+        break;
+    case 7:
+        itemSaveGame8.at37 = 0;
+        break;
+    case 8:
+        itemSaveGame9.at37 = 0;
+        break;
+    case 9:
+        itemSaveGame10.at37 = 0;
+        break;
+    default:
+        break;
+    }
+}
+
 short gQuickLoadSlot = -1;
 short gQuickSaveSlot = -1;
 
@@ -2165,6 +2204,7 @@ void SaveGame(CGameMenuItemZEditBitmap *pItem, CGameMenuEvent *event)
     gGameOptions.picEntry = gSavedOffset;
     gSaveGameOptions[nSlot] = gGameOptions;
     UpdateSavedInfo(nSlot);
+    UpdateSaveGameItemText(nSlot);
     gGameMenuMgr.Deactivate();
     viewSetMessage("Game saved");
 }
@@ -2189,6 +2229,7 @@ void QuickSaveGame(void)
     gGameOptions.picEntry = gSavedOffset;
     gSaveGameOptions[gQuickSaveSlot] = gGameOptions;
     UpdateSavedInfo(gQuickSaveSlot);
+    UpdateSaveGameItemText(gQuickSaveSlot);
     gGameMenuMgr.Deactivate();
     viewSetMessage("Game saved");
 }

--- a/source/blood/src/network.cpp
+++ b/source/blood/src/network.cpp
@@ -925,7 +925,7 @@ void netInitialize(bool bConsole)
         {
             char buffer[128];
             sprintf(buffer, "Waiting for players (%i\\%i)", numplayers, gNetPlayers);
-            viewLoadingScreen(2518, "Network Game", NULL, buffer);
+            viewLoadingScreen(gMenuPicnum, "Network Game", NULL, buffer);
             videoNextPage();
         }
         while (numplayers < gNetPlayers)
@@ -967,7 +967,7 @@ void netInitialize(bool bConsole)
                     {
                         char buffer[128];
                         sprintf(buffer, "Waiting for players (%i\\%i)", numplayers, gNetPlayers);
-                        viewLoadingScreen(2518, "Network Game", NULL, buffer);
+                        viewLoadingScreen(gMenuPicnum, "Network Game", NULL, buffer);
                         videoNextPage();
                     }
                     break;
@@ -999,7 +999,7 @@ void netInitialize(bool bConsole)
                     {
                         char buffer[128];
                         sprintf(buffer, "Waiting for players (%i\\%i)", numplayers, gNetPlayers);
-                        viewLoadingScreen(2518, "Network Game", NULL, buffer);
+                        viewLoadingScreen(gMenuPicnum, "Network Game", NULL, buffer);
                         videoNextPage();
                     }
                     break;
@@ -1061,7 +1061,7 @@ void netInitialize(bool bConsole)
         initprintf("%s\n", buffer);
         if (!bConsole)
         {
-            viewLoadingScreen(2518, "Network Game", NULL, buffer);
+            viewLoadingScreen(gMenuPicnum, "Network Game", NULL, buffer);
             videoNextPage();
         }
         gNetENetClient = enet_host_create(NULL, 1, BLOOD_ENET_CHANNEL_MAX, 0, 0);
@@ -1086,7 +1086,7 @@ void netInitialize(bool bConsole)
         bool bWaitServer = true;
         if (!bConsole)
         {
-            viewLoadingScreen(2518, "Network Game", NULL, "Waiting for server response");
+            viewLoadingScreen(gMenuPicnum, "Network Game", NULL, "Waiting for server response");
             videoNextPage();
         }
         while (bWaitServer)


### PR DESCRIPTION
This PR will dim the menu background while the menu is active/rendered, and makes reading options easier on the eyes. I've attached a video of this in action.

https://user-images.githubusercontent.com/38839485/155873427-3c417887-ddc2-4bb5-ad01-a4b223b1f50f.mp4


