### PR TITLE
match startgtk.game.cpp to commit 08056b05d5d986a6bd94b1ca095cbf10d44…

### DIFF
--- a/source/tekwar/src/startgtk.game.cpp
+++ b/source/tekwar/src/startgtk.game.cpp
@@ -758,6 +758,10 @@ static GtkWidget *create_window(void)
 
 
 // -- BUILD ENTRY POINTS ------------------------------------------------------
+bool startwin_isopen(void)
+{
+    return gtkenabled && stwidgets.startwin;
+}
 
 int32_t startwin_open(void)
 {

--- a/source/witchaven/src/startgtk.game.cpp
+++ b/source/witchaven/src/startgtk.game.cpp
@@ -758,6 +758,10 @@ static GtkWidget *create_window(void)
 
 
 // -- BUILD ENTRY POINTS ------------------------------------------------------
+bool startwin_isopen(void)
+{
+    return gtkenabled && stwidgets.startwin;
+}
 
 int32_t startwin_open(void)
 {


### PR DESCRIPTION
This PR is the sibling of commit 08056b05d5d986a6bd94b1ca095cbf10d44f09f0 ```ETekWar/EWitchaven: Add missing startwin_isopen()``` which added the statement to ```startwin.game.cpp```.  This does the same for ```startgtk.game.cpp```.