### PR TITLE
Blood: Reset thinkTime for kDudeModernCustomDude initializing

### DIFF
--- a/source/blood/src/aiunicult.cpp
+++ b/source/blood/src/aiunicult.cpp
@@ -2192,7 +2192,7 @@ void aiGenDudeInitSprite(spritetype* pSprite, XSPRITE* pXSprite) {
     switch (pSprite->type) {
         case kDudeModernCustom: {
             DUDEEXTRA_STATS* pDudeExtraE = &gDudeExtra[pSprite->extra].stats;
-            pDudeExtraE->active = 0;
+            pDudeExtraE->active = pDudeExtraE->thinkTime = 0;
             aiGenDudeNewState(pSprite, &genDudeIdleL);
             break;
         }


### PR DESCRIPTION
This PR fixes an error introduced in commit https://github.com/nukeykt/NBlood/commit/08c35968b11f04f49d42477f29c3cbbd06ac4cd7.

Function `aiGenDudeInitSprite()` originally reset thinkTime for kDudeModernCustom, however I skimmed over this by accident when refactoring dudeExtra structure.