### PR TITLE
Blood: Implemented joystick support

### DIFF
--- a/source/blood/src/_functio.h
+++ b/source/blood/src/_functio.h
@@ -231,12 +231,13 @@ static const char * mouseclickeddefaults[MAXMOUSEBUTTONS] =
    {
    };
 
-
+#if 0
 static const char * mouseanalogdefaults[MAXMOUSEAXES] =
    {
    "analog_turning",
    "analog_moving",
    };
+#endif
 
 #if defined(GEKKO)
 static const char * joystickdefaults[MAXJOYBUTTONSANDHATS] =
@@ -292,75 +293,6 @@ static const char * joystickanalogdefaults[MAXJOYAXES] =
 
 static const char * joystickdigitaldefaults[MAXJOYDIGITAL] =
    {
-   };
-#else
-static const char * joystickdefaults[MAXJOYBUTTONSANDHATS] =
-   {
-   "Fire",
-   "Strafe",
-   "Run",
-   "Open",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "Aim_Down",
-   "Look_Right",
-   "Aim_Up",
-   "Look_Left",
-   };
-
-
-static const char * joystickclickeddefaults[MAXJOYBUTTONSANDHATS] =
-   {
-   "",
-   "Inventory",
-   "Jump",
-   "Crouch",
-   };
-
-
-static const char * joystickanalogdefaults[MAXJOYAXES] =
-   {
-   "analog_turning",
-   "analog_moving",
-   "analog_strafing",
-   };
-
-
-static const char * joystickdigitaldefaults[MAXJOYDIGITAL] =
-   {
-   "",
-   "",
-   "",
-   "",
-   "",
-   "",
-   "Run",
    };
 #endif
 

--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -994,6 +994,27 @@ void LocalKeys(void)
             break;
         }
     }
+    else if (CONTROL_JoystickEnabled)
+    {
+        static int32_t joyold = 0;
+        int32_t joy = JOYSTICK_GetControllerButtons() == (1 << CONTROLLER_BUTTON_START);
+        if (joy && !joyold)
+        {
+            JOYSTICK_ClearAllButtons();
+            if (gGameStarted && (gPlayer[myconnectindex].pXSprite->health != 0 || gGameOptions.nGameType > 0))
+            {
+                if (!gGameMenuMgr.m_bActive)
+                    gGameMenuMgr.Push(&menuMainWithSave,-1);
+            }
+            else
+            {
+                if (!gGameMenuMgr.m_bActive)
+                    gGameMenuMgr.Push(&menuMain,-1);
+            }
+        }
+        joyold = joy;
+        return;
+    }
 }
 
 bool gRestartGame = false;

--- a/source/blood/src/config.h
+++ b/source/blood/src/config.h
@@ -45,6 +45,7 @@ extern int32_t JoystickAnalogueAxes[MAXJOYAXES];
 extern int32_t JoystickAnalogueScale[MAXJOYAXES];
 extern int32_t JoystickAnalogueDead[MAXJOYAXES];
 extern int32_t JoystickAnalogueSaturate[MAXJOYAXES];
+extern int32_t JoystickAnalogueInvert[MAXJOYAXES];
 extern uint8_t KeyboardKeys[NUMGAMEFUNCTIONS][2];
 extern int32_t scripthandle;
 extern int32_t setupread;

--- a/source/blood/src/controls.cpp
+++ b/source/blood/src/controls.cpp
@@ -477,18 +477,25 @@ void ctrlGetInput(void)
     else
         input.q16turn = fix16_sadd(input.q16turn, fix16_sdiv(fix16_from_int(info.mousex), F16(32)));
 
-    input.strafe -= -(info.dx<<5);
-
-#if 0
-    if (info.dz < 0)
-        gInput.mlook = ClipRange((info.dz+127)>>7, -127, 127);
-    else
-        gInput.mlook = ClipRange(info.dz>>7, -127, 127);
-#endif
     if (gMouseAim)
         input.q16mlook = fix16_sadd(input.q16mlook, fix16_sdiv(fix16_from_int(info.mousey), F16(128)));
     else
         input.forward -= info.mousey;
+
+    if (CONTROL_JoystickEnabled) // controller input
+    {
+        input.strafe -= info.dx>>1;
+        input.forward -= info.dz>>1;
+        if (info.mousey == 0)
+        {
+            if (gMouseAim)
+                input.q16mlook = fix16_sadd(input.q16mlook, fix16_sdiv(fix16_from_int(info.dpitch>>4), F16(128)));
+            else
+                input.forward -= info.dpitch>>1;
+        }
+        if (input.q16turn == 0)
+            input.q16turn = fix16_sadd(input.q16mlook, fix16_sdiv(fix16_from_int(info.dyaw>>4), F16(32)));
+    }
     if (!gMouseAimingFlipped)
         input.q16mlook = -input.q16mlook;
 

--- a/source/blood/src/credits.cpp
+++ b/source/blood/src/credits.cpp
@@ -36,13 +36,26 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "sound.h"
 #include "view.h"
 
+inline char keyJoyGetScan(void)
+{
+    char ch = keyGetScan();
+    if (CONTROL_JoystickEnabled && !ch)
+    {
+        int32_t joy = JOYSTICK_GetControllerButtons();
+        JOYSTICK_ClearAllButtons();
+        if ((joy == (1 << CONTROLLER_BUTTON_A)) || (joy == (1 << CONTROLLER_BUTTON_B)) || (joy == (1 << CONTROLLER_BUTTON_START)))
+            ch = 1;
+    }
+    return ch;
+}
+
 char Wait(int nTicks)
 {
     totalclock = 0;
     while (totalclock < nTicks)
     {
         gameHandleEvents();
-        if (keyGetScan())
+        if (keyJoyGetScan())
             return FALSE;
     }
     return TRUE;
@@ -59,7 +72,7 @@ char DoFade(char r, char g, char b, int nTicks)
         gFrameClock += 2;
         scrNextPage();
         scrFadeAmount(divscale16(ClipHigh((int)totalclock, nTicks), nTicks));
-        if (keyGetScan())
+        if (keyJoyGetScan())
             return FALSE;
     } while (totalclock <= nTicks);
     return TRUE;
@@ -76,7 +89,7 @@ char DoUnFade(int nTicks)
         gFrameClock += 2;
         scrNextPage();
         scrFadeAmount(0x10000-divscale16(ClipHigh((int)totalclock, nTicks), nTicks));
-        if (keyGetScan())
+        if (keyJoyGetScan())
             return FALSE;
     } while (totalclock <= nTicks);
     return TRUE;

--- a/source/blood/src/demo.cpp
+++ b/source/blood/src/demo.cpp
@@ -318,24 +318,39 @@ void CDemo::ProcessKeys(void)
         char nKey;
         while ((nKey = keyGetScan()) != 0)
         {
-	        char UNUSED(alt) = keystatus[0x38] | keystatus[0xb8];
-	        char UNUSED(ctrl) = keystatus[0x1d] | keystatus[0x9d];
+	        char UNUSED(alt) = keystatus[sc_LeftAlt] | keystatus[sc_RightAlt];
+	        char UNUSED(ctrl) = keystatus[sc_LeftControl] | keystatus[sc_RightControl];
             switch (nKey)
             {
-            case 1:
+            case sc_Escape:
                 if (!CGameMenuMgr::m_bActive)
                 {
                     gGameMenuMgr.Push(&menuMain, -1);
                     at2 = 1;
                 }
                 break;
-            case 0x58:
+            case sc_F12:
                 gViewIndex = connectpoint2[gViewIndex];
                 if (gViewIndex == -1)
                     gViewIndex = connecthead;
                 gView = &gPlayer[gViewIndex];
                 break;
             }
+        }
+        if (!nKey && CONTROL_JoystickEnabled)
+        {
+            static int32_t joyold = 0;
+            int32_t joy = JOYSTICK_GetControllerButtons() == (1 << CONTROLLER_BUTTON_START);
+            if (joy && !joyold)
+            {
+                JOYSTICK_ClearAllButtons();
+                if (!CGameMenuMgr::m_bActive)
+                {
+                    gGameMenuMgr.Push(&menuMain, -1);
+                    at2 = 1;
+                }
+            }
+            joyold = joy;
         }
         break;
     default:

--- a/source/blood/src/endgame.cpp
+++ b/source/blood/src/endgame.cpp
@@ -81,6 +81,12 @@ void CEndGameMgr::ProcessKeys(void)
     //else
     {
         char ch = keyGetScan();
+        if (CONTROL_JoystickEnabled && !ch)
+        {
+            int32_t joy = JOYSTICK_GetControllerButtons();
+            JOYSTICK_ClearAllButtons();
+            ch = joy == (1 << CONTROLLER_BUTTON_START);
+        }
         if (!ch)
             return;
         if (gGameOptions.nGameType > 0 || numplayers > 1)

--- a/source/blood/src/gamemenu.cpp
+++ b/source/blood/src/gamemenu.cpp
@@ -224,7 +224,7 @@ void CGameMenuMgr::Process(void)
     CGameMenuEvent event;
     event.at0 = 0;
     event.at2 = 0;
-    char key;
+    char key = 0;
     if (!pActiveMenu->MouseEvent(event) && (key = keyGetScan()) != 0 )
     {
         keyFlushScans();
@@ -277,6 +277,28 @@ void CGameMenuMgr::Process(void)
             event.at0 = kMenuEventKey;
             break;
         }
+    }
+    else if (CONTROL_JoystickEnabled && !key)
+    {
+        static int32_t joyold = 0;
+        int32_t joy = JOYSTICK_GetControllerButtons();
+        JOYSTICK_ClearAllButtons();
+        if (joy != joyold)
+        {
+            if (joy & (1 << CONTROLLER_BUTTON_DPAD_UP))
+                event.at0 = kMenuEventUp;
+            else if (joy & (1 << CONTROLLER_BUTTON_DPAD_DOWN))
+                event.at0 = kMenuEventDown;
+            else if (joy & (1 << CONTROLLER_BUTTON_DPAD_LEFT))
+                event.at0 = kMenuEventLeft;
+            else if (joy & (1 << CONTROLLER_BUTTON_DPAD_RIGHT))
+                event.at0 = kMenuEventRight;
+            else if (joy & (1 << CONTROLLER_BUTTON_A))
+                event.at0 = kMenuEventEnter;
+            else if ((joy & (1 << CONTROLLER_BUTTON_B)) || (joy & (1 << CONTROLLER_BUTTON_START)))
+                event.at0 = kMenuEventEscape;
+        }
+        joyold = joy;
     }
     if (pActiveMenu->Event(event))
         Pop();
@@ -658,6 +680,8 @@ bool CGameMenuItemZBool::Event(CGameMenuEvent &event)
 {
     switch (event.at0)
     {
+    case kMenuEventLeft:
+    case kMenuEventRight:
     case kMenuEventEnter:
     case kMenuEventSpace:
         at20 = !at20;

--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -659,15 +659,32 @@ void UpdatePlayerName(CGameMenuItemZEdit *pItem, CGameMenuEvent *pEvent);
 CGameMenuItemTitle itemOptionsPlayerTitle("PLAYER SETUP", 1, 160, 20, 2038);
 CGameMenuItemZEdit itemOptionsPlayerName("PLAYER NAME:", 3, 66, 60, 180, szPlayerName, MAXPLAYERNAME, 0, UpdatePlayerName, 0);
 
+#define JOYSTICKITEMSPERPAGE 16 // this must be an even value, as double tap inputs rely on odd index position
+#define MAXJOYSTICKBUTTONPAGES (max(1, (MAXJOYBUTTONSANDHATS*2 / JOYSTICKITEMSPERPAGE))) // we double all buttons/hats so each input can be bind for double tap
+
 CGameMenu menuOptionsControlKeyboard;
 CGameMenu menuOptionsControlMouse;
 CGameMenu menuOptionsControlMouseButtonAssignment;
+CGameMenu menuOptionsControlJoystickButtonAssignment[MAXJOYSTICKBUTTONPAGES];
+CGameMenu menuOptionsControlJoystickListAxes; // contains list of editable joystick axes
+CGameMenu menuOptionsControlJoystickAxis[MAXJOYAXES]; // options menu for each joystick axis
 
 void SetupMouseMenu(CGameMenuItemChain *pItem);
+void SetupJoystickButtonsMenu(CGameMenuItemChain *pItem);
+void SetupJoystickAxesMenu(CGameMenuItemChain *pItem);
+void SetJoystickScale(CGameMenuItemSlider* pItem);
+void SetJoystickAnalogue(CGameMenuItemZCycle* pItem);
+void SetJoystickAnalogueInvert(CGameMenuItemZBool* pItem);
+void SetJoystickDigitalPos(CGameMenuItemZCycle* pItem);
+void SetJoystickDigitalNeg(CGameMenuItemZCycle* pItem);
+void SetJoystickDeadzone(CGameMenuItemSlider* pItem);
+void SetJoystickSaturate(CGameMenuItemSlider* pItem);
 
 CGameMenuItemTitle itemOptionsControlTitle("CONTROL SETUP", 1, 160, 20, 2038);
 CGameMenuItemChain itemOptionsControlKeyboard("KEYBOARD SETUP", 1, 0, 60, 320, 1, &menuOptionsControlKeyboard, -1, NULL, 0);
 CGameMenuItemChain itemOptionsControlMouse("MOUSE SETUP", 1, 0, 80, 320, 1, &menuOptionsControlMouse, -1, SetupMouseMenu, 0);
+CGameMenuItemChain itemOptionsControlJoystickButtons("JOYSTICK BUTTONS SETUP", 1, 0, 120, 320, 1, &menuOptionsControlJoystickButtonAssignment[0], -1, SetupJoystickButtonsMenu, 0);
+CGameMenuItemChain itemOptionsControlJoystickAxes("JOYSTICK AXES SETUP", 1, 0, 140, 320, 1, &menuOptionsControlJoystickListAxes, -1, SetupJoystickAxesMenu, 0);
 
 CGameMenuItemTitle itemOptionsControlKeyboardTitle("KEYBOARD SETUP", 1, 160, 20, 2038);
 CGameMenuItemChain itemOptionsControlKeyboardList("Configure Keys...", 1, 0, 60, 320, 1, &menuKeys, -1, NULL, 0);
@@ -680,17 +697,19 @@ void SetMouseXSensitivity(CGameMenuItemSliderFloat *pItem);
 void SetMouseYSensitivity(CGameMenuItemSliderFloat*pItem);
 
 void PreDrawControlMouse(CGameMenuItem *pItem);
+void SetMouseButton(CGameMenuItemZCycle *pItem);
+void SetJoyButton(CGameMenuItemZCycle *pItem);
 
 void SetupMouseButtonMenu(CGameMenuItemChain *pItem);
 
 CGameMenuItemTitle itemOptionsControlMouseTitle("MOUSE SETUP", 1, 160, 20, 2038);
 CGameMenuItemChain itemOptionsControlMouseButton("BUTTON ASSIGNMENT", 3, 66, 60, 180, 0, &menuOptionsControlMouseButtonAssignment, 0, SetupMouseButtonMenu, 0);
-CGameMenuItemSliderFloat itemOptionsControlMouseSensitivity("SENSITIVITY:", 3, 66, 70, 180, &CONTROL_MouseSensitivity, 1.f, 50.f, 1.f, SetMouseSensitivity, -1, -1, kMenuSliderValue);
+CGameMenuItemSliderFloat itemOptionsControlMouseSensitivity("SENSITIVITY:", 3, 66, 70, 180, &CONTROL_MouseSensitivity, 1.f, 100.f, 1.f, SetMouseSensitivity, -1, -1, kMenuSliderValue);
 CGameMenuItemZBool itemOptionsControlMouseAimFlipped("INVERT AIMING:", 3, 66, 80, 180, false, SetMouseAimFlipped, NULL, NULL);
 CGameMenuItemZBool itemOptionsControlMouseAimMode("AIMING TYPE:", 3, 66, 90, 180, false, SetMouseAimMode, "HOLD", "TOGGLE");
 CGameMenuItemZBool itemOptionsControlMouseVerticalAim("VERTICAL AIMING:", 3, 66, 100, 180, false, SetMouseVerticalAim, NULL, NULL);
-CGameMenuItemSliderFloat itemOptionsControlMouseXSensitivity("HORIZ SENS:", 3, 66, 110, 180, &CONTROL_MouseAxesSensitivity[0], 1.f, 50.f, 1.f, SetMouseXSensitivity, -1, -1, kMenuSliderValue);
-CGameMenuItemSliderFloat itemOptionsControlMouseYSensitivity("VERT SENS:", 3, 66, 120, 180, &CONTROL_MouseAxesSensitivity[1], 1.f, 50.f, 1.f, SetMouseYSensitivity, -1, -1, kMenuSliderValue);
+CGameMenuItemSliderFloat itemOptionsControlMouseXSensitivity("HORIZ SENS:", 3, 66, 110, 180, &CONTROL_MouseAxesSensitivity[0], 1.f, 100.f, 1.f, SetMouseXSensitivity, -1, -1, kMenuSliderValue);
+CGameMenuItemSliderFloat itemOptionsControlMouseYSensitivity("VERT SENS:", 3, 66, 120, 180, &CONTROL_MouseAxesSensitivity[1], 1.f, 100.f, 1.f, SetMouseYSensitivity, -1, -1, kMenuSliderValue);
 
 void SetupNetworkMenu(void);
 void SetupNetworkHostMenu(CGameMenuItemChain *pItem);
@@ -754,9 +773,36 @@ static int32_t MenuMouseDataIndex[MENUMOUSEFUNCTIONS][2] = {
     { 6, 1, },
 };
 
-void SetMouseButton(CGameMenuItemZCycle *pItem);
-
 CGameMenuItemZCycle *pItemOptionsControlMouseButton[MENUMOUSEFUNCTIONS];
+
+char MenuJoyButtonNames[MAXJOYBUTTONSANDHATS*2][64] = {""};
+
+const char *zJoystickAnalogue[] =
+{
+    "-None-",
+    "Turning",
+    "Strafing",
+    "Moving",
+    "Look Up/Down",
+};
+
+CGameMenuItemTitle itemJoyButtonsTitle("JOYSTICK SETUP", 1, 160, 20, 2038);
+CGameMenuItemZCycle *pItemOptionsControlJoyButton[MAXJOYSTICKBUTTONPAGES][JOYSTICKITEMSPERPAGE];
+CGameMenuItemChain *pItemOptionsControlJoyButtonNextPage[MAXJOYSTICKBUTTONPAGES];
+
+char MenuJoyAxisNames[MAXJOYAXES][64] = {""};
+
+CGameMenuItemTitle itemJoyAxesTitle("JOYSTICK AXES", 1, 160, 20, 2038);
+CGameMenuItemChain *pItemOptionsControlJoystickAxis[MAXJOYAXES]; // dynamic list for each axis
+
+CGameMenuItemTitle *pItemOptionsControlJoystickAxisName[MAXJOYAXES];
+CGameMenuItemSlider *pItemOptionsControlJoystickAxisScale[MAXJOYAXES];
+CGameMenuItemZCycle *pItemOptionsControlJoystickAxisAnalogue[MAXJOYAXES];
+CGameMenuItemZBool *pItemOptionsControlJoystickAxisAnalogueInvert[MAXJOYAXES];
+CGameMenuItemZCycle *pItemOptionsControlJoystickAxisDigitalPos[MAXJOYAXES];
+CGameMenuItemZCycle *pItemOptionsControlJoystickAxisDigitalNeg[MAXJOYAXES];
+CGameMenuItemSlider *pItemOptionsControlJoystickAxisDeadzone[MAXJOYAXES];
+CGameMenuItemSlider *pItemOptionsControlJoystickAxisSaturate[MAXJOYAXES];
 
 void SetupLoadingScreen(void)
 {
@@ -1326,6 +1372,8 @@ void SetupOptionsMenu(void)
     menuOptionsControl.Add(&itemOptionsControlTitle, false);
     menuOptionsControl.Add(&itemOptionsControlKeyboard, true);
     menuOptionsControl.Add(&itemOptionsControlMouse, false);
+    menuOptionsControl.Add(&itemOptionsControlJoystickButtons, false);
+    menuOptionsControl.Add(&itemOptionsControlJoystickAxes, false);
     menuOptionsControl.Add(&itemBloodQAV, false);
 
     menuOptionsControlKeyboard.Add(&itemOptionsControlKeyboardTitle, false);
@@ -1347,8 +1395,9 @@ void SetupOptionsMenu(void)
     itemOptionsControlMouseVerticalAim.pPreDrawCallback = PreDrawControlMouse;
 
     menuOptionsControlMouseButtonAssignment.Add(&itemOptionsControlMouseTitle, false);
+    int i;
     int y = 60;
-    for (int i = 0; i < MENUMOUSEFUNCTIONS; i++)
+    for (i = 0; i < MENUMOUSEFUNCTIONS; i++)
     {
         pItemOptionsControlMouseButton[i] = new CGameMenuItemZCycle(MenuMouseNames[i], 3, 66, y, 180, 0, SetMouseButton, pzGamefuncsStrings, NUMGAMEFUNCTIONS+1, 0, true);
         dassert(pItemOptionsControlMouseButton[i] != NULL);
@@ -1356,6 +1405,134 @@ void SetupOptionsMenu(void)
         y += 10;
     }
     menuOptionsControlMouseButtonAssignment.Add(&itemBloodQAV, false);
+
+    if (!CONTROL_JoystickEnabled) // joystick disabled, don't bother populating joystick menus
+    {
+        itemOptionsControlJoystickButtons.bEnable = 0;
+        itemOptionsControlJoystickAxes.bEnable = 0;
+        return;
+    }
+
+    i = 0;
+    for (int nButton = 0; nButton < joystick.numButtons; nButton++) // store every joystick button/hat name for button list at launch
+    {
+        const char *pzButtonName = joyGetName(1, nButton);
+        if (pzButtonName == NULL) // if we've ran out of button names, store joystick hat names
+        {
+            for (int nHats = 0; nHats < (joystick.numHats > 0) * 4; nHats++)
+            {
+                const char *pzHatName = joyGetName(2, nHats);
+                if (pzHatName == NULL)
+                    break;
+                Bsnprintf(MenuJoyButtonNames[i++], 64, "%s", pzHatName);
+                Bsnprintf(MenuJoyButtonNames[i++], 64, "Double %s", pzHatName);
+            }
+            break;
+        }
+        Bsnprintf(MenuJoyButtonNames[i++], 64, "%s", pzButtonName);
+        Bsnprintf(MenuJoyButtonNames[i++], 64, "Double %s", pzButtonName);
+    }
+    const int nMaxJoyButtons = i;
+
+    i = 0;
+    for (int nAxis = 0; nAxis < joystick.numAxes; nAxis++) // store every joystick axes for axes list at launch
+    {
+        const char *pzAxisName = joyGetName(0, nAxis);
+        if (pzAxisName == NULL) // if we've ran out of axes names, stop
+            break;
+        Bsnprintf(MenuJoyAxisNames[i++], 64, "%s", pzAxisName);
+    }
+    const int nMaxJoyAxes = i;
+
+    if (nMaxJoyButtons <= 0) // joystick has no buttons, disable button menu
+    {
+        itemOptionsControlJoystickButtons.bEnable = 0;
+    }
+    else
+    {
+        i = 0;
+        for (int nPage = 0; nPage < MAXJOYSTICKBUTTONPAGES; nPage++) // create lists of joystick button items
+        {
+            y = 35;
+            menuOptionsControlJoystickButtonAssignment[nPage].Add(&itemJoyButtonsTitle, false);
+            for (int nButton = 0; nButton < JOYSTICKITEMSPERPAGE; nButton++) // populate button list
+            {
+                pItemOptionsControlJoyButton[nPage][nButton] = new CGameMenuItemZCycle(MenuJoyButtonNames[i], 3, 66, y, 180, 0, SetJoyButton, pzGamefuncsStrings, NUMGAMEFUNCTIONS+1, 0, true);
+                dassert(pItemOptionsControlJoyButton[nPage][nButton] != NULL);
+                menuOptionsControlJoystickButtonAssignment[nPage].Add(pItemOptionsControlJoyButton[nPage][nButton], nButton == 0);
+                y += 9;
+                i++;
+                if (i >= nMaxJoyButtons) // if we've reached the total number of buttons, stop populating list
+                    break;
+            }
+            if (i < nMaxJoyButtons) // if we still have more buttons to list, add next page menu item at bottom of page
+            {
+                pItemOptionsControlJoyButtonNextPage[nPage] = new CGameMenuItemChain("NEXT PAGE", 3, 0, 182, 320, 1, &menuOptionsControlJoystickButtonAssignment[nPage+1], -1, NULL, 0);
+                dassert(pItemOptionsControlJoyButtonNextPage[nPage] != NULL);
+                menuOptionsControlJoystickButtonAssignment[nPage].Add(pItemOptionsControlJoyButtonNextPage[nPage], false);
+            }
+            menuOptionsControlJoystickButtonAssignment[nPage].Add(&itemBloodQAV, false);
+        }
+    }
+
+    if (nMaxJoyAxes <= 0) // joystick has no axes, disable axis menu
+    {
+        itemOptionsControlJoystickAxes.bEnable = 0;
+        return;
+    }
+
+    for (int nAxis = 0; nAxis < (int)ARRAY_SIZE(pItemOptionsControlJoystickAxis); nAxis++) // set all possible axis items to null (used for button setup)
+        pItemOptionsControlJoystickAxis[nAxis] = NULL;
+
+    y = 40;
+    const char bUseBigFont = nMaxJoyAxes <= 6;
+    menuOptionsControlJoystickListAxes.Add(&itemJoyAxesTitle, false);
+    for (int nAxis = 0; nAxis < nMaxJoyAxes; nAxis++) // create list of axes for joystick axis menu
+    {
+        pItemOptionsControlJoystickAxis[nAxis] = new CGameMenuItemChain(MenuJoyAxisNames[nAxis], bUseBigFont ? 1 : 3, 66, y, 180, 0, &menuOptionsControlJoystickAxis[nAxis], -1, NULL, 0);
+        dassert(pItemOptionsControlJoystickAxis[nAxis] != NULL);
+        menuOptionsControlJoystickListAxes.Add(pItemOptionsControlJoystickAxis[nAxis], nAxis == 0);
+        y += bUseBigFont ? 20 : 10;
+    }
+    menuOptionsControlJoystickListAxes.Add(&itemBloodQAV, false);
+
+    for (int nAxis = 0; nAxis < nMaxJoyAxes; nAxis++) // create settings for each listed joystick axis
+    {
+        y = 40;
+        menuOptionsControlJoystickAxis[nAxis].Add(&itemJoyAxesTitle, false);
+        pItemOptionsControlJoystickAxisName[nAxis] = new CGameMenuItemTitle(MenuJoyAxisNames[nAxis], 3, 160, y, -1); // get axis name
+        dassert(pItemOptionsControlJoystickAxisName[nAxis] != NULL);
+        menuOptionsControlJoystickAxis[nAxis].Add(pItemOptionsControlJoystickAxisName[nAxis], false);
+        y += 12;
+        pItemOptionsControlJoystickAxisScale[nAxis] = new CGameMenuItemSlider("AXIS SCALE:", 1, 18, y, 280, &JoystickAnalogueScale[nAxis], fix16_from_int(0), fix16_from_float(2.f), fix16_from_float(0.025f), SetJoystickScale, -1, -1, kMenuSliderQ16); // get axis scale
+        dassert(pItemOptionsControlJoystickAxisScale[nAxis] != NULL);
+        menuOptionsControlJoystickAxis[nAxis].Add(pItemOptionsControlJoystickAxisScale[nAxis], true);
+        y += 25;
+        pItemOptionsControlJoystickAxisAnalogue[nAxis] = new CGameMenuItemZCycle("ANALOG:", 1, 18, y, 280, 0, SetJoystickAnalogue, zJoystickAnalogue, ARRAY_SSIZE(zJoystickAnalogue), 0); // get analog function
+        dassert(pItemOptionsControlJoystickAxisAnalogue[nAxis] != NULL);
+        menuOptionsControlJoystickAxis[nAxis].Add(pItemOptionsControlJoystickAxisAnalogue[nAxis], false);
+        y += 17;
+        pItemOptionsControlJoystickAxisAnalogueInvert[nAxis] = new CGameMenuItemZBool("ANALOG INVERT:", 1, 18, y, 280, false, SetJoystickAnalogueInvert, NULL, NULL); // get analog function
+        dassert(pItemOptionsControlJoystickAxisAnalogueInvert[nAxis] != NULL);
+        menuOptionsControlJoystickAxis[nAxis].Add(pItemOptionsControlJoystickAxisAnalogueInvert[nAxis], false);
+        y += 17;
+        pItemOptionsControlJoystickAxisDigitalPos[nAxis] = new CGameMenuItemZCycle("DIGITAL +:", 1, 18, y, 280, 0, SetJoystickDigitalPos, pzGamefuncsStrings, NUMGAMEFUNCTIONS+1, 0, true); // get digital function
+        dassert(pItemOptionsControlJoystickAxisDigitalPos[nAxis] != NULL);
+        menuOptionsControlJoystickAxis[nAxis].Add(pItemOptionsControlJoystickAxisDigitalPos[nAxis], false);
+        y += 17;
+        pItemOptionsControlJoystickAxisDigitalNeg[nAxis] = new CGameMenuItemZCycle("DIGITAL -:", 1, 18, y, 280, 0, SetJoystickDigitalNeg, pzGamefuncsStrings, NUMGAMEFUNCTIONS+1, 0, true); // get digital function
+        dassert(pItemOptionsControlJoystickAxisDigitalNeg[nAxis] != NULL);
+        menuOptionsControlJoystickAxis[nAxis].Add(pItemOptionsControlJoystickAxisDigitalNeg[nAxis], false);
+        y += 25;
+        pItemOptionsControlJoystickAxisDeadzone[nAxis] = new CGameMenuItemSlider("DEAD ZONE:", 1, 18, y, 280, &JoystickAnalogueDead[nAxis], fix16_from_int(0), fix16_from_float(0.5f), fix16_from_float(0.025f), SetJoystickDeadzone, -1, -1, kMenuSliderPercent); // get dead size
+        dassert(pItemOptionsControlJoystickAxisDeadzone[nAxis] != NULL);
+        menuOptionsControlJoystickAxis[nAxis].Add(pItemOptionsControlJoystickAxisDeadzone[nAxis], false);
+        y += 17;
+        pItemOptionsControlJoystickAxisSaturate[nAxis] = new CGameMenuItemSlider("SATURATE:", 1, 18, y, 280, &JoystickAnalogueSaturate[nAxis], fix16_from_int(0), fix16_from_float(0.5f), fix16_from_float(0.025f), SetJoystickSaturate, -1, -1, kMenuSliderPercent); // get saturate
+        dassert(pItemOptionsControlJoystickAxisSaturate[nAxis] != NULL);
+        menuOptionsControlJoystickAxis[nAxis].Add(pItemOptionsControlJoystickAxisSaturate[nAxis], false);
+        menuOptionsControlJoystickAxis[nAxis].Add(&itemBloodQAV, false);
+    }
 }
 
 void SetupMenus(void)
@@ -1937,6 +2114,7 @@ void UpdateNumVoices(CGameMenuItemSlider *pItem)
 
 void UpdateMusicDevice(CGameMenuItemZCycle *pItem)
 {
+    UNREFERENCED_PARAMETER(pItem);
     itemOptionsSoundSF2Bank.bEnable = 0;
     itemOptionsSoundSF2Bank.bNoDraw = 1;
     switch (nMusicDeviceValues[itemOptionsSoundMusicDevice.m_nFocus])
@@ -1988,7 +2166,7 @@ void SetupOptionsSound(CGameMenuItemChain *pItem)
     }
     itemOptionsSoundNumVoices.nValue = NumVoices;
     itemOptionsSoundMusicDevice.m_nFocus = 0;
-    for (int i = 0; i < ARRAY_SIZE(nMusicDeviceValues); i++)
+    for (int i = 0; i < (int)ARRAY_SIZE(nMusicDeviceValues); i++)
     {
         if (nMusicDeviceValues[i] == MusicDevice)
         {
@@ -2037,6 +2215,206 @@ void SetupMouseMenu(CGameMenuItemChain *pItem)
     // itemOptionsControlMouseYScale.nValue = CONTROL_MouseAxesScale[1];
 }
 
+void SetupJoystickButtonsMenu(CGameMenuItemChain *pItem)
+{
+    UNREFERENCED_PARAMETER(pItem);
+    const int nMaxJoyButtons = (joystick.numButtons * 2) + ((joystick.numHats > 0) * 4);
+    for (int nPage = 0; nPage < MAXJOYSTICKBUTTONPAGES; nPage++) // go through each axis and setup binds
+    {
+        for (int nButton = 0; nButton < JOYSTICKITEMSPERPAGE; nButton++)
+        {
+            if (nButton >= nMaxJoyButtons) // reached end of button list
+                return;
+            const char bDoubleTap = nButton & 1;
+            const int nJoyButton = ((nPage * JOYSTICKITEMSPERPAGE)>>1) + (nButton>>1); // we halve the button index because button lists are listed in pairs of single tap/double tap inputs
+            auto pButton = pItemOptionsControlJoyButton[nPage][nButton];
+            if (!pButton)
+                break;
+            pButton->m_nFocus = 0;
+            for (int j = 0; j < NUMGAMEFUNCTIONS+1; j++)
+            {
+                if (JoystickFunctions[nJoyButton][bDoubleTap] == nGamefuncsValues[j])
+                {
+                    pButton->m_nFocus = j;
+                    break;
+                }
+            }
+        }
+    }
+}
+
+void SetupJoystickAxesMenu(CGameMenuItemChain *pItem)
+{
+    UNREFERENCED_PARAMETER(pItem);
+    for (int nAxis = 0; nAxis < MAXJOYAXES; nAxis++) // set settings for each listed joystick axis
+    {
+        if (pItemOptionsControlJoystickAxis[nAxis] == NULL) // reached end of list, stop
+            return;
+        pItemOptionsControlJoystickAxisScale[nAxis]->nValue = JoystickAnalogueScale[nAxis];
+        switch (JoystickAnalogueAxes[nAxis])
+        {
+        case analog_lookingupanddown:
+            pItemOptionsControlJoystickAxisAnalogue[nAxis]->m_nFocus = 4;
+            break;
+        case analog_moving:
+            pItemOptionsControlJoystickAxisAnalogue[nAxis]->m_nFocus = 3;
+            break;
+        case analog_strafing:
+            pItemOptionsControlJoystickAxisAnalogue[nAxis]->m_nFocus = 2;
+            break;
+        case analog_turning:
+            pItemOptionsControlJoystickAxisAnalogue[nAxis]->m_nFocus = 1;
+            break;
+        default: // unsupported/none
+            pItemOptionsControlJoystickAxisAnalogue[nAxis]->m_nFocus = 0;
+            break;
+        }
+        pItemOptionsControlJoystickAxisDigitalPos[nAxis]->m_nFocus = 0;
+        for (int j = 0; j < NUMGAMEFUNCTIONS+1; j++)
+        {
+            if (JoystickDigitalFunctions[nAxis][0] == nGamefuncsValues[j])
+            {
+                pItemOptionsControlJoystickAxisDigitalPos[nAxis]->m_nFocus = j;
+                break;
+            }
+        }
+        pItemOptionsControlJoystickAxisDigitalNeg[nAxis]->m_nFocus = 0;
+        for (int j = 0; j < NUMGAMEFUNCTIONS+1; j++)
+        {
+            if (JoystickDigitalFunctions[nAxis][1] == nGamefuncsValues[j])
+            {
+                pItemOptionsControlJoystickAxisDigitalNeg[nAxis]->m_nFocus = j;
+                break;
+            }
+        }
+        pItemOptionsControlJoystickAxisDeadzone[nAxis]->nValue = JoystickAnalogueDead[nAxis];
+        pItemOptionsControlJoystickAxisSaturate[nAxis]->nValue = JoystickAnalogueSaturate[nAxis];
+    }
+}
+
+void SetJoystickScale(CGameMenuItemSlider* pItem)
+{
+    for (int nAxis = 0; nAxis < MAXJOYAXES; nAxis++)
+    {
+        if (pItem == pItemOptionsControlJoystickAxisScale[nAxis])
+        {
+            JoystickAnalogueScale[nAxis] = pItem->nValue;
+            CONTROL_SetAnalogAxisScale(nAxis, JoystickAnalogueScale[nAxis], controldevice_joystick);
+            break;
+        }
+    }
+}
+
+void SetJoystickAnalogue(CGameMenuItemZCycle* pItem)
+{
+    for (int nAxis = 0; nAxis < MAXJOYAXES; nAxis++)
+    {
+        if (pItem == pItemOptionsControlJoystickAxisAnalogue[nAxis])
+        {
+            switch (pItem->m_nFocus)
+            {
+            case 4: // looking up/down
+                JoystickAnalogueAxes[nAxis] = analog_lookingupanddown;
+                break;
+            case 3: // moving
+                JoystickAnalogueAxes[nAxis] = analog_moving;
+                break;
+            case 2: // strafing
+                JoystickAnalogueAxes[nAxis] = analog_strafing;
+                break;
+            case 1: // turning
+                JoystickAnalogueAxes[nAxis] = analog_turning;
+                break;
+            case 0: // none
+            default:
+                JoystickAnalogueAxes[nAxis] = -1;
+                break;
+            }
+            CONTROL_MapAnalogAxis(nAxis, JoystickAnalogueAxes[nAxis]);
+            break;
+        }
+    }
+}
+
+void SetJoystickAnalogueInvert(CGameMenuItemZBool* pItem)
+{
+    for (int nAxis = 0; nAxis < MAXJOYAXES; nAxis++)
+    {
+        if (pItem == pItemOptionsControlJoystickAxisAnalogueInvert[nAxis])
+        {
+            JoystickAnalogueInvert[nAxis] = pItem->at20;
+            CONTROL_SetAnalogAxisInvert(nAxis, JoystickAnalogueInvert[nAxis]);
+            break;
+        }
+    }
+}
+
+void SetJoystickDigitalPos(CGameMenuItemZCycle* pItem)
+{
+    for (int nAxis = 0; nAxis < MAXJOYAXES; nAxis++)
+    {
+        if (pItem == pItemOptionsControlJoystickAxisDigitalPos[nAxis])
+        {
+            for (int j = 0; j < NUMGAMEFUNCTIONS+1; j++)
+            {
+                if (JoystickDigitalFunctions[nAxis][0] == nGamefuncsValues[j])
+                {
+                    int nFunc = nGamefuncsValues[pItem->m_nFocus];
+                    JoystickDigitalFunctions[nAxis][0] = nFunc;
+                    CONTROL_MapDigitalAxis(nAxis, JoystickDigitalFunctions[nAxis][0], 0);
+                    return;
+                }
+            }
+        }
+    }
+}
+
+void SetJoystickDigitalNeg(CGameMenuItemZCycle* pItem)
+{
+    for (int nAxis = 0; nAxis < MAXJOYAXES; nAxis++)
+    {
+        if (pItem == pItemOptionsControlJoystickAxisDigitalNeg[nAxis])
+        {
+            for (int j = 0; j < NUMGAMEFUNCTIONS+1; j++)
+            {
+                if (JoystickDigitalFunctions[nAxis][1] == nGamefuncsValues[j])
+                {
+                    int nFunc = nGamefuncsValues[pItem->m_nFocus];
+                    JoystickDigitalFunctions[nAxis][1] = nFunc;
+                    CONTROL_MapDigitalAxis(nAxis, JoystickDigitalFunctions[nAxis][1], 1);
+                    return;
+                }
+            }
+        }
+    }
+}
+
+void SetJoystickDeadzone(CGameMenuItemSlider* pItem)
+{
+    for (int nAxis = 0; nAxis < MAXJOYAXES; nAxis++)
+    {
+        if (pItem == pItemOptionsControlJoystickAxisDeadzone[nAxis])
+        {
+            JoystickAnalogueDead[nAxis] = pItem->nValue;
+            JOYSTICK_SetDeadZone(nAxis, JoystickAnalogueDead[nAxis], JoystickAnalogueSaturate[nAxis]);
+            break;
+        }
+    }
+}
+
+void SetJoystickSaturate(CGameMenuItemSlider* pItem)
+{
+    for (int nAxis = 0; nAxis < MAXJOYAXES; nAxis++)
+    {
+        if (pItem == pItemOptionsControlJoystickAxisSaturate[nAxis])
+        {
+            JoystickAnalogueSaturate[nAxis] = pItem->nValue;
+            JOYSTICK_SetDeadZone(nAxis, JoystickAnalogueDead[nAxis], JoystickAnalogueSaturate[nAxis]);
+            break;
+        }
+    }
+}
+
 void PreDrawControlMouse(CGameMenuItem *pItem)
 {
     if (pItem == &itemOptionsControlMouseVerticalAim)
@@ -2054,6 +2432,25 @@ void SetMouseButton(CGameMenuItemZCycle *pItem)
             CONTROL_MapButton(nFunc, MenuMouseDataIndex[i][0], MenuMouseDataIndex[i][1], controldevice_mouse);
             CONTROL_FreeMouseBind(MenuMouseDataIndex[i][0]);
             break;
+        }
+    }
+}
+
+void SetJoyButton(CGameMenuItemZCycle *pItem)
+{
+    for (int nPage = 0; nPage < MAXJOYSTICKBUTTONPAGES; nPage++) // find selected menu item used for this bind
+    {
+        for (int nButton = 0; nButton < JOYSTICKITEMSPERPAGE; nButton++)
+        {
+            if (pItem == pItemOptionsControlJoyButton[nPage][nButton]) // found menu item, now bind function to joystick button
+            {
+                const char bDoubleTap = nButton & 1;
+                const int nJoyButton = ((nPage * JOYSTICKITEMSPERPAGE)>>1) + (nButton>>1); // we halve the button index because button lists are listed in pairs of single tap/double tap inputs
+                int nFunc = nGamefuncsValues[pItem->m_nFocus];
+                JoystickFunctions[nJoyButton][bDoubleTap] = nFunc;
+                CONTROL_MapButton(nFunc, nJoyButton, bDoubleTap, controldevice_joystick);
+                return;
+            }
         }
     }
 }


### PR DESCRIPTION
This is a very big PR, but it does work with the two controllers I've tried with, and from a friend's brief testing.

Using dynamic menu objects, the new joystick code will construct the button input pages, as well as a scaling axis menu. I used shadow warrior as my reference for implementing the joystick code, and added a feature to invert each axis. However no controller defaults are provided, as I was not too sure if this was a hold over from a wii port, or if they were broken.

Hooks have been added to game menu class, demo mode input handling and cutscenes/level end logic.