### PR TITLE
Blood: Tweak ROR sprite cstat behavior

### DIFF
--- a/source/blood/src/mirrors.cpp
+++ b/source/blood/src/mirrors.cpp
@@ -420,11 +420,11 @@ void DrawMirrors(int x, int y, int z, fix16_t a, fix16_t horiz, int smooth, int 
                     bakCstat = gPlayer[viewPlayer].pSprite->cstat;
                     if (gViewPos == 0)
                     {
-                        gPlayer[viewPlayer].pSprite->cstat |= 32768;
+                        gPlayer[viewPlayer].pSprite->cstat |= CSTAT_SPRITE_INVISIBLE;
                     }
                     else
                     {
-                        gPlayer[viewPlayer].pSprite->cstat |= 514;
+                        gPlayer[viewPlayer].pSprite->cstat |= CSTAT_SPRITE_TRANSLUCENT_INVERT | CSTAT_SPRITE_TRANSLUCENT;
                     }
                 }
 #ifdef POLYMER
@@ -462,11 +462,11 @@ void DrawMirrors(int x, int y, int z, fix16_t a, fix16_t horiz, int smooth, int 
                     bakCstat = gPlayer[viewPlayer].pSprite->cstat;
                     if (gViewPos == 0)
                     {
-                        gPlayer[viewPlayer].pSprite->cstat |= 32768;
+                        gPlayer[viewPlayer].pSprite->cstat |= CSTAT_SPRITE_INVISIBLE;
                     }
                     else
                     {
-                        gPlayer[viewPlayer].pSprite->cstat |= 514;
+                        gPlayer[viewPlayer].pSprite->cstat |= CSTAT_SPRITE_TRANSLUCENT_INVERT | CSTAT_SPRITE_TRANSLUCENT;
                     }
                 }
 #ifdef POLYMER

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -3497,7 +3497,7 @@ void viewDrawScreen(void)
         {
             CalcPosition(gView->pSprite, (int*)&cX, (int*)&cY, (int*)&cZ, &nSectnum, fix16_to_int(cA), q16horiz);
         }
-        CheckLink((int*)&cX, (int*)&cY, (int*)&cZ, &nSectnum);
+        const char bLink = CheckLink((int*)&cX, (int*)&cY, (int*)&cZ, &nSectnum);
         int v78 = gViewInterpolate ? interpolateang(gScreenTiltO, gScreenTilt, gInterpolate) : gScreenTilt;
         char v14 = 0;
         char v10 = 0;
@@ -3694,15 +3694,15 @@ RORHACK:
         for (int i = 0; i < 16; i++)
             ror_status[i] = TestBitString(gotpic, 4080+i);
         fix16_t deliriumPitchI = gViewInterpolate ? interpolate(fix16_from_int(deliriumPitchO), fix16_from_int(deliriumPitch), gInterpolate) : fix16_from_int(deliriumPitch);
-        DrawMirrors(cX, cY, cZ, cA, q16horiz + fix16_from_int(defaultHoriz) + deliriumPitchI, gInterpolate, gViewIndex);
+        DrawMirrors(cX, cY, cZ, cA, q16horiz + fix16_from_int(defaultHoriz) + deliriumPitchI, gInterpolate, bLink && !VanillaMode() ? gViewIndex : -1); // only hide self sprite while traversing between sector
         int bakCstat = gView->pSprite->cstat;
-        if (gViewPos == 0)
+        if (gViewPos == 0) // don't render self while in first person view
         {
-            gView->pSprite->cstat |= 32768;
+            gView->pSprite->cstat |= CSTAT_SPRITE_INVISIBLE;
         }
-        else
+        else // chase camera - render as transparent
         {
-            gView->pSprite->cstat |= 514;
+            gView->pSprite->cstat |= CSTAT_SPRITE_TRANSLUCENT_INVERT | CSTAT_SPRITE_TRANSLUCENT;
         }
 #ifdef POLYMER
         if (videoGetRenderMode() == REND_POLYMER)


### PR DESCRIPTION
This PR changes the behavior used for viewing player sprites across ror sectors, such as when transitioning between ror. After comparing with 1.21 on a custom level it should appear to be more accurate now.