### PR TITLE
Blood: Set inittype on actSpawnDude()

### DIFF
--- a/source/blood/src/actor.cpp
+++ b/source/blood/src/actor.cpp
@@ -6167,6 +6167,8 @@ spritetype *actSpawnDude(spritetype *pSource, short nType, int a3, int a4)
         y = pSource->y+mulscale30r(Sin(angle), a3);
     }
     pSprite2->type = nType;
+    if (!VanillaMode())
+        pSprite2->inittype = nType;
     pSprite2->ang = angle;
     vec3_t pos = { x, y, z };
     setsprite(pSprite2->index, &pos);


### PR DESCRIPTION
This PR changes `actSpawnDude()` to set the sprite property `inittype` for newly spawned dudes. The current behavior for spawn dudes will not set `inittype`, and the water cultist fix that relies on `inittype` will not work ([actor.cpp](https://github.com/nukeykt/NBlood/blob/1717c943be602cd8d4412ffafb6f632a5fd9efe4/source/blood/src/actor.cpp#L4868)).

I've also tested and confirmed that the PR does not change the respawning behavior for spawned enemies, as `actSpawnDude()` [sets the respawn variable to ignore](https://github.com/nukeykt/NBlood/blob/1717c943be602cd8d4412ffafb6f632a5fd9efe4/source/blood/src/actor.cpp#L6176) (this was a fix introduced in https://github.com/nukeykt/NBlood/commit/9e787bd8e00a9f826747a1414e4d3de88dc3c6f6).