### PR TITLE
Blood: Rename sub_79760() to netResetState()

### DIFF
--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -764,7 +764,7 @@ void StartLevel(GAMEOPTIONS *gameOptions)
     if (!bVanilla && !gMe->packSlots[1].isActive) // if diving suit is not active, turn off reverb sound effect
         sfxSetReverb(0);
     ambInit();
-    sub_79760();
+    netResetState();
     gCacheMiss = 0;
     gFrame = 0;
     gChokeCounter = 0;
@@ -1772,7 +1772,7 @@ int app_main(int argc, char const * const * argv)
         credLogosDos();
     scrSetDac();
 RESTART:
-    sub_79760();
+    netResetState();
     gViewIndex = myconnectindex;
     gMe = gView = &gPlayer[myconnectindex];
     netBroadcastPlayerInfo(myconnectindex);

--- a/source/blood/src/network.cpp
+++ b/source/blood/src/network.cpp
@@ -218,7 +218,7 @@ void netSendPacketAll(char *pBuffer, int nSize)
             netSendPacket(p, pBuffer, nSize);
 }
 
-void sub_79760(void)
+void netResetState(void)
 {
     gNetFifoClock = gFrameClock = totalclock = 0;
     gNetFifoMasterTail = 0;
@@ -887,7 +887,7 @@ void netInitialize(bool bConsole)
 {
     netDeinitialize();
     memset(gPlayerReady, 0, sizeof(gPlayerReady));
-    sub_79760();
+    netResetState();
 #ifndef NETCODE_DISABLE
     char buffer[128];
     gNetENetServer = gNetENetClient = NULL;

--- a/source/blood/src/network.h
+++ b/source/blood/src/network.h
@@ -142,7 +142,7 @@ inline void GetPacketBuffer(char *&p, void *pBuffer, int size)
     p += size;
 }
 
-void sub_79760(void);
+void netResetState(void);
 void netResetToSinglePlayer(void);
 void netBroadcastMessage(int nPlayer, const char *pzMessage);
 void netWaitForEveryone(char a1);


### PR DESCRIPTION
This PR renames network.cpp function `sub_79760()` to the more descriptive `netResetState()`.