### PR TITLE
Blood: Clear all input on level start

### DIFF
--- a/source/blood/src/levels.cpp
+++ b/source/blood/src/levels.cpp
@@ -96,6 +96,9 @@ void levelPlayIntroScene(int nEpisode)
     viewResizeView(gViewSize);
     credReset();
     scrSetDac();
+    ControlInfo info;
+    CONTROL_GetInput(&info); // clear mouse and all input after cutscene has finished playing
+    ctrlClearAllInput();
 }
 
 void levelPlayEndScene(int nEpisode)


### PR DESCRIPTION
This PR clears player input polling while cutscene is playing, so when level starts keyboard/mouse movement will be flushed.