### PR TITLE
[NBlood] Cutscene volume fix #684 

### DIFF
--- a/source/blood/src/sound.cpp
+++ b/source/blood/src/sound.cpp
@@ -375,6 +375,8 @@ void sndStartWavDisk(const char *pzFile, int nVolume, int nChannel)
         pChannel = &Channel[nChannel];
     if (pChannel->hVoice > 0)
         sndKillSound(pChannel);
+    nVolume *= 80;
+    nVolume = clamp(nVolume, 0, 255); // clamp to range that audiolib accepts
     int hFile = kopen4loadfrommod(pzFile, 0);
     if (hFile == -1)
         return;


### PR DESCRIPTION
This PR fixes the volume in the cutscenes #684  . The _int nVolume_ in _sndStartSample_ was being multiplied by 80, while it wasn't in _sndStartWavDisk_, leading to the cutscene volume being very low.