### PR TITLE
Blood: Initialize viewbob members on player spawn

### DIFF
--- a/source/blood/src/player.cpp
+++ b/source/blood/src/player.cpp
@@ -640,6 +640,15 @@ void playerResetPowerUps(PLAYER* pPlayer)
 
 void playerResetPosture(PLAYER* pPlayer) {
     memcpy(pPlayer->pPosture, gPostureDefaults, sizeof(gPostureDefaults));
+    if (!VanillaMode()) {
+        pPlayer->bobPhase = 0;
+        pPlayer->bobAmp = 0;
+        pPlayer->swayAmp = 0;
+        pPlayer->bobHeight = 0;
+        pPlayer->bobWidth = 0;
+        pPlayer->swayHeight = 0;
+        pPlayer->swayWidth = 0;
+    }
 }
 
 void playerStart(int nPlayer, int bNewLevel)
@@ -859,7 +868,6 @@ void playerReset(PLAYER *pPlayer)
     #endif
     // reset posture (mainly required for resetting movement speed and jump height)
     playerResetPosture(pPlayer);
-
 }
 
 int gPlayerScores[kMaxPlayers];


### PR DESCRIPTION
This PR will reset view/sway members for player initialization function `playerResetPosture()`. Currently if the player is jumping/moving during a level change trigger (such as E1M3) it'll retain the view bob/sway values for the next level, causing the player's view to 'jiggle' on spawn. This PR will initialize the view bob/sway values to 0 on level change and multiplayer spawn reset.