### PR TITLE
Blood: Use damage constants

### DIFF
--- a/source/blood/src/actor.cpp
+++ b/source/blood/src/actor.cpp
@@ -2556,8 +2556,8 @@ void actInit(bool bSaveLoad) {
         ///////////////
 
         for (int i = 0; i < kDudeMax - kDudeBase; i++)
-            for (int j = 0; j < 7; j++)
-                dudeInfo[i].at70[j] = mulscale8(DudeDifficulty[gGameOptions.nDifficulty], dudeInfo[i].startDamage[j]);
+            for (int j = 0; j < kDamageMax; j++)
+                dudeInfo[i].curDamage[j] = mulscale8(DudeDifficulty[gGameOptions.nDifficulty], dudeInfo[i].startDamage[j]);
 
         for (int nSprite = headspritestat[kStatDude]; nSprite >= 0; nSprite = nextspritestat[nSprite]) {
             if (sprite[nSprite].extra <= 0 || sprite[nSprite].extra >= kMaxXSprites) continue;
@@ -3541,7 +3541,7 @@ int actDamageSprite(int nSource, spritetype *pSprite, DAMAGE_TYPE damageType, in
                 //ThrowError("Bad Dude Failed: initial=%d type=%d %s\n", (int)pSprite->inittype, (int)pSprite->type, (int)(pSprite->flags & 16) ? "RESPAWN" : "NORMAL");
             }
 
-            int nType = pSprite->type - kDudeBase; int nDamageFactor = getDudeInfo(nType+kDudeBase)->at70[damageType];
+            int nType = pSprite->type - kDudeBase; int nDamageFactor = getDudeInfo(nType+kDudeBase)->curDamage[damageType];
             #ifdef NOONE_EXTENSIONS
             if (pSprite->type == kDudeModernCustom)
                 nDamageFactor = gGenDudeExtra[pSprite->index].dmgControl[damageType];
@@ -3741,7 +3741,7 @@ void actImpactMissile(spritetype *pMissile, int hitCode)
                 DAMAGE_TYPE rand1 = (DAMAGE_TYPE)Random(7);
                 int rand2 = (7 + Random(7)) << 4;
                 int nDamage = actDamageSprite(nOwner, pSpriteHit, rand1, rand2);
-                if ((pThingInfo && pThingInfo->dmgControl[kDamageBurn] != 0) || (pDudeInfo && pDudeInfo->at70[kDamageBurn] != 0))
+                if ((pThingInfo && pThingInfo->dmgControl[kDamageBurn] != 0) || (pDudeInfo && pDudeInfo->curDamage[kDamageBurn] != 0))
                     actBurnSprite(pMissile->owner, pXSpriteHit, 360);
 
                 // by NoOne: make Life Leech heal user, just like it was in 1.0x versions
@@ -3833,7 +3833,7 @@ void actImpactMissile(spritetype *pMissile, int hitCode)
             sfxKill3DSound(pMissile, -1, -1);
             if ((hitCode == 3 && pSpriteHit) && (pThingInfo || pDudeInfo)) {
                 int nOwner = actSpriteOwnerToSpriteId(pMissile);
-                if ((pThingInfo && pThingInfo->dmgControl[kDamageBurn] != 0) || (pDudeInfo && pDudeInfo->at70[kDamageBurn] != 0)) {
+                if ((pThingInfo && pThingInfo->dmgControl[kDamageBurn] != 0) || (pDudeInfo && pDudeInfo->curDamage[kDamageBurn] != 0)) {
                     if (pThingInfo && pSpriteHit->type == kThingTNTBarrel && pXSpriteHit->burnTime == 0)
                         evPost(nSpriteHit, 3, 0, kCallbackFXFlameLick);
                 

--- a/source/blood/src/ai.cpp
+++ b/source/blood/src/ai.cpp
@@ -127,7 +127,7 @@ bool isImmune(spritetype* pSprite, int dmgType, int minScale) {
             return (thingInfo[pSprite->type - kThingBase].dmgControl[dmgType] <= minScale);
         else if (IsDudeSprite(pSprite)) {
             if (IsPlayerSprite(pSprite)) return (gPlayer[pSprite->type - kDudePlayer1].damageControl[dmgType] <= minScale);
-            else return (dudeInfo[pSprite->type - kDudeBase].at70[dmgType] <= minScale);
+            else return (dudeInfo[pSprite->type - kDudeBase].curDamage[dmgType] <= minScale);
         }
     }
 

--- a/source/blood/src/dude.h
+++ b/source/blood/src/dude.h
@@ -21,6 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 //-------------------------------------------------------------------------
 #pragma once
+#include "actor.h"
 #include "blood.h"
 struct DUDEINFO {
     short seqStartID; // seq
@@ -45,8 +46,8 @@ struct DUDEINFO {
     int backSpeed; // backward speed (unused)
     int angSpeed; // turn speed
     int nGibType[3]; // which gib used when explode dude
-    int startDamage[7]; // start damage shift
-    int at70[7]; // real damage? Hmm?
+    int startDamage[kDamageMax]; // start damage shift
+    int curDamage[kDamageMax]; // current damage stat (post-shift)
     int at8c; // unused ?
     int at90; // unused ?
 };

--- a/source/blood/src/messages.cpp
+++ b/source/blood/src/messages.cpp
@@ -114,7 +114,7 @@ void SetAmmo(bool stat)
 
 void SetWeapons(bool stat)
 {
-    for (int i = 0; i < 14; i++)
+    for (int i = 0; i < kWeaponMax; i++)
     {
         gMe->hasWeapon[i] = stat;
     }

--- a/source/blood/src/nnexts.cpp
+++ b/source/blood/src/nnexts.cpp
@@ -524,7 +524,7 @@ bool nnExtIsImmune(spritetype* pSprite, int dmgType, int minScale) {
         else if (IsDudeSprite(pSprite)) {
             if (IsPlayerSprite(pSprite)) return (gPlayer[pSprite->type - kDudePlayer1].damageControl[dmgType]);
             else if (pSprite->type == kDudeModernCustom) return (gGenDudeExtra[pSprite->index].dmgControl[dmgType] <= minScale);
-            else return (getDudeInfo(pSprite->type)->at70[dmgType] <= minScale);
+            else return (getDudeInfo(pSprite->type)->curDamage[dmgType] <= minScale);
         }
     }
 
@@ -2194,7 +2194,7 @@ void trPlayerCtrlEraseStuff(XSPRITE* pXSource, PLAYER* pPlayer) {
         case 1: // erase weapons
             WeaponLower(pPlayer);
 
-            for (int i = 0; i < 14; i++) {
+            for (int i = 0; i < kWeaponMax; i++) {
                 pPlayer->hasWeapon[i] = false;
                 // also erase ammo
                 if (i < 12) pPlayer->ammoCount[i] = 0;

--- a/source/blood/src/player.cpp
+++ b/source/blood/src/player.cpp
@@ -300,26 +300,26 @@ char powerupActivate(PLAYER *pPlayer, int nPowerUp)
         #endif
         case kItemFeatherFall:
         case kItemJumpBoots:
-            pPlayer->damageControl[0]++;
+            pPlayer->damageControl[kDamageFall]++;
             break;
         case kItemReflectShots: // reflective shots
             if (pPlayer == gMe && gGameOptions.nGameType == 0)
                 sfxSetReverb2(1);
             break;
         case kItemDeathMask:
-            for (int i = 0; i < 7; i++)
+            for (int i = 0; i < kDamageMax; i++)
                 pPlayer->damageControl[i]++;
             break;
         case kItemDivingSuit: // diving suit
-            pPlayer->damageControl[4]++;
+            pPlayer->damageControl[kDamageDrown]++;
             if (pPlayer == gMe && gGameOptions.nGameType == 0)
                 sfxSetReverb(1);
             break;
         case kItemGasMask:
-            pPlayer->damageControl[4]++;
+            pPlayer->damageControl[kDamageDrown]++;
             break;
         case kItemArmorAsbest:
-            pPlayer->damageControl[1]++;
+            pPlayer->damageControl[kDamageBurn]++;
             break;
         case kItemTwoGuns:
             pPlayer->input.newWeapon = pPlayer->curWeapon;
@@ -351,15 +351,15 @@ void powerupDeactivate(PLAYER *pPlayer, int nPowerUp)
         #endif
         case kItemFeatherFall:
         case kItemJumpBoots:
-            pPlayer->damageControl[0]--;
+            pPlayer->damageControl[kDamageFall]--;
             break;
         case kItemDeathMask:
-            for (int i = 0; i < 7; i++)
+            for (int i = 0; i < kDamageMax; i++)
                 pPlayer->damageControl[i]--;
             break;
         case kItemDivingSuit:
-            pPlayer->damageControl[4]--;
-            if (pPlayer == gMe && VanillaMode() ? true : pPlayer->pwUpTime[24] == 0)
+            pPlayer->damageControl[kDamageDrown]--;
+            if ((pPlayer == gMe) && (VanillaMode() || !powerupCheck(pPlayer, kPwUpReflectShots)))
                 sfxSetReverb(0);
             break;
         case kItemReflectShots:
@@ -367,10 +367,10 @@ void powerupDeactivate(PLAYER *pPlayer, int nPowerUp)
                 sfxSetReverb(0);
             break;
         case kItemGasMask:
-            pPlayer->damageControl[4]--;
+            pPlayer->damageControl[kDamageDrown]--;
             break;
         case kItemArmorAsbest:
-            pPlayer->damageControl[1]--;
+            pPlayer->damageControl[kDamageBurn]--;
             break;
         case kItemTwoGuns:
             pPlayer->input.newWeapon = pPlayer->curWeapon;
@@ -595,20 +595,20 @@ void playerSetRace(PLAYER *pPlayer, int nLifeMode)
     // By NoOne: don't forget to change clipdist for grow and shrink modes
     pPlayer->pSprite->clipdist = pDudeInfo->clipdist;
     
-    for (int i = 0; i < 7; i++)
-        pDudeInfo->at70[i] = mulscale8(Handicap[gProfile[pPlayer->nPlayer].skill], pDudeInfo->startDamage[i]);
+    for (int i = 0; i < kDamageMax; i++)
+        pDudeInfo->curDamage[i] = mulscale8(Handicap[gProfile[pPlayer->nPlayer].skill], pDudeInfo->startDamage[i]);
 }
 
 void playerSetGodMode(PLAYER *pPlayer, char bGodMode)
 {
     if (bGodMode)
     {
-        for (int i = 0; i < 7; i++)
+        for (int i = 0; i < kDamageMax; i++)
             pPlayer->damageControl[i]++;
     }
     else
     {
-        for (int i = 0; i < 7; i++)
+        for (int i = 0; i < kDamageMax; i++)
             pPlayer->damageControl[i]--;
     }
     pPlayer->godMode = bGodMode;
@@ -754,7 +754,7 @@ void playerStart(int nPlayer, int bNewLevel)
     pPlayer->hasFlag = 0;
     for (int i = 0; i < 8; i++)
         pPlayer->used2[i] = -1;
-    for (int i = 0; i < 7; i++)
+    for (int i = 0; i < kDamageMax; i++)
         pPlayer->damageControl[i] = 0;
     if (pPlayer->godMode)
         playerSetGodMode(pPlayer, 1);
@@ -830,7 +830,7 @@ void playerReset(PLAYER *pPlayer)
         3, 4, 2, 8, 9, 10, 7, 1, 1, 1, 1, 1, 1, 1
     };
     dassert(pPlayer != NULL);
-    for (int i = 0; i < 14; i++)
+    for (int i = 0; i < kWeaponMax; i++)
     {
         pPlayer->hasWeapon[i] = gInfiniteAmmo;
         pPlayer->weaponMode[i] = 0;
@@ -839,7 +839,7 @@ void playerReset(PLAYER *pPlayer)
     pPlayer->curWeapon = kWeaponNone;
     pPlayer->qavCallback = -1;
     pPlayer->input.newWeapon = kWeaponPitchfork;
-    for (int i = 0; i < 14; i++)
+    for (int i = 0; i < kWeaponMax; i++)
     {
         pPlayer->weaponOrder[0][i] = dword_136400[i];
         pPlayer->weaponOrder[1][i] = dword_136438[i];

--- a/source/blood/src/player.h
+++ b/source/blood/src/player.h
@@ -143,7 +143,7 @@ struct PLAYER
     bool                hasKey[8];
     char                hasFlag;
     short               used2[8];  // ??
-    int                 damageControl[7];
+    int                 damageControl[kDamageMax];
     char                curWeapon;
     char                nextWeapon;
     int                 weaponTimer;


### PR DESCRIPTION
This PR renames dude info struct member at70 to curDamage, which holds the currently shifted damage values for the game session, as well as using constants to access curDamage array.