### PR TITLE
Fix videoSetGamma() for SDL1 target

### DIFF
--- a/source/build/src/sdlayer.cpp
+++ b/source/build/src/sdlayer.cpp
@@ -2059,13 +2059,13 @@ int32_t videoSetGamma(void)
 
     if (sdl_window)
         i = SDL_SetWindowGammaRamp(sdl_window, &gammaTable[0], &gammaTable[256], &gammaTable[512]);
-#else
-    i = SDL_SetGammaRamp(&gammaTable[0], &gammaTable[256], &gammaTable[512]);
-    if (i != -1)
-#endif
-
     if (i < 0)
     {
+#else
+    i = SDL_SetGammaRamp(&gammaTable[0], &gammaTable[256], &gammaTable[512]);
+    if ((i != -1) && (i < 0))
+    {
+#endif
         if (i != INT32_MIN)
             LOG_F(ERROR, "Failed setting window gamma ramp: %s.", SDL_GetError());
 


### PR DESCRIPTION
This PR fixes SDL 1 target for videoSetGamma(). Due to the non-bracketed if statement it would not properly set the gamma on first launch for SDL 1 builds.