### PR TITLE
Blood: cache tilesiz values in local variables in VectorScan

### DIFF
--- a/source/blood/src/gameutil.cpp
+++ b/source/blood/src/gameutil.cpp
@@ -485,9 +485,11 @@ int VectorScan(spritetype *pSprite, int nOffset, int nZOffset, int dx, int dy, i
             if ((pOther->cstat & 0x30) != 0)
                 return 3;
             int nPicnum = pOther->picnum;
-            if (tilesiz[nPicnum].x == 0 || tilesiz[nPicnum].y == 0)
+            int nSizX = tilesiz[nPicnum].x;
+            int nSizY = tilesiz[nPicnum].y;
+            if (nSizX == 0 || nSizY == 0)
                 return 3;
-            int height = (tilesiz[nPicnum].y*pOther->yrepeat)<<2;
+            int height = (nSizY*pOther->yrepeat)<<2;
             int otherZ = pOther->z;
             if (pOther->cstat & 0x80)
                 otherZ += height / 2;
@@ -495,22 +497,22 @@ int VectorScan(spritetype *pSprite, int nOffset, int nZOffset, int dx, int dy, i
             if (nOffset)
                 otherZ -= (nOffset*pOther->yrepeat)<<2;
             dassert(height > 0);
-            int height2 = scale(otherZ-gHitInfo.hitz, tilesiz[nPicnum].y, height);
+            int height2 = scale(otherZ-gHitInfo.hitz, nSizY, height);
             if (!(pOther->cstat & 8))
-                height2 = tilesiz[nPicnum].y-height2;
-            if (height2 >= 0 && height2 < tilesiz[nPicnum].y)
+                height2 = nSizY-height2;
+            if (height2 >= 0 && height2 < nSizY)
             {
-                int width = (tilesiz[nPicnum].x*pOther->xrepeat)>>2;
+                int width = (nSizX*pOther->xrepeat)>>2;
                 width = (width*3)/4;
                 int check1 = ((y1 - pOther->y)*dx - (x1 - pOther->x)*dy) / ksqrt(dx*dx+dy*dy);
                 dassert(width > 0);
-                int width2 = scale(check1, tilesiz[nPicnum].x, width);
+                int width2 = scale(check1, nSizX, width);
                 int nOffset = picanm[nPicnum].xofs;
-                width2 += nOffset + tilesiz[nPicnum].x / 2;
-                if (width2 >= 0 && width2 < tilesiz[nPicnum].x)
+                width2 += nOffset + nSizX / 2;
+                if (width2 >= 0 && width2 < nSizX)
                 {
                     char *pData = tileLoadTile(nPicnum);
-                    if (pData[width2*tilesiz[nPicnum].y+height2] != (char)255)
+                    if (pData[width2*nSizY+height2] != (char)255)
                         return 3;
                 }
             }


### PR DESCRIPTION
This is a mostly cosmetic change to make the hitsprite part of VectorScan similar to the hitwall one, which caches the tilesiz values in local variables.