### PR TITLE
Blood Allow fire button to be used for tnt/spray throw

### DIFF
--- a/source/blood/src/weapon.cpp
+++ b/source/blood/src/weapon.cpp
@@ -1813,14 +1813,15 @@ char WeaponFindLoaded(PLAYER *pPlayer, int *a2)
 
 char processSprayCan(PLAYER *pPlayer)
 {
+    const char bUseShootAsThrow = !VanillaMode() && pPlayer->input.buttonFlags.shoot;
     switch (pPlayer->weaponState)
     {
     case 5:
-        if (!pPlayer->input.buttonFlags.shoot2)
+        if (!pPlayer->input.buttonFlags.shoot2 || bUseShootAsThrow)
             pPlayer->weaponState = 6;
         return 1;
     case 6:
-        if (pPlayer->input.buttonFlags.shoot2)
+        if (pPlayer->input.buttonFlags.shoot2 && !bUseShootAsThrow)
         {
             pPlayer->weaponState = 3;
             pPlayer->fuseTime = pPlayer->weaponTimer;
@@ -1851,14 +1852,15 @@ char processSprayCan(PLAYER *pPlayer)
 
 char processTNT(PLAYER *pPlayer)
 {
+    const char bUseShootAsThrow = !VanillaMode() && pPlayer->input.buttonFlags.shoot;
     switch (pPlayer->weaponState)
     {
     case 4:
-        if (!pPlayer->input.buttonFlags.shoot2)
+        if (!pPlayer->input.buttonFlags.shoot2 || bUseShootAsThrow)
             pPlayer->weaponState = 5;
         return 1;
     case 5:
-        if (pPlayer->input.buttonFlags.shoot2)
+        if (pPlayer->input.buttonFlags.shoot2 && !bUseShootAsThrow)
         {
             pPlayer->weaponState = 1;
             pPlayer->fuseTime = pPlayer->weaponTimer;


### PR DESCRIPTION
This PR removes the issue where holding down alt fire blocks the fire button being used for throwing tnt/spray cans.