### PR TITLE
Blood: Use network friendly QRand for sfxPlay3DSoundCP()

### DIFF
--- a/source/blood/src/sfx.cpp
+++ b/source/blood/src/sfx.cpp
@@ -272,7 +272,7 @@ void sfxPlay3DSoundCP(spritetype* pSprite, int soundId, int chanId, int nFlags, 
     if (size <= 0) return;
     
     if (pitch <= 0) pitch = pEffect->pitch;
-    else pitch -= Random(pEffect->pitchRange);
+    else pitch -= QRandom(pEffect->pitchRange);
 
     int v14;
     v14 = mulscale16(pitch, sndGetRate(pEffect->format));


### PR DESCRIPTION
This PR fixes a possible desync when using sfxPlay3DSoundCP(). If a client had sound turned off, this function will not call Random(), and thus would introduce a desync for that client. By using QRand this ensures no such desync will happen.