### PR TITLE
gModernMap:

### DIFF
--- a/source/blood/src/actor.cpp
+++ b/source/blood/src/actor.cpp
@@ -5849,7 +5849,7 @@ void actProcessSprites(void)
             pDb = pList->Last(); len = pList->Length();
 
             // trigger sprites from impact list
-            while (--len >= 0)
+            while (--len >= 0 && *pDb != kListEndDefault)
             {
                 pSpr = &sprite[*pDb];
                 if (!(pSpr->flags & kHitagFree))

--- a/source/blood/src/aiunicult.cpp
+++ b/source/blood/src/aiunicult.cpp
@@ -1250,14 +1250,23 @@ void killDudeLeech(spritetype* pLeech) {
 }
     
 XSPRITE* getNextIncarnation(XSPRITE* pXSprite) {
-    for (int i = bucketHead[pXSprite->txID]; i < bucketHead[pXSprite->txID + 1]; i++) {
-        if (rxBucket[i].type != 3 || rxBucket[i].index == pXSprite->reference)
-            continue;
-        
-        if (sprite[rxBucket[i].index].statnum == kStatInactive)
-            return &xsprite[sprite[rxBucket[i].index].extra];
+    
+    RXBUCKET* pRx; int s, e, t = -1;
+    getRxBucket(pXSprite->txID, &s, &e, &pRx);
+    while (s < e)
+    {
+        if (pRx->type == OBJ_SPRITE && sprite[pRx->index].statnum == kStatInactive)
+        {
+            t = pRx->index;
+            if (nnExtRandom(0, 6) == 3)
+                break;
+        }
+
+        pRx++;
+        s++;
     }
-    return NULL;
+
+    return (t >= 0) ? &xsprite[sprite[t].extra] : NULL;
 }
 
 bool dudeIsMelee(XSPRITE* pXSprite) {
@@ -1788,13 +1797,15 @@ void genDudeTransform(spritetype* pSprite) {
             // re-init sprite
             aiInitSprite(pSprite);
 
-            // try to restore target
-            if (target == -1) aiSetTarget(pXSprite, pSprite->x, pSprite->y, pSprite->z);
-            else aiSetTarget(pXSprite, target);
+            if (!pXSprite->dudeFlag4)
+            {
+                // try to restore target
+                if (target == -1) aiSetTarget(pXSprite, pSprite->x, pSprite->y, pSprite->z);
+                else aiSetTarget(pXSprite, target);
 
-            // finally activate it
-            aiActivateDude(pSprite, pXSprite);
-
+                // finally activate it
+                aiActivateDude(pSprite, pXSprite);
+            }
             break;
     }
     pXIncarnation->triggerOn = triggerOn;

--- a/source/blood/src/aiunicult.cpp
+++ b/source/blood/src/aiunicult.cpp
@@ -1157,7 +1157,7 @@ bool playGenDudeSound(spritetype* pSprite, int mode) {
     // ensure sound played in it's full length (if not interruptable)
     if (pExtra->sndPlaying && !sndInfo->interruptable)
     {
-        register int i = nBonkles;
+        int i = nBonkles;
         while(--i >= 0)
         {
             BONKLE* pBonk = &Bonkle[i];

--- a/source/blood/src/eventq.cpp
+++ b/source/blood/src/eventq.cpp
@@ -600,7 +600,7 @@ void evKill(int a1, int a2)
 void evKill(int idx, int type, int causer)
 {
     #ifdef NOONE_EXTENSIONS
-    if (gModernMap)
+    if (gModernMap && isPartOfCauserScript(type, idx))
         eventQ.Kill(idx, type, causer);
     else
     #endif

--- a/source/blood/src/nnexts.cpp
+++ b/source/blood/src/nnexts.cpp
@@ -279,7 +279,7 @@ void nnExResetPatrolBonkles() {
 
 char idListProcessProxySprite(int32_t nSpr)
 {
-    register int i, okDist;
+    int i, okDist;
     bool causerPart;
 
     spritetype* pSpr = &sprite[nSpr];
@@ -338,7 +338,7 @@ char idListProcessProxySprite(int32_t nSpr)
 char idListProcessSightSprite(int32_t nSpr)
 {
     static int z[3];
-    register int i, j;
+    int i, j;
     spritetype* pSpr = &sprite[nSpr];
     PLAYER* pPlayer; spritetype* pPlaySpr;
     bool causerPart;
@@ -728,7 +728,7 @@ void getSectorWalls(int nSect, int* swal, int* ewal)
 
 bool isMultiTx(short nSpr)
 {
-    register int i, j = 0;
+    int i, j = 0;
     if (sprite[nSpr].statnum < kStatFree && (sprite[nSpr].type == 25 || sprite[nSpr].type == 26))
     {
         for (i = 0; i < 4; i++)
@@ -740,7 +740,7 @@ bool isMultiTx(short nSpr)
 
 bool multiTxGetRange(int nSpr, int out[4])
 {
-    register int j;
+    int j;
     XSPRITE* pXSpr = &xsprite[sprite[nSpr].extra];
     for (j = 0; j < 4; j++) out[j] = 0;
 
@@ -764,7 +764,7 @@ bool multiTxGetRange(int nSpr, int out[4])
 
 bool multiTxPointsRx(int rx, short nSpr)
 {
-    register int j; int txrng[4];
+    int j; int txrng[4];
 
     // ranged
     if (multiTxGetRange(nSpr, txrng))
@@ -785,7 +785,7 @@ bool multiTxPointsRx(int rx, short nSpr)
 int collectObjectsByChannel(int nChannel, bool rx, OBJECT_LIST* pOut, char flags)
 {
     bool ok, link = false, unlink = false;
-    register int i = numsectors;
+    int i = numsectors;
     int c = 0, j, s, e, f;
 
     //return 0;
@@ -880,7 +880,7 @@ int getChannelOf(int objType, int objIdx, bool rx)
 
 int collectBranchByChannel(int nChannelA, bool rx, OBJECT_LIST* pOut)
 {
-    register int i = 0, l, nChannelB;
+    int i = 0, l, nChannelB;
     OBJECT_LIST objects; OBJECT* pObj;
 
     collectObjectsByChannel(nChannelA, rx, &objects, 0);
@@ -905,7 +905,7 @@ int collectBranchByChannel(int nChannelA, bool rx, OBJECT_LIST* pOut)
 void nnExtInitCauserTable()
 {
     OBJECT_LIST objects; OBJECT* pObj;
-    register int t = sizeof(OBJECT_STATUS1) * (OBJ_SECTOR + 1);
+    int t = sizeof(OBJECT_STATUS1) * (OBJ_SECTOR + 1);
     collectBranchByChannel(kChannelEventCauser, false, &objects);
 
     if (!gEvCauser)
@@ -926,7 +926,7 @@ void nnExtInitCauserTable()
 
 void nnExtInitSprite(int nSpr, bool bSaveLoad)
 {
-    register int i;
+    int i;
     spritetype* pSpr = &sprite[nSpr];
     if ((pSpr->flags & kHitagFree))
         return;
@@ -1181,7 +1181,7 @@ void nnExtInitSprite(int nSpr, bool bSaveLoad)
 
 void nnExtInitModernStuff(bool bSaveLoad) {
     
-    register int i, j;
+    int i, j;
     nnExtResetGlobals();
 
     // initialize super xsprites lists
@@ -5693,7 +5693,7 @@ void useGibObject(XSPRITE* pXSource, spritetype* pSpr)
         pSpr = pSource;
 
     static int a[3];
-    register int e, i = pSpr->index;
+    int e, i = pSpr->index;
     a[0] = ClipRange(pXSource->data1, 0, 31);
     a[1] = ClipRange(pXSource->data2, 0, 31);
     a[2] = ClipRange(pXSource->data3, 0, 31);
@@ -7605,14 +7605,14 @@ int getVelocityAngle(spritetype* pSpr)
 
 void killEffectGenCallbacks(int oId, int oType = OBJ_SPRITE)
 {
-    register int l = sizeof(gEffectGenCallbacks) / sizeof(gEffectGenCallbacks[0]);
+    int l = sizeof(gEffectGenCallbacks) / sizeof(gEffectGenCallbacks[0]);
     while (--l >= 0)
         evKill(oId, oType, (CALLBACK_ID)gEffectGenCallbacks[l]);
 }
 
 void killEffectGenCallbacks(XSPRITE* pXSource)
 {
-    register int i, j;
+    int i, j;
     if (pXSource->data2 < kEffectGenCallbackBase)
         return;
 

--- a/source/blood/src/nnexts.h
+++ b/source/blood/src/nnexts.h
@@ -296,7 +296,7 @@ public:
         if (limit > 0 && length >= limit)
             ThrowError("Limit of %d items in list reached!", limit);
 
-        register int t = length; db[length++] = nID;
+        int t = length; db[length++] = nID;
         db = (int32_t*)Brealloc(db, (length + 1) * sizeof(int32_t));
         dassert(db != NULL);
         
@@ -306,7 +306,7 @@ public:
 
     int32_t* AddIfNotExists(int nID)
     {
-        register int t;
+        int t;
         if ((t = Find(nID)) != EOL)
             return &db[t];
 
@@ -338,7 +338,7 @@ public:
 
     int Find(int nID)
     {
-        register int i = length;
+        int i = length;
         while (--i >= 0)
         {
             if (db[i] == nID)
@@ -365,7 +365,7 @@ public:
 
     void Process(char(*pFunc)(int32_t), bool reverse)
     {
-        register int i;
+        int i;
         if (reverse)
         {
             i = length;
@@ -451,7 +451,7 @@ public:
 
     int Find(int nType, int nIndex)
     {
-        register int i;
+        int i;
         for (i = 0; i < externalCount; i++)
         {
             if (db[i].type == nType && db[i].index == nIndex)

--- a/source/blood/src/nnexts.h
+++ b/source/blood/src/nnexts.h
@@ -228,6 +228,20 @@ struct PATROL_FOUND_SOUNDS {
     int cur;
 
 };
+
+struct OBJECT_STATUS1
+{
+    struct
+    {
+        unsigned int ok : 1;
+    }
+#if kMaxSprites >= kMaxSectors
+    id[kMaxSprites];
+#else
+    id[kMaxSectors];
+#endif
+};
+
 #pragma pack(pop)
 
 
@@ -355,7 +369,7 @@ public:
         if (reverse)
         {
             i = length;
-            while (--i >= 0)
+            while (--i >= 0 && db[i] != EOL)
             {
                 if (pFunc(db[i]) == kListREMOVE)
                     Remove(i, true);
@@ -448,35 +462,6 @@ public:
     }
 };
 
-// SPRITES_NEAR_SECTORS
-// Intended for move sprites that is close to the outside walls with
-// TranslateSector and/or zTranslateSector similar to Powerslave(Exhumed) way
-// --------------------------------------------------------------------------
-class SPRINSECT
-{
-#define kMaxSprNear 256
-#define kWallDist	16
-
-private:
-    struct SPRITES
-    {
-        unsigned int nSector;
-        signed   int sprites[kMaxSprNear + 1];
-    };
-    SPRITES* db;
-    unsigned int length;
-    bool Alloc(int nLength); // normally should be used when loading saved game
-public:
-    void Free();
-    void Init(int nDist = kWallDist); // used in trInit to collect the sprites before translation
-    void Save(LoadSave* pSave);
-    void Load(LoadSave* pLoad);
-    int* GetSprPtr(int nSector);
-    ~SPRINSECT() { Free(); };
-
-};
-
-
 // - VARIABLES ------------------------------------------------------------------
 extern bool gTeamsSpawnUsed;
 extern bool gEventRedirectsUsed;
@@ -489,12 +474,12 @@ extern DUDEINFO_EXTRA gDudeInfoExtra[kDudeMax];
 extern TRPLAYERCTRL gPlayerCtrl[kMaxPlayers];
 extern SPRITEMASS gSpriteMass[kMaxXSprites];
 extern AISTATE genPatrolStates[kPatrolStateSize];
-extern SPRINSECT gSprNSect;
 
 extern IDLIST gProxySpritesList;
 extern IDLIST gSightSpritesList;
 extern IDLIST gImpactSpritesList;
 extern IDLIST gPhysSpritesList;
+extern OBJECT_STATUS1* gEvCauser;
 
 // - FUNCTIONS ------------------------------------------------------------------
 inline bool xsprIsFine(spritetype* pSpr);
@@ -560,6 +545,7 @@ void useDudeSpawn(XSPRITE* pXSource, spritetype* pSprite);
 void useCustomDudeSpawn(XSPRITE* pXSource, spritetype* pSprite);
 void useVelocityChanger(XSPRITE* pXSource, int causerID, short objType, int objIndex);
 void useGibObject(XSPRITE* pXSource, spritetype* pSpr);
+void useDripGenerator(XSPRITE* pXSource, spritetype* pSprite);
 bool txIsRanged(XSPRITE* pXSource);
 void seqTxSendCmdAll(XSPRITE* pXSource, int nIndex, COMMAND_ID cmd, bool modernSend, int causerID);
 //  -------------------------------------------------------------------------   //
@@ -668,12 +654,192 @@ bool isMovableSector(sectortype* pSect);
 bool isUnderwaterSector(XSECTOR* pXSect);
 bool isUnderwaterSector(sectortype* pSect);
 bool isUnderwaterSector(int nSector);
-
 bool isOnRespawn(spritetype* pSpr);
 int getDigitFromValue(int nVal, int nOffs);
 void killEffectGenCallbacks(XSPRITE* pXSource);
 bool seqCanOverride(Seq* pSeq, int nFrame, bool* xrp, bool* yrp, bool* plu);
+void getRxBucket(int nChannel, int* nStart, int* nEnd, RXBUCKET** pRx = NULL);
+inline bool isPartOfCauserScript(int objType, int objIndex)
+{
+    return gEvCauser[objType].id[objIndex].ok;
+}
 
+// SPRITES_NEAR_SECTORS
+// Intended for move sprites that is close to the outside walls with
+// TranslateSector and/or zTranslateSector similar to Powerslave(Exhumed) way
+// --------------------------------------------------------------------------
+class SPRINSECT
+{
+#define kMaxSprNear 256
+#define kWallDist	16
+
+private:
+    //-----------------------------------------------------------------------------------
+    struct SPRITES
+    {
+        unsigned int nSector;
+        signed   int sprites[kMaxSprNear + 1];
+    };
+    SPRITES* db;
+    unsigned int length;
+    //-----------------------------------------------------------------------------------
+    bool Alloc(int nLength) // normally should be used when loading saved game
+    {
+        Free();
+        if (nLength <= 0)
+            return false;
+
+        db = (SPRITES*)Bmalloc(nLength * sizeof(SPRITES));
+        dassert(db != NULL);
+
+        length = nLength;
+        while (nLength--)
+        {
+            SPRITES* pEntry = &db[nLength];
+            Bmemset(pEntry->sprites, -1, sizeof(pEntry->sprites));
+        }
+
+        return true;
+    }
+    //-----------------------------------------------------------------------------------
+public:
+    void Free()
+    {
+        length = 0;
+        if (db)
+            Bfree(db), db = NULL;
+    }
+    //-----------------------------------------------------------------------------------
+    void Init(int nDist = kWallDist) // used in trInit to collect the sprites before translation
+    {
+        Free();
+
+        int i, j, k, nSprites;
+        int* collected = (int*)Bmalloc(sizeof(int) * kMaxSprites);
+        for (i = 0; i < numsectors; i++)
+        {
+            sectortype* pSect = &sector[i];
+            if (!isMovableSector(pSect->type))
+                continue;
+
+            switch (pSect->type) {
+            case kSectorZMotionSprite:
+            case kSectorSlideMarked:
+            case kSectorRotateMarked:
+                continue;
+                // only allow non-marked sectors
+            default:
+                break;
+            }
+
+            nSprites = getSpritesNearWalls(i, collected, kMaxSprites, nDist);
+
+            // exclude sprites that is not allowed
+            for (j = nSprites - 1; j >= 0; j--)
+            {
+                spritetype* pSpr = &sprite[collected[j]];
+                if ((pSpr->cstat & 0x6000) && pSpr->sectnum >= 0)
+                {
+                    // if *next* sector is movable, exclude to avoid fighting
+                    if (!isMovableSector(sector[pSpr->sectnum].type))
+                    {
+                        switch (pSpr->statnum) {
+                        default:
+                            continue;
+                        case kStatMarker:
+                        case kStatPathMarker:
+                            if (pSpr->flags & 0x1) continue;
+                            // no break
+                        case kStatDude:
+                            break;
+                        }
+                    }
+                }
+
+                nSprites--;
+                for (k = j; k < nSprites; k++)
+                    collected[k] = collected[k + 1];
+            }
+
+            if (nSprites > 0)
+            {
+                db = (SPRITES*)Brealloc(db, ((unsigned int)(length + 1)) * sizeof(SPRITES));
+                dassert(db != NULL);
+
+                SPRITES* pEntry = &db[length];
+                Bmemset(pEntry->sprites, -1, sizeof(pEntry->sprites));
+                Bmemcpy(pEntry->sprites, collected, sizeof(pEntry->sprites[0]) * ClipHigh(nSprites, kMaxSprNear));
+                pEntry->nSector = i;
+                length++;
+            }
+        }
+
+        Bfree(collected);
+    }
+    //-----------------------------------------------------------------------------------
+    void Save(LoadSave* pSave)
+    {
+        unsigned int i, j;
+        pSave->Write(&length, sizeof(length));  // total db length
+        for (i = 0; i < length; i++)
+        {
+            // owner sector
+            pSave->Write(&db[i].nSector, sizeof(db[i].nSector));
+
+            j = 0;
+            while (j < kMaxSprNear)
+            {
+                pSave->Write(&db[i].sprites[j], sizeof(db[i].sprites[j]));
+                if (db[i].sprites[j] == -1) // sprites end reached
+                    break;
+
+                j++;
+            }
+        }
+    }
+    //-----------------------------------------------------------------------------------
+    void Load(LoadSave* pLoad)
+    {
+        unsigned int i, j;
+
+        pLoad->Read(&i, sizeof(length));
+        if (!Alloc(i))
+            return; // the length is zero
+
+        for (i = 0; i < length; i++)
+        {
+            // owner sector
+            pLoad->Read(&db[i].nSector, sizeof(db[i].nSector));
+
+            j = 0;
+            while (j < kMaxSprNear)
+            {
+                pLoad->Read(&db[i].sprites[j], sizeof(db[i].sprites[j]));
+                if (db[i].sprites[j] == -1) // sprites end reached
+                    break;
+
+                j++;
+            }
+
+        }
+    }
+    //-----------------------------------------------------------------------------------
+    int* GetSprPtr(int nSector)
+    {
+        unsigned int i;
+        for (i = 0; i < length; i++)
+        {
+            if (db[i].nSector == (unsigned int)nSector && db[i].sprites[0] >= 0)
+                return (int*)db[i].sprites;
+        }
+        return NULL;
+    }
+    //-----------------------------------------------------------------------------------
+    ~SPRINSECT() { Free(); };
+
+};
+
+extern SPRINSECT gSprNSect;
 #endif
 
 ////////////////////////////////////////////////////////////////////////

--- a/source/blood/src/nnextsif.cpp
+++ b/source/blood/src/nnextsif.cpp
@@ -228,7 +228,7 @@ static char helperChkWall(int nWall)
 
 static char helperCmpHeight(char ceil)
 {
-    register int nHeigh1, nHeigh2;
+    int nHeigh1, nHeigh2;
     switch (pSect->type)
     {
         case kSectorZMotion:
@@ -306,10 +306,10 @@ static char helperCmpSeq(int (*pFunc) (int, int))
 
 static char helperChkHitscan(int nWhat)
 {
-    register int nAng = pSpr->ang & kAngMask;
-    register int nOldStat = pSpr->cstat;
-    register int nHit = -1, nSlope = 0;
-    register int nMask = -1;
+    int nAng = pSpr->ang & kAngMask;
+    int nOldStat = pSpr->cstat;
+    int nHit = -1, nSlope = 0;
+    int nMask = -1;
 
     if ((nOldStat & CSTAT_SPRITE_ALIGNMENT) == CSTAT_SPRITE_ALIGNMENT_SLOPE)
         nSlope = spriteGetSlope(pSpr->index);
@@ -386,7 +386,7 @@ static char helperChkHitscan(int nWhat)
 
 static char helperChkMarker(int nWhat)
 {
-    register int t;
+    int t;
     if (pXSpr->dudeFlag4 && spriRangeIsFine(pXSpr->target) && sprite[pXSpr->target].type == kMarkerPath)
     {
         switch (nWhat) {
@@ -415,12 +415,12 @@ static char helperChkMarker(int nWhat)
 
 static char helperChkTarget(int nWhat)
 {
-    register int t = 0;
+    int t = 0;
     if (spriRangeIsFine(pXSpr->target))
     {
         spritetype* pTrgt = &sprite[pXSpr->target]; DUDEINFO* pInfo = getDudeInfo(pSpr->type);
-        register int eyeAboveZ = pInfo->eyeHeight * pSpr->yrepeat << 2;
-        register int dx = pTrgt->x - pSpr->x; int dy = pTrgt->y - pSpr->y;
+        int eyeAboveZ = pInfo->eyeHeight * pSpr->yrepeat << 2;
+        int dx = pTrgt->x - pSpr->x; int dy = pTrgt->y - pSpr->y;
 
         switch (nWhat) {
             case 1:
@@ -449,7 +449,7 @@ static char helperChkTarget(int nWhat)
 
 static char helperChkRoom(short* pArray, int nWhat)
 {
-    register int t = pArray[objIndex];
+    int t = pArray[objIndex];
     if (t >= 0)
     {
         if (PUSH)
@@ -495,7 +495,7 @@ static char gamCmpStatnumCount(void)    { return Cmp(gStatCount[ClipRange(arg3, 
 static char gamCmpNumsprites(void)      { return Cmp(Numsprites); }
 static char gamChkPlayerConnect(void)
 {
-    register int i;
+    int i;
     for (i = connecthead; i >= 0; i = connectpoint2[i])
     {
         if (gPlayer[i].nPlayer + 1 != arg3) continue;
@@ -520,7 +520,7 @@ static char sectCmpFloorSlope(void)     { return Cmp(pSect->floorheinum); }
 static char sectCmpCeilSlope(void)      { return Cmp(pSect->ceilingheinum); }
 static char sectChkSprTypeInSect(void)
 {
-    register int i;
+    int i;
     for (i = headspritesect[objIndex]; i >= 0; i = nextspritesect[i])
     {
         if (!Cmp(sprite[i].type)) continue;
@@ -548,7 +548,7 @@ static char wallChkIsMirror(void)
 {
 #if 0
     // new ROR code
-    register int i = mirrorcnt;
+    int i = mirrorcnt;
     while (--i >= 0)
     {
         if (mirror[i].type == 0 && mirror[i].id == objIndex)
@@ -890,7 +890,7 @@ static char mixCmpObjXIndex(void)
 
 static char mixCmpSerials(void)
 {
-    register unsigned int i = 0, d;
+    unsigned int i = 0, d;
     int serials[kPushRange + 1] = { pXCond->targetX,  pXCond->targetY,  pXCond->targetZ,  pXCond->sysData1 };
     int t[3];
     
@@ -960,7 +960,7 @@ static char sprCmpChkVelocity(void)
 static char sprChkUnderwater(void)      { return isUnderwaterSector(pSpr->sectnum); }
 static char sprChkDmgImmune(void)
 {
-    register int i;
+    int i;
     if (arg1 == -1)
     {
         for (i = 0; i < kDmgMax; i++)
@@ -982,7 +982,7 @@ static char sprChkHitscanSpr(void)      { return helperChkHitscan(4); }
 static char sprChkHitscanMasked(void)   { return helperChkHitscan(5); }
 static char sprChkIsTarget(void)
 {
-    register int i;
+    int i;
     for (i = headspritestat[kStatDude]; i >= 0; i = nextspritestat[i])
     {
         if (pSpr->index == i)
@@ -1002,7 +1002,7 @@ static char sprChkIsTarget(void)
 /**---------------------------------------------------------------------------**/
 static char sprCmpHealth(void)
 {
-    register int t = 0;
+    int t = 0;
     if (IsDudeSprite(pSpr))
         t = (pXSpr->sysData2 > 0) ? ClipRange(pXSpr->sysData2 << 4, 1, 65535) : getDudeInfo(pSpr->type)->startHealth << 4;
     else if (pSpr->type == kThingBloodChunks)
@@ -1036,7 +1036,7 @@ static char sprChkTouchWall(void)
 /**---------------------------------------------------------------------------**/
 static char sprChkTouchSpite(void)
 {
-    register int id = -1;
+    int id = -1;
     SPRITEHIT* pHit;
 
     if (xAvail)
@@ -1095,7 +1095,7 @@ static char sprChkTouchSpite(void)
 /**---------------------------------------------------------------------------**/
 static char sprCmpBurnTime(void)
 {
-    register int t = (IsDudeSprite(pSpr)) ? 2400 : 1200;
+    int t = (IsDudeSprite(pSpr)) ? 2400 : 1200;
     if (!Cmp((kPercFull * pXSpr->burnTime) / t)) return false;
     else if (PUSH && spriRangeIsFine(pXSpr->burnSource)) Push(EVOBJ_SPRITE, pXSpr->burnSource);
     return true;
@@ -1103,7 +1103,7 @@ static char sprCmpBurnTime(void)
 /**---------------------------------------------------------------------------**/
 static char sprChkIsFlareStuck(void)
 {
-    register int i;
+    int i;
     for (i = headspritestat[kStatFlare]; i >= 0; i = nextspritestat[i])
     {
         spritetype* pFlare = &sprite[i];
@@ -1163,7 +1163,7 @@ static char gdudCmpAiStateTimer(void)       { return Cmp(pXSpr->stateTimer); };
 static char cdudChkLeechThrown(void) { return helperChkSprite(genDudeExtra(pSpr)->nLifeLeech); };
 static char cdudChkLeechDead(void)
 {
-    register int t;
+    int t;
     t = genDudeExtra(pSpr)->nLifeLeech;
     if (!spriRangeIsFine(t) && pSpr->owner == kMaxSprites - 1) return true;
     else if (PUSH) Push(EVOBJ_SPRITE, t);
@@ -1211,7 +1211,7 @@ static char plyChkPackItemActive(void)      { return (valueIsBetween(arg1, 0, 6)
 static char plyCmpPackItemSelect(void)      { return Cmp(pPlayer->packItemId + 1); }
 static char plyCmpPowerupAmount(void)
 {
-    register int t;
+    int t;
     if (arg3 > 0 && arg3 <= (kMaxAllowedPowerup - (kMinAllowedPowerup << 1) + 1))
     {
         t = (kMinAllowedPowerup + arg3) - 1; // allowable powerups
@@ -1271,7 +1271,7 @@ static char plyCmpAmmo(void)
 }
 static char plyChkSpriteItOwns(void)
 { 
-    register int i;
+    int i;
     if (rngok(arg3, 0, kMaxStatus + 1))
     {
         for (i = headspritestat[arg3]; i >= 0; i = nextspritestat[i])
@@ -1586,7 +1586,7 @@ static char CheckCustomDude()
 
 static char CheckPlayer()
 {
-    register int i;
+    int i;
     if (objType == EVOBJ_SPRITE && rngok(objIndex, 0, kMaxSprites))
     {
         pSpr = &sprite[objIndex];
@@ -1685,7 +1685,7 @@ static void Push(int oType, int oIndex)
 
 static void Restore()
 {
-    register int t;
+    int t;
     switch (pXCond->command - kCmdPop)
     {
         case 0:
@@ -2000,7 +2000,7 @@ void conditionsTrackingAlloc(bool bSaveLoad)
 
 void conditionsTrackingClear()
 {
-    register int i = gTrackingConditionsListLength;
+    int i = gTrackingConditionsListLength;
     if (gTrackingConditionsList)
     {
         while (--i >= 0)
@@ -2028,8 +2028,8 @@ void conditionsTrackingProcess()
     TRACKING_CONDITION* pTr;
     XSPRITE* pXSpr;
     
-    register int i = gTrackingConditionsListLength;
-    register int t;
+    int i = gTrackingConditionsListLength;
+    int t;
 
     while (--i >= 0)
     {
@@ -2050,8 +2050,8 @@ void conditionsTrackingProcess()
 
 void conditionsLinkPlayer(XSPRITE* pXCtrl, PLAYER* pPlay)
 {
-    register int i = gTrackingConditionsListLength;
-    register int t;
+    int i = gTrackingConditionsListLength;
+    int t;
     OBJECT* o;
 
     // search for player control sprite and replace it with actual player sprite
@@ -2080,8 +2080,8 @@ void conditionsLinkPlayer(XSPRITE* pXCtrl, PLAYER* pPlay)
 // this updates index of object in all conditions
 void conditionsUpdateIndex(int oType, int oldIndex, int newIndex)
 {
-    register int i = gTrackingConditionsListLength;
-    register int t;
+    int i = gTrackingConditionsListLength;
+    int t;
     OBJECT* o;
 
     // update index in tracking conditions first
@@ -2292,7 +2292,7 @@ void useCondition(spritetype* pSource, XSPRITE* pXSource, EVENT* pEvn)
 #ifdef CONDITIONS_USE_BUBBLE_ACTION
 void conditionsBubble(XSPRITE* pXStart, void(*pActionFunc)(XSPRITE*, int), int nValue)
 {
-    register int i, j;
+    int i, j;
 
     pActionFunc(pXStart, nValue);
 

--- a/source/blood/src/nnextsif.cpp
+++ b/source/blood/src/nnextsif.cpp
@@ -928,7 +928,7 @@ static char sprChkOwner(void)           { return helperChkSprite(pSpr->owner); }
 static char sprChkSector(void)          { return helperChkSector(pSpr->sectnum); }
 static char sprCmpVelocityNew(void)
 {
-    switch (arg1)
+    switch (arg3)
     {
         case 0:		return (Cmp(xvel[pSpr->index]) || Cmp(yvel[pSpr->index]) || Cmp(zvel[pSpr->index]));
         case 1:		return Cmp(xvel[pSpr->index]);


### PR DESCRIPTION
- Do not allow to repeat action for all generators if state is 0
- Allow picking random incarnation for kModernDudeCustom
- Always kill all events if object is not part of event causer trigger sequence
- Fix incorrect argument for condition
- Stop dude patrol if there is no path markers to follow (no dassert)
- Fix potentially unsafe sprite removing from dynamic sprite lists
- Rewrite initialization