### PR TITLE
Blood: Fix map scroll not using forward/backwards input

### DIFF
--- a/source/blood/src/controls.cpp
+++ b/source/blood/src/controls.cpp
@@ -501,7 +501,7 @@ void ctrlGetInput(void)
     if (!gViewMap.bFollowMode && gViewMode == 4)
     {
         gViewMap.turn += input.q16turn<<2;
-        gViewMap.forward += gMouseAim ? gInput.forward : clamp(gInput.forward + fix16_sadd(input.forward, fix16_sdiv(fix16_from_int(-info.mousey), F16(8192))), -2048, 2048);
+        gViewMap.forward += gMouseAim ? input.forward : clamp(fix16_sadd(input.forward, fix16_sdiv(fix16_from_int(-info.mousey), F16(8192))), -2048, 2048);
         gViewMap.strafe += input.strafe;
         input.q16turn = 0;
         input.forward = 0;


### PR DESCRIPTION
This fixes 2D map mode not using forwards/backwards input while in scroll mode, which matches the same behavior as 1.21 DOS.