### PR TITLE
Blood: Allow cheat phrases to be sent in multiplayer

### DIFF
--- a/source/blood/src/messages.cpp
+++ b/source/blood/src/messages.cpp
@@ -297,6 +297,7 @@ void LevelWarpAndRecord(int nEpisode, int nLevel)
     char buffer[BMAX_PATH];
     levelSetupOptions(nEpisode, nLevel);
     gGameStarted = false;
+    gCheatMgr.ResetCheats();
     strcpy(buffer, levelGetFilename(nEpisode, nLevel));
     ChangeExtension(buffer, ".DEM");
     gDemo.Create(buffer);
@@ -623,7 +624,7 @@ void CPlayerMsg::ProcessKeys(void)
             break;
         case sc_Enter:
         case sc_kpad_Enter:
-            if (gCheatMgr.Check(text))
+            if ((gGameOptions.nGameType == 0) && gCheatMgr.Check(text))
                 Term();
             else
                 Send();


### PR DESCRIPTION
This PR only sets cheat message filtering for single player, and resets current active cheats on demo recording.