### PR TITLE
Blood: Update player angold for modern kMarkerWarpDest types

### DIFF
--- a/source/blood/src/nnexts.cpp
+++ b/source/blood/src/nnexts.cpp
@@ -2806,7 +2806,7 @@ void useTeleportTarget(XSPRITE* pXSource, spritetype* pSprite) {
 
     if (pXSource->data2 == 1) {
         
-        if (pPlayer) pPlayer->q16ang = fix16_from_int(pSource->ang);
+        if (pPlayer) pPlayer->q16ang = fix16_from_int(pSource->ang), pPlayer->angold = pSource->ang;
         else if (isDude) xsprite[pSprite->extra].goalAng = pSprite->ang = pSource->ang;
         else pSprite->ang = pSource->ang;
     }


### PR DESCRIPTION
This PR updates angold for modern level teleports to prevent turn interpolation for the current tick. The same fix was applied in commit https://github.com/nukeykt/NBlood/commit/6902fc73eaecfa2cd049970d8b69f8808aee897b for default teleporter triggers.