### PR TITLE
Blood: Fix intro playback video

### DIFF
--- a/source/blood/src/credits.cpp
+++ b/source/blood/src/credits.cpp
@@ -103,7 +103,8 @@ void credLogosDos(void)
         }
     }
 
-    credReset();
+    if (videoGetRenderMode() == REND_CLASSIC)
+        credReset();
 
     if (!credPlaySmk("GTI.SMK", "gti.wav", 301) && !credPlaySmk("movie/GTI.SMK", "movie/gti.wav", 301))
     {
@@ -198,12 +199,7 @@ char credPlaySmk(const char *_pzSMK, const char *_pzWAV, int nWav)
     }
     uint32_t nWidth, nHeight;
     Smacker_GetFrameSize(hSMK, nWidth, nHeight);
-    uint8_t palette[768];
-    uint8_t *pFrame = (uint8_t*)Xmalloc(nWidth*nHeight);
-    walock[kSMKTile] = CACHE1D_PERMANENT;
-    waloff[kSMKTile] = (intptr_t)pFrame;
-    tileSetSize(kSMKTile, nHeight, nWidth);
-
+    uint8_t *pFrame = (uint8_t*)Xcalloc(1,nWidth*nHeight);
     if (!pFrame)
     {
         Smacker_Close(hSMK);
@@ -211,9 +207,22 @@ char credPlaySmk(const char *_pzSMK, const char *_pzWAV, int nWav)
         Xfree(pzWAV_);
         return FALSE;
     }
+
     int nFrameRate = Smacker_GetFrameRate(hSMK);
     int nFrames = Smacker_GetNumFrames(hSMK);
+    if (!nFrames || !nFrameRate)
+    {
+        Smacker_Close(hSMK);
+        Xfree(pzSMK_);
+        Xfree(pzWAV_);
+        return FALSE;
+    }
 
+    walock[kSMKTile] = CACHE1D_PERMANENT;
+    waloff[kSMKTile] = (intptr_t)pFrame;
+    tileSetSize(kSMKTile, nHeight, nWidth);
+
+    uint8_t palette[768];
     Smacker_GetPalette(hSMK, palette);
     paletteSetColorTable(kSMKPal, palette);
     videoSetPalette(gBrightness>>2, kSMKPal, 8+2);


### PR DESCRIPTION
This PR adds additional memory checks to `credLogosDos()` as well as fixing the glitched palette bug that occurs when using an OpenGL renderer (polymost/polymer). For the second intro video playback it'll display one glitched frame. This issue was introduced in commit https://github.com/nukeykt/NBlood/commit/869d85ea10f69b037b51d5aeb5f0232a73379a5a.

![The problem.jpg](https://user-images.githubusercontent.com/38839485/158322525-02bfc565-b9bf-4dc9-b9c8-56be3c62882d.jpg)