### PR TITLE
Blood: Check enemy type when adding to enemy level count

### DIFF
--- a/source/blood/src/aispid.cpp
+++ b/source/blood/src/aispid.cpp
@@ -184,7 +184,7 @@ static void SpidBirthSeqCallback(int, int nXSprite)
         if (pSpawn) {
             pDudeExtraE->birthCounter++;
             pSpawn->owner = nSprite;
-            gKillMgr.AddCount(1);
+            gKillMgr.AddCount(pSpawn);
         }
     }
 

--- a/source/blood/src/aiunicult.cpp
+++ b/source/blood/src/aiunicult.cpp
@@ -259,7 +259,7 @@ static void genDudeAttack1(int, int nXIndex) {
                         aiActivateDude(pSpawned, &xsprite[pSpawned->extra]);
                 }
 
-                gKillMgr.AddCount(1);
+                gKillMgr.AddCount(pSpawned);
                 pExtra->slave[pExtra->slaveCount++] = pSpawned->index;
                 if (!playGenDudeSound(pSprite, kGenDudeSndAttackNormal))
                     sfxPlay3DSoundCP(pSprite, 379, 1, 0, 0x10000 - Random3(0x3000));
@@ -1691,7 +1691,7 @@ spritetype* genDudeSpawn(XSPRITE* pXSource, spritetype* pSprite, int nDist) {
         pDude->yrepeat = pSource->yrepeat;
     }
 
-    gKillMgr.AddCount(1);
+    gKillMgr.AddCount(pDude);
     aiInitSprite(pDude);
     return pDude;
 }

--- a/source/blood/src/endgame.cpp
+++ b/source/blood/src/endgame.cpp
@@ -133,8 +133,16 @@ void CKillMgr::AddCount(int nCount)
     at0 += nCount;
 }
 
+void CKillMgr::AddCount(spritetype* pSprite)
+{
+    dassert(pSprite != NULL);
+    if (pSprite->statnum == kStatDude && pSprite->type != kDudeBat && pSprite->type != kDudeRat && pSprite->type != kDudeInnocent && pSprite->type != kDudeBurningInnocent)
+        at0++;
+}
+
 void CKillMgr::AddKill(spritetype* pSprite)
 {
+    dassert(pSprite != NULL);
     if (pSprite->statnum == kStatDude && pSprite->type != kDudeBat && pSprite->type != kDudeRat && pSprite->type != kDudeInnocent && pSprite->type != kDudeBurningInnocent)
         at4++;
 }
@@ -143,6 +151,7 @@ void CKillMgr::RemoveKill(spritetype* pSprite)
 {
     if (gKillMgr.at4 <= 0)
         return;
+    dassert(pSprite != NULL);
     if (pSprite->statnum == kStatDude && pSprite->type != kDudeBat && pSprite->type != kDudeRat && pSprite->type != kDudeInnocent && pSprite->type != kDudeBurningInnocent)
         at4--;
 }
@@ -155,8 +164,7 @@ void CKillMgr::CountTotalKills(void)
         spritetype* pSprite = &sprite[nSprite];
         if (pSprite->type < kDudeBase || pSprite->type >= kDudeMax)
             ThrowError("Non-enemy sprite (%d) in the enemy sprite list.", nSprite);
-        if (pSprite->statnum == kStatDude && pSprite->type != kDudeBat && pSprite->type != kDudeRat && pSprite->type != kDudeInnocent && pSprite->type != kDudeBurningInnocent)
-            at0++;
+        AddCount(pSprite);
     }
 }
 

--- a/source/blood/src/endgame.h
+++ b/source/blood/src/endgame.h
@@ -41,6 +41,7 @@ public:
     CKillMgr();
     void SetCount(int);
     void AddCount(int);
+    void AddCount(spritetype *pSprite);
     void AddKill(spritetype *pSprite);
     void RemoveKill(spritetype *pSprite);
     void CountTotalKills(void);

--- a/source/blood/src/nnexts.cpp
+++ b/source/blood/src/nnexts.cpp
@@ -338,7 +338,7 @@ spritetype* nnExtSpawnDude(XSPRITE* pXSource, spritetype* pSprite, short nType, 
 
     aiInitSprite(pDude);
 
-    gKillMgr.AddCount(1);
+    gKillMgr.AddCount(pDude);
 
     bool burning = IsBurningDude(pDude);
     if (burning) {

--- a/source/blood/src/triggers.cpp
+++ b/source/blood/src/triggers.cpp
@@ -493,7 +493,7 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, EVENT event)
             spritetype* pSpawn = actSpawnDude(pSprite, pXSprite->data1, -1, 0);
             if (pSpawn) {
                 XSPRITE *pXSpawn = &xsprite[pSpawn->extra];
-                gKillMgr.AddCount(1);
+                gKillMgr.AddCount(pSpawn);
                 switch (pXSprite->data1) {
                     case kDudeBurningInnocent:
                     case kDudeBurningCultist:


### PR DESCRIPTION
This PR adds additional checks to the kill manager class. When adding an enemy it will apply the same check ruleset as CountTotalKills(). This fixes a off by one miscount when blacklisted sprite types are spawned via level trigger or respawned when level is using respawning enemies setting.