### PR TITLE
Blood: Store net_address/net_port as CVARs

### DIFF
--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -699,7 +699,7 @@ void NetworkHostGame(CGameMenuItemChain *pItem);
 void NetworkJoinGame(CGameMenuItemChain *pItem);
 
 char zNetAddressBuffer[16] = "localhost";
-char zNetPortBuffer[6];
+char zNetPortBuffer[6] = "23513";
 
 CGameMenuItemTitle itemNetworkTitle("MULTIPLAYER", 1, 160, 20, 2038);
 CGameMenuItemChain itemNetworkHost("HOST A GAME", 1, 0, 80, 320, 1, &menuNetworkHost, -1, SetupNetworkHostMenu, 0);
@@ -2078,7 +2078,6 @@ void SetupMouseButtonMenu(CGameMenuItemChain *pItem)
 
 void SetupNetworkMenu(void)
 {
-    sprintf(zNetPortBuffer, "%d", gNetPort);
     if (strlen(gNetAddress) > 0)
         strncpy(zNetAddressBuffer, gNetAddress, sizeof(zNetAddressBuffer)-1);
 

--- a/source/blood/src/menu.h
+++ b/source/blood/src/menu.h
@@ -54,6 +54,8 @@ extern short gQuickSaveSlot;
 extern char strRestoreGameStrings[][16];
 extern char restoreGameDifficulty[];
 extern const char *zDiffStrings[];
+extern char zNetAddressBuffer[16];
+extern char zNetPortBuffer[6];
 extern char zUserMapName[BMAX_PATH];
 void drawLoadingScreen(void);
 void SetupMenus(void);

--- a/source/blood/src/osdcmd.cpp
+++ b/source/blood/src/osdcmd.cpp
@@ -37,6 +37,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "gamemenu.h"
 #include "globals.h"
 #include "levels.h"
+#include "menu.h"
 #include "messages.h"
 #include "network.h"
 #include "osdcmds.h"
@@ -1045,6 +1046,8 @@ int32_t registerosdcommands(void)
         { "mus_volume", "controls music volume", (void *)&MusicVolume, CVAR_INT, 0, 255 },
         { "mus_device", "music device", (void *)&MusicDevice, CVAR_INT, 0, ASS_NumSoundCards },
         { "mus_redbook", "enables/disables redbook audio", (void *)&CDAudioToggle, CVAR_BOOL, 0, 1 },
+        { "net_address","sets network address used for multiplayer", (void *)zNetAddressBuffer, CVAR_STRING|CVAR_FUNCPTR, 0, 16 },
+        { "net_port","sets network port used for multiplayer", (void *)zNetPortBuffer, CVAR_STRING|CVAR_FUNCPTR, 0, 6 },
 //
 //        { "osdhightile", "enable/disable hires art replacements for console text", (void *)&osdhightile, CVAR_BOOL, 0, 1 },
 //        { "osdscale", "adjust console text size", (void *)&osdscale, CVAR_FLOAT|CVAR_FUNCPTR, 1, 4 },


### PR DESCRIPTION
This PR reimplements the PR https://github.com/nukeykt/NBlood/pull/562 as CVARs. Using OSD it'll automatically save and load the last used network port and address on load.