### PR TITLE
Blood: Use pack constants and misc fixes

### DIFF
--- a/source/blood/src/actor.cpp
+++ b/source/blood/src/actor.cpp
@@ -5984,16 +5984,16 @@ void actProcessSprites(void)
                     actDamageSprite(nSprite, pSprite, kDamageDrown, 12);
                 if (pPlayer->isUnderwater)
                 {
-                    char bActive = packItemActive(pPlayer, 1);
-                    if (bActive || pPlayer->godMode)
+                    const char bDivingSuit = packItemActive(pPlayer, kPackDivingSuit);
+                    if (bDivingSuit || pPlayer->godMode)
                         pPlayer->underwaterTime = 1200;
                     else
                         pPlayer->underwaterTime = ClipLow(pPlayer->underwaterTime-4, 0);
-                    if (pPlayer->underwaterTime < 1080 && packCheckItem(pPlayer, 1) && !bActive)
-                        packUseItem(pPlayer, 1);
+                    if (pPlayer->underwaterTime < 1080 && packCheckItem(pPlayer, kPackDivingSuit) && !bDivingSuit)
+                        packUseItem(pPlayer, kPackDivingSuit);
                     if (!pPlayer->underwaterTime)
                     {
-                        pPlayer->chokeEffect += 4;
+                        pPlayer->chokeEffect += kTicsPerFrame;
                         if (Chance(pPlayer->chokeEffect))
                             actDamageSprite(nSprite, pSprite, kDamageDrown, 3<<4);
                     }
@@ -6005,7 +6005,7 @@ void actProcessSprites(void)
                 }
                 else if (gGameOptions.nGameType == 0)
                 {
-                    if (pPlayer->pXSprite->health > 0 && pPlayer->restTime >= 1200 && Chance(0x200))
+                    if (pPlayer->pXSprite && (pPlayer->pXSprite->health > 0) && (pPlayer->restTime >= 1200) && Chance(0x200))
                     {
                         pPlayer->restTime = -1;
                         sfxPlay3DSound(pSprite, 3100+Random(11), 0, 2);

--- a/source/blood/src/aizombf.cpp
+++ b/source/blood/src/aizombf.cpp
@@ -67,7 +67,7 @@ static void HackSeqCallback(int, int nXSprite)
         return;
     XSPRITE *pXSprite = &xsprite[nXSprite];
     int nSprite = pXSprite->reference;
-    if (nXSprite < 0 || nXSprite >= kMaxSprites)
+    if (nSprite < 0 || nSprite >= kMaxSprites)
         return;
     spritetype *pSprite = &sprite[nSprite];
     if (pSprite->type != kDudeZombieButcher)

--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -765,7 +765,7 @@ void StartLevel(GAMEOPTIONS *gameOptions)
     InitMirrors();
     gFrameClock = 0;
     trInit();
-    if (!VanillaMode() && !packItemActive(gMe, kPackDivingSuit) && !powerupCheck(gMe, kPwUpReflectShots)) // if diving suit/reflective shots powerup is not active, turn off reverb sound effect
+    if (!VanillaMode() && !packItemActive(gMe, kPackDivingSuit)) // if diving suit is not active, turn off reverb sound effect
         sfxSetReverb(0);
     ambInit();
     netResetState();

--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -762,7 +762,7 @@ void StartLevel(GAMEOPTIONS *gameOptions)
     InitMirrors();
     gFrameClock = 0;
     trInit();
-    if (!bVanilla && !gMe->packSlots[1].isActive) // if diving suit is not active, turn off reverb sound effect
+    if (!VanillaMode() && !packItemActive(gMe, kPackDivingSuit) && !powerupCheck(gMe, kPwUpReflectShots)) // if diving suit/reflective shots powerup is not active, turn off reverb sound effect
         sfxSetReverb(0);
     ambInit();
     netResetState();

--- a/source/blood/src/common_game.h
+++ b/source/blood/src/common_game.h
@@ -80,7 +80,9 @@ void _consoleSysMsg(const char* pMessage, ...);
 #define kTicsPerFrame 4
 #define kTicsPerSec (kTicRate/kTicsPerFrame)
 
+#define LENSBUFFER 4077
 #define TILTBUFFER 4078
+#define CRYSTALBALLBUFFER 4079
 
 #define kExplodeMax 8
 

--- a/source/blood/src/loadsave.cpp
+++ b/source/blood/src/loadsave.cpp
@@ -160,6 +160,7 @@ void LoadSave::LoadGame(char *pzFile)
     else
         gGameMessageMgr.Clear();
     viewSetErrorMessage("");
+    viewResizeView(gViewSize);
     if (!gGameStarted)
     {
         netWaitForEveryone(0);

--- a/source/blood/src/loadsave.cpp
+++ b/source/blood/src/loadsave.cpp
@@ -129,8 +129,8 @@ void LoadSave::LoadGame(char *pzFile)
     InitSectorFX();
     viewInitializePrediction();
     PreloadCache();
-    if (!bVanilla && !gMe->packSlots[1].isActive) // if diving suit is not active, turn off reverb sound effect
-        sfxSetReverb(0);
+    if (!VanillaMode()) // set reverb sound effect state
+        sfxSetReverb(packItemActive(gMe, kPackDivingSuit) || powerupCheck(gMe, kPwUpReflectShots));
     ambInit();
 #ifdef YAX_ENABLE
     yax_update(numyaxbunches > 0 ? 2 : 1);

--- a/source/blood/src/messages.cpp
+++ b/source/blood/src/messages.cpp
@@ -82,14 +82,14 @@ void SetClipMode(bool noclip)
 
 void packStuff(PLAYER *pPlayer)
 {
-    for (int i = 0; i < 5; i++)
+    for (int i = 0; i < kPackMax; i++)
         packAddItem(pPlayer, i);
 }
 
 void packClear(PLAYER *pPlayer)
 {
     pPlayer->packItemId = 0;
-    for (int i = 0; i < 5; i++)
+    for (int i = 0; i < kPackMax; i++)
     {
         pPlayer->packSlots[i].isActive = 0;
         pPlayer->packSlots[i].curAmount = 0;
@@ -224,7 +224,7 @@ void ToggleBoots(void)
         if (!VanillaMode())
         {
             gMe->pwUpTime[kPwUpJumpBoots] = 0;
-            gMe->packSlots[4].curAmount = 0;
+            gMe->packSlots[kPackJumpBoots].curAmount = 0;
         }
         powerupDeactivate(gMe, kPwUpJumpBoots);
     }
@@ -823,10 +823,10 @@ void CCheatMgr::Process(CCheatMgr::CHEATCODE nCheatCode, char* pzArgs)
         }
         break;
     case kCheatFrankenstein:
-        gMe->packSlots[0].curAmount = 100;
+        gMe->packSlots[kPackMedKit].curAmount = 100;
         break;
     case kCheatCheeseHead:
-        gMe->packSlots[1].curAmount = 100;
+        gMe->packSlots[kPackDivingSuit].curAmount = 100;
         if (!VanillaMode())
             gMe->pwUpTime[kPwUpDivingSuit] = gPowerUpInfo[kPwUpDivingSuit].bonusTime;
         break;
@@ -879,7 +879,7 @@ void CCheatMgr::Process(CCheatMgr::CHEATCODE nCheatCode, char* pzArgs)
         break;
     case kCheatCousteau:
         actHealDude(gMe->pXSprite,200,200);
-        gMe->packSlots[1].curAmount = 100;
+        gMe->packSlots[kPackDivingSuit].curAmount = 100;
         if (!VanillaMode())
             gMe->pwUpTime[kPwUpDivingSuit] = gPowerUpInfo[kPwUpDivingSuit].bonusTime;
         break;

--- a/source/blood/src/network.cpp
+++ b/source/blood/src/network.cpp
@@ -67,7 +67,7 @@ char gNetAddress[32];
 // PORT-TODO: Use different port?
 int gNetPort = kNetDefaultPort;
 
-const short word_1328AC = 0x214;
+const short kNetVersion = 0x214;
 
 PKT_STARTGAME gPacketStartGame;
 
@@ -505,7 +505,7 @@ void netGetPackets(void)
         case 252:
             pPacket += 4;
             memcpy(&gPacketStartGame, pPacket, sizeof(PKT_STARTGAME));
-            if (gPacketStartGame.version != word_1328AC)
+            if (gPacketStartGame.version != kNetVersion)
                 ThrowError("\nThese versions of Blood cannot play together.\n");
             gStartNewGame = 1;
             break;
@@ -562,7 +562,7 @@ void netBroadcastNewGame(void)
 {
     if (numplayers < 2)
         return;
-    gPacketStartGame.version = word_1328AC;
+    gPacketStartGame.version = kNetVersion;
     char *pPacket = packet;
     PutPacketByte(pPacket, 252);
     PutPacketDWord(pPacket, myconnectindex);

--- a/source/blood/src/nnexts.cpp
+++ b/source/blood/src/nnexts.cpp
@@ -2212,7 +2212,7 @@ void trPlayerCtrlEraseStuff(XSPRITE* pXSource, PLAYER* pPlayer) {
             if (pXSource->data2) break;
             fallthrough__;
         case 3: // erase all pack items
-            for (int i = 0; i < 5; i++) {
+            for (int i = 0; i < kPackMax; i++) {
                 pPlayer->packSlots[i].isActive = false;
                 pPlayer->packSlots[i].curAmount = 0;
             }

--- a/source/blood/src/player.cpp
+++ b/source/blood/src/player.cpp
@@ -359,11 +359,11 @@ void powerupDeactivate(PLAYER *pPlayer, int nPowerUp)
             break;
         case kItemDivingSuit:
             pPlayer->damageControl[4]--;
-            if (pPlayer == gMe && VanillaMode() ? true : pPlayer->pwUpTime[24] == 0)
+            if ((pPlayer == gMe) && (VanillaMode() || !powerupCheck(pPlayer, kPwUpReflectShots)))
                 sfxSetReverb(0);
             break;
         case kItemReflectShots:
-            if (pPlayer == gMe && VanillaMode() ? true : pPlayer->packSlots[1].isActive == 0)
+            if ((pPlayer == gMe) && (VanillaMode() || !packItemActive(pPlayer, kPackDivingSuit)))
                 sfxSetReverb(0);
             break;
         case kItemGasMask:
@@ -419,7 +419,12 @@ void powerupProcess(PLAYER *pPlayer)
 
 void powerupClear(PLAYER *pPlayer)
 {
-    for (int i = kMaxPowerUps-1; i >= 0; i--)
+    if (!VanillaMode() && (pPlayer == gMe)) // turn off reverb sound effects
+    {
+        if (packItemActive(pPlayer, kPackDivingSuit) || powerupCheck(pPlayer, kPwUpReflectShots)) // if diving suit/reflective shots powerup is active, turn off reverb effect
+            sfxSetReverb(0);
+    }
+    for (int i = 0; i < kMaxPowerUps; i++)
     {
         pPlayer->pwUpTime[i] = 0;
     }
@@ -433,18 +438,18 @@ int packItemToPowerup(int nPack)
 {
     int nPowerUp = -1;
     switch (nPack) {
-        case 0:
+        case kPackMedKit:
             break;
-        case 1:
+        case kPackDivingSuit:
             nPowerUp = kPwUpDivingSuit;
             break;
-        case 2:
+        case kPackCrystalBall:
             nPowerUp = kPwUpCrystalBall;
             break;
-        case 3:
+        case kPackBeastVision:
             nPowerUp = kPwUpBeastVision;
             break;
-        case 4:
+        case kPackJumpBoots:
             nPowerUp = kPwUpJumpBoots;
             break;
         default:
@@ -458,20 +463,20 @@ int powerupToPackItem(int nPowerUp)
 {
     switch (nPowerUp) {
         case kPwUpDivingSuit:
-            return 1;
+            return kPackDivingSuit;
         case kPwUpCrystalBall:
-            return 2;
+            return kPackCrystalBall;
         case kPwUpBeastVision:
-            return 3;
+            return kPackBeastVision;
         case kPwUpJumpBoots:
-            return 4;
+            return kPackJumpBoots;
     }
     return -1;
 }
 
 char packAddItem(PLAYER *pPlayer, unsigned int nPack)
 {
-    if (nPack <= 4)
+    if (nPack < kPackMax)
     {
         if (pPlayer->packSlots[nPack].curAmount >= 100)
             return 0;
@@ -501,13 +506,13 @@ char packItemActive(PLAYER *pPlayer, int nPack)
 
 void packUseItem(PLAYER *pPlayer, int nPack)
 {
-    char v4 = 0;
+    char bActivate = 0;
     int nPowerUp = -1;
     if (pPlayer->packSlots[nPack].curAmount > 0)
     {
         switch (nPack)
         {
-        case 0:
+        case kPackMedKit:
         {
             XSPRITE *pXSprite = pPlayer->pXSprite;
             unsigned int health = pXSprite->health>>4;
@@ -515,24 +520,24 @@ void packUseItem(PLAYER *pPlayer, int nPack)
             {
                 int heal = ClipHigh(100-health, pPlayer->packSlots[0].curAmount);
                 actHealDude(pXSprite, heal, 100);
-                pPlayer->packSlots[0].curAmount -= heal;
+                pPlayer->packSlots[kPackMedKit].curAmount -= heal;
             }
             break;
         }
-        case 1:
-            v4 = 1;
+        case kPackDivingSuit:
+            bActivate = 1;
             nPowerUp = kPwUpDivingSuit;
             break;
-        case 2:
-            v4 = 1;
+        case kPackCrystalBall:
+            bActivate = 1;
             nPowerUp = kPwUpCrystalBall;
             break;
-        case 3:
-            v4 = 1;
+        case kPackBeastVision:
+            bActivate = 1;
             nPowerUp = kPwUpBeastVision;
             break;
-        case 4:
-            v4 = 1;
+        case kPackJumpBoots:
+            bActivate = 1;
             nPowerUp = kPwUpJumpBoots;
             break;
         default:
@@ -541,7 +546,7 @@ void packUseItem(PLAYER *pPlayer, int nPack)
         }
     }
     pPlayer->packItemTime = 0;
-    if (v4)
+    if (bActivate)
         powerupSetState(pPlayer, nPowerUp, pPlayer->packSlots[nPack].isActive);
 }
 
@@ -549,7 +554,7 @@ void packPrevItem(PLAYER *pPlayer)
 {
     if (pPlayer->packItemTime > 0)
     {
-        for (int nPrev = ClipLow(pPlayer->packItemId-1,0); nPrev >= 0; nPrev--)
+        for (int nPrev = ClipLow(pPlayer->packItemId-1,kPackMedKit); nPrev >= kPackMedKit; nPrev--)
         {
             if (pPlayer->packSlots[nPrev].curAmount)
             {
@@ -565,7 +570,7 @@ void packNextItem(PLAYER *pPlayer)
 {
     if (pPlayer->packItemTime > 0)
     {
-        for (int nNext = ClipHigh(pPlayer->packItemId+1,5); nNext < 5; nNext++)
+        for (int nNext = ClipHigh(pPlayer->packItemId+1,kPackMax); nNext < kPackMax; nNext++)
         {
             if (pPlayer->packSlots[nNext].curAmount)
             {
@@ -859,7 +864,7 @@ void playerReset(PLAYER *pPlayer)
     pPlayer->qavLoop = 0;
     pPlayer->packItemId = -1;
 
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < kPackMax; i++) {
         pPlayer->packSlots[i].isActive = 0;
         pPlayer->packSlots[i].curAmount = 0;
     }
@@ -1514,11 +1519,11 @@ void ProcessInput(PLAYER *pPlayer)
     default:
         if (!pPlayer->cantJump && pInput->buttonFlags.jump && pXSprite->height == 0) {
             #ifdef NOONE_EXTENSIONS
-            if ((packItemActive(pPlayer, 4) && pPosture->pwupJumpZ != 0) || pPosture->normalJumpZ != 0)
+            if ((packItemActive(pPlayer, kPackJumpBoots) && pPosture->pwupJumpZ != 0) || pPosture->normalJumpZ != 0)
             #endif
                 sfxPlay3DSound(pSprite, 700, 0, 0);
 
-            if (packItemActive(pPlayer, 4)) zvel[nSprite] = pPosture->pwupJumpZ; //-0x175555;
+            if (packItemActive(pPlayer, kPackJumpBoots)) zvel[nSprite] = pPosture->pwupJumpZ; //-0x175555;
             else zvel[nSprite] = pPosture->normalJumpZ; //-0xbaaaa;
             pPlayer->cantJump = 1;
         }
@@ -1713,26 +1718,26 @@ void ProcessInput(PLAYER *pPlayer)
     if (pInput->useFlags.useBeastVision)
     {
         pInput->useFlags.useBeastVision = 0;
-        if (pPlayer->packSlots[3].curAmount > 0)
-            packUseItem(pPlayer, 3);
+        if (pPlayer->packSlots[kPackBeastVision].curAmount > 0)
+            packUseItem(pPlayer, kPackBeastVision);
     }
     if (pInput->useFlags.useCrystalBall)
     {
         pInput->useFlags.useCrystalBall = 0;
-        if (pPlayer->packSlots[2].curAmount > 0)
-            packUseItem(pPlayer, 2);
+        if (pPlayer->packSlots[kPackCrystalBall].curAmount > 0)
+            packUseItem(pPlayer, kPackCrystalBall);
     }
     if (pInput->useFlags.useJumpBoots)
     {
         pInput->useFlags.useJumpBoots = 0;
-        if (pPlayer->packSlots[4].curAmount > 0)
-            packUseItem(pPlayer, 4);
+        if (pPlayer->packSlots[kPackJumpBoots].curAmount > 0)
+            packUseItem(pPlayer, kPackJumpBoots);
     }
     if (pInput->useFlags.useMedKit)
     {
         pInput->useFlags.useMedKit = 0;
-        if (pPlayer->packSlots[0].curAmount > 0)
-            packUseItem(pPlayer, 0);
+        if (pPlayer->packSlots[kPackMedKit].curAmount > 0)
+            packUseItem(pPlayer, kPackMedKit);
     }
     if (pInput->keyFlags.holsterWeapon)
     {
@@ -1851,8 +1856,8 @@ void playerProcess(PLAYER *pPlayer)
     {
         pPlayer->underwaterTime = 1200;
         pPlayer->chokeEffect = 0;
-        if (packItemActive(pPlayer, 1))
-            packUseItem(pPlayer, 1);
+        if (packItemActive(pPlayer, kPackDivingSuit))
+            packUseItem(pPlayer, kPackDivingSuit);
     }
     int nType = kDudePlayer1-kDudeBase;
     switch (pPlayer->posture)

--- a/source/blood/src/player.cpp
+++ b/source/blood/src/player.cpp
@@ -644,6 +644,12 @@ void playerResetPowerUps(PLAYER* pPlayer)
             continue;
         pPlayer->pwUpTime[i] = 0;
     }
+    if (!VanillaMode() && (pPlayer == gView)) // reset delirium tilt view variables
+    {
+        gScreenTiltO = gScreenTilt = 0;
+        deliriumTurnO = deliriumTurn = 0;
+        deliriumPitchO = deliriumPitch = 0;
+    }
 }
 
 void playerResetPosture(PLAYER* pPlayer) {

--- a/source/blood/src/player.h
+++ b/source/blood/src/player.h
@@ -53,6 +53,17 @@ enum
     kPostureMax    = 3,
 };
 
+// inventory pack
+enum
+{
+    kPackMedKit      = 0,
+    kPackDivingSuit  = 1,
+    kPackCrystalBall = 2,
+    kPackBeastVision = 3,
+    kPackJumpBoots   = 4,
+    kPackMax         = 5,
+};
+
 struct PACKINFO
 {
     bool isActive;       // is active (0/1)
@@ -188,7 +199,7 @@ struct PLAYER
     bool                cantJump;
     int                 packItemTime;  // pack timer
     int                 packItemId;    // pack id 1: diving suit, 2: crystal ball, 3: beast vision 4: jump boots
-    PACKINFO            packSlots[5];  // at325 [1]: diving suit, [2]: crystal ball, [3]: beast vision [4]: jump boots
+    PACKINFO            packSlots[kPackMax];
     int                 armor[3];      // armor
     //int               at342;
     //int               at346;

--- a/source/blood/src/sfx.cpp
+++ b/source/blood/src/sfx.cpp
@@ -80,15 +80,13 @@ void Calc3DValues(BONKLE *pBonkle)
     lVol = Vol3d(angle - (gMe->pSprite->ang - 85), v18);
     int phaseLeft = mulscale16r(distanceL, pBonkle->format == 1 ? 4114 : 8228);
     lPitch = scale(pBonkle->pitch, dmulscale30r(cosVal, earVL.dx, sinVal, earVL.dy) + 5853, v8 + 5853);
-    if (lPitch < 0 || lPitch > pBonkle->pitch * 4)
-        lPitch = pBonkle->pitch;
+    lPitch = ClipRange(lPitch, 5000, 50000);
 
     int distanceR = approxDist(pBonkle->curPos.x - earR.x, pBonkle->curPos.y - earR.y);
     rVol = Vol3d(angle - (gMe->pSprite->ang + 85), v14);
     int phaseRight = mulscale16r(distanceR, pBonkle->format == 1 ? 4114 : 8228);
     rPitch = scale(pBonkle->pitch, dmulscale30r(cosVal, earVR.dx, sinVal, earVR.dy) + 5853, v8 + 5853);
-    if (rPitch < 0 || rPitch > pBonkle->pitch * 4)
-        rPitch = pBonkle->pitch;
+    rPitch = ClipRange(rPitch, 5000, 50000);
 
     int phaseMin = ClipHigh(phaseLeft, phaseRight);
     lPhase = phaseRight - phaseMin;

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -3493,7 +3493,6 @@ void viewDrawScreen(void)
         const char bLink = CheckLink((int*)&cX, (int*)&cY, (int*)&cZ, &nSectnum);
         int v78 = gViewInterpolate ? interpolateang(gScreenTiltO, gScreenTilt, gInterpolate) : gScreenTilt;
         char v14 = 0;
-        char v10 = 0;
         bool bDelirium = powerupCheck(gView, kPwUpDeliriumShroom) > 0;
         static bool bDeliriumOld = false;
         int tiltcs = 0, tiltdim = 320;
@@ -3845,8 +3844,8 @@ RORHACK:
             viewingRange = viewingrange;
             yxAspect = yxaspect;
             renderSetAspect(65536, 54613);
-            rotatesprite(280<<16, 35<<16, 53248, 512, 4077, v10, v14, 512+6, gViewX0, gViewY0, gViewX1, gViewY1);
-            rotatesprite(280<<16, 35<<16, 53248, 0, 1683, v10, 0, 512+35, gViewX0, gViewY0, gViewX1, gViewY1);
+            rotatesprite(280<<16, 35<<16, 53248, 512, 4077, 0, v14, 512+6, gViewX0, gViewY0, gViewX1, gViewY1);
+            rotatesprite(280<<16, 35<<16, 53248, 0, 1683, 0, 0, 512+35, gViewX0, gViewY0, gViewX1, gViewY1);
             renderSetAspect(viewingRange, yxAspect);
         }
         

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -1906,7 +1906,7 @@ void viewInit(void)
         lensTable[i] = B_LITTLE32(lensTable[i]);
     }
 #endif
-    char *data = tileAllocTile(4077, kLensSize, kLensSize, 0, 0);
+    char *data = tileAllocTile(LENSBUFFER, kLensSize, kLensSize, 0, 0);
     memset(data, 255, kLensSize*kLensSize);
     gGameMessageMgr.SetState(gMessageState);
     gGameMessageMgr.SetCoordinates(1, 1);
@@ -3142,14 +3142,16 @@ void viewSetErrorMessage(const char *pMessage)
 
 void DoLensEffect(void)
 {
-    char *d = (char*)waloff[4077];
+    char *d = (char*)waloff[LENSBUFFER];
     dassert(d != NULL);
-    char *s = (char*)waloff[4079];
+    char *s = (char*)waloff[CRYSTALBALLBUFFER];
     dassert(s != NULL);
     for (int i = 0; i < kLensSize*kLensSize; i++, d++)
+    {
         if (lensTable[i] >= 0)
             *d = s[lensTable[i]];
-    tileInvalidate(4077, -1, -1);
+    }
+    tileInvalidate(LENSBUFFER, -1, -1);
 }
 
 void UpdateDacs(int nPalette, bool bNoTint)
@@ -3492,7 +3494,7 @@ void viewDrawScreen(void)
         }
         const char bLink = CheckLink((int*)&cX, (int*)&cY, (int*)&cZ, &nSectnum);
         int v78 = gViewInterpolate ? interpolateang(gScreenTiltO, gScreenTilt, gInterpolate) : gScreenTilt;
-        char v14 = 0;
+        char nPalCrystalBall = 0;
         bool bDelirium = powerupCheck(gView, kPwUpDeliriumShroom) > 0;
         static bool bDeliriumOld = false;
         int tiltcs = 0, tiltdim = 320;
@@ -3543,11 +3545,11 @@ void viewDrawScreen(void)
             }
             PLAYER *pOther = &gPlayer[i];
             //othercameraclock = gGameClock;
-            if (!waloff[4079])
+            if (!waloff[CRYSTALBALLBUFFER])
             {
-                tileAllocTile(4079, 128, 128, 0, 0);
+                tileAllocTile(CRYSTALBALLBUFFER, 128, 128, 0, 0);
             }
-            renderSetTarget(4079, 128, 128);
+            renderSetTarget(CRYSTALBALLBUFFER, 128, 128);
             renderSetAspect(65536, 78643);
             int vd8 = pOther->pSprite->x;
             int vd4 = pOther->pSprite->y;
@@ -3576,9 +3578,7 @@ void viewDrawScreen(void)
             CalcOtherPosition(pOther->pSprite, &vd8, &vd4, &vd0, &vcc, v50, 0);
             CheckLink(&vd8, &vd4, &vd0, &vcc);
             if (IsUnderwaterSector(vcc))
-            {
-                v14 = 10;
-            }
+                nPalCrystalBall = 10;
             memcpy(bakMirrorGotpic, gotpic+510, 2);
             memcpy(gotpic+510, otherMirrorGotpic, 2);
             g_visibility = (int32_t)(ClipLow(gVisibility-32*pOther->visibility, 0) * (numplayers > 1 ? 1.f : r_ambientlightrecip));
@@ -3838,13 +3838,13 @@ RORHACK:
             rotatesprite(0, 200<<16, 65536, 0, 2358, 0, 0, 256+22, gViewX0, gViewY0, gViewX1, gViewY1);
             rotatesprite(320<<16, 200<<16, 65536, 1024, 2358, 0, 0, 512+18, gViewX0, gViewY0, gViewX1, gViewY1);
         }
-        if (bCrystalBall && waloff[4079])
+        if (bCrystalBall && waloff[CRYSTALBALLBUFFER])
         {
             DoLensEffect();
             viewingRange = viewingrange;
             yxAspect = yxaspect;
             renderSetAspect(65536, 54613);
-            rotatesprite(280<<16, 35<<16, 53248, 512, 4077, 0, v14, 512+6, gViewX0, gViewY0, gViewX1, gViewY1);
+            rotatesprite(280<<16, 35<<16, 53248, kAng90, LENSBUFFER, 0, nPalCrystalBall, 512+6, gViewX0, gViewY0, gViewX1, gViewY1);
             rotatesprite(280<<16, 35<<16, 53248, 0, 1683, 0, 0, 512+35, gViewX0, gViewY0, gViewX1, gViewY1);
             renderSetAspect(viewingRange, yxAspect);
         }

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -3838,7 +3838,7 @@ RORHACK:
             rotatesprite(0, 200<<16, 65536, 0, 2358, 0, 0, 256+22, gViewX0, gViewY0, gViewX1, gViewY1);
             rotatesprite(320<<16, 200<<16, 65536, 1024, 2358, 0, 0, 512+18, gViewX0, gViewY0, gViewX1, gViewY1);
         }
-        if (bCrystalBall)
+        if (bCrystalBall && waloff[4079])
         {
             DoLensEffect();
             viewingRange = viewingrange;

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -459,7 +459,7 @@ void fakeProcessInput(PLAYER *pPlayer, GINPUT *pInput)
         break;
     default:
         if (!predict.at6f && predict.at71 && predict.at6a == 0) {
-            if (packItemActive(pPlayer, 4)) predict.at64 = pPosture->pwupJumpZ;//-0x175555;
+            if (packItemActive(pPlayer, kPackJumpBoots)) predict.at64 = pPosture->pwupJumpZ;//-0x175555;
             else predict.at64 = pPosture->normalJumpZ;//-0xbaaaa;
             predict.at6f = 1;
         }
@@ -1205,7 +1205,7 @@ void TileHGauge(int nTile, int x, int y, int nMult, int nDiv, int nStat, int nSc
     rotatesprite(x<<16, y<<16, nScale, 0, nTile, 0, 0, nStat|90, 0, 0, sbx, ydim-1);
 }
 
-int gPackIcons[5] = {
+int gPackIcons[kPackMax] = {
     2569, 2564, 2566, 2568, 2560
 };
 
@@ -1215,7 +1215,7 @@ struct PACKICON2 {
     int nYOffs;
 };
 
-PACKICON2 gPackIcons2[] = {
+PACKICON2 gPackIcons2[kPackMax] = {
     { 519, (int)(65536*0.5), 0 },
     { 830, (int)(65536*0.3), 0 },
     { 760, (int)(65536*0.6), 0 },
@@ -1398,12 +1398,12 @@ void viewDrawAimedPlayerName(void)
 
 void viewDrawPack(PLAYER *pPlayer, int x, int y)
 {
-    int packs[5];
+    int packs[kPackMax];
     if (pPlayer->packItemTime)
     {
         int nPacks = 0;
         int width = 0;
-        for (int i = 0; i < 5; i++)
+        for (int i = 0; i < kPackMax; i++)
         {
             if (pPlayer->packSlots[i].curAmount)
             {
@@ -1873,7 +1873,7 @@ void viewPrecacheTiles(void)
     {
         tilePrecacheTile(kSBarNegative + i, 0);
     }
-    for (int i = 0; i < 5; i++)
+    for (int i = 0; i < kPackMax; i++)
     {
         tilePrecacheTile(gPackIcons[i], 0);
         tilePrecacheTile(gPackIcons2[i].nTile, 0);
@@ -3834,7 +3834,7 @@ RORHACK:
         {
             viewBurnTime(gView->pXSprite->burnTime);
         }
-        if (packItemActive(gView, 1))
+        if (packItemActive(gView, kPackDivingSuit))
         {
             rotatesprite(0, 0, 65536, 0, 2344, 0, 0, 256+18, gViewX0, gViewY0, gViewX1, gViewY1);
             rotatesprite(320<<16, 0, 65536, 1024, 2344, 0, 0, 512+22, gViewX0, gViewY0, gViewX1, gViewY1);

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -2447,7 +2447,7 @@ tspritetype *viewAddEffect(int nTSprite, VIEW_EFFECT nViewEffect)
         pNSprite->shade = pTSprite->shade;
         pNSprite->xrepeat = 32;
         pNSprite->yrepeat = 32;
-        pNSprite->ang = (gView->pSprite->ang + 512) & 2047; // always face viewer
+        pNSprite->ang = (gCameraAng + kAng90) & kAngMask; // always face viewer
         const int nVoxel = voxelIndex[nTile];
         if (gShowWeapon == 2 && usevoxels && gDetail >= 4 && videoGetRenderMode() != REND_POLYMER && nVoxel != -1)
         {

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -3506,7 +3506,7 @@ void viewDrawScreen(void)
             if (videoGetRenderMode() == REND_CLASSIC)
             {
                 int vr = viewingrange;
-                walock[TILTBUFFER] = 255;
+                walock[TILTBUFFER] = CACHE1D_PERMANENT;
                 if (!waloff[TILTBUFFER])
                 {
                     tileAllocTile(TILTBUFFER, 640, 640, 0, 0);


### PR DESCRIPTION
This PR defines a new set of kPack constants used by player inventory, as well as resolving the annoying reverb bug by reloading a save while reflective shots powerup is active. Other edits include giving crystal ball tile a constant define, and tweaking audio pitch adjustment for doppler calculation to match 1.21 behavior.