### PR TITLE
Blood: Fix prev weap cycling bug for TNT

### DIFF
--- a/source/blood/src/weapon.cpp
+++ b/source/blood/src/weapon.cpp
@@ -2082,13 +2082,13 @@ void WeaponProcess(PLAYER *pPlayer) {
     }
     if ((pPlayer->curWeapon == kWeaponNone) && (pPlayer->input.newWeapon != kWeaponNone) && !VanillaMode()) // if player is switching weapon (and not holstered), clear next/prev keyflags
     {
-        pPlayer->input.keyFlags.nextWeapon = kWeaponNone;
-        pPlayer->input.keyFlags.prevWeapon = kWeaponNone;
+        pPlayer->input.keyFlags.nextWeapon = 0;
+        pPlayer->input.keyFlags.prevWeapon = 0;
     }
     const KEYFLAGS oldKeyFlags = pPlayer->input.keyFlags; // used to fix next/prev weapon issue for banned weapons
     if (pPlayer->input.keyFlags.nextWeapon)
     {
-        pPlayer->input.keyFlags.nextWeapon = kWeaponNone;
+        pPlayer->input.keyFlags.nextWeapon = 0;
         if (VanillaMode())
         {
             pPlayer->weaponState = 0;
@@ -2110,7 +2110,7 @@ void WeaponProcess(PLAYER *pPlayer) {
     }
     if (pPlayer->input.keyFlags.prevWeapon)
     {
-        pPlayer->input.keyFlags.prevWeapon = kWeaponNone;
+        pPlayer->input.keyFlags.prevWeapon = 0;
         if (VanillaMode())
         {
             pPlayer->weaponState = 0;

--- a/source/blood/src/weapon.cpp
+++ b/source/blood/src/weapon.cpp
@@ -1991,6 +1991,7 @@ void WeaponProcess(PLAYER *pPlayer) {
     }
     #endif
 
+    char bTNTRemoteProxyCycling = 1;
     if (pPlayer->pXSprite->health == 0)
     {
         pPlayer->qavLoop = 0;
@@ -2106,6 +2107,10 @@ void WeaponProcess(PLAYER *pPlayer) {
                 return;
             }
         }
+        else
+        {
+            bTNTRemoteProxyCycling = 0; // next weapon should bypass tnt cycling logic
+        }
         pPlayer->input.newWeapon = weapon;
     }
     if (pPlayer->input.keyFlags.prevWeapon)
@@ -2127,6 +2132,10 @@ void WeaponProcess(PLAYER *pPlayer) {
                 pPlayer->nextWeapon = weapon;
                 return;
             }
+        }
+        else
+        {
+            bTNTRemoteProxyCycling = 0; // prev weapon should bypass tnt cycling logic
         }
         pPlayer->input.newWeapon = weapon;
     }
@@ -2174,7 +2183,7 @@ void WeaponProcess(PLAYER *pPlayer) {
                 pPlayer->curWeapon = oldWeapon;
             }
         }
-        if (pPlayer->input.newWeapon == kWeaponTNT)
+        if (bTNTRemoteProxyCycling && (pPlayer->input.newWeapon == kWeaponTNT))
         {
             if (pPlayer->curWeapon == kWeaponTNT)
             {


### PR DESCRIPTION
This PR fixes a bug introduced in commit https://github.com/nukeykt/NBlood/commit/6980e8b35527dfba1f994d97bef58505773a26ec.

When equipped with TNT, Remote TNT and Proxy TNT, attempting to switch to TNT via previous weapon will trigger the auto cycle TNT logic, and reselect Proxy TNT instead.