### PR TITLE
BLOOD:Resource Error handing when Blood Game resources file(s) not found

### DIFF
--- a/source/blood/src/resource.cpp
+++ b/source/blood/src/resource.cpp
@@ -92,7 +92,11 @@ void Resource::Init(const char *filename)
     if (filename)
     {
         handle = kopen4loadfrommod(filename, 0);
-        if (handle != -1)
+        if (handle == -1)
+        {
+            ThrowError("File not found %s", filename);
+        }
+        else
         {
             int nFileLength = kfilelength(handle);
             dassert(nFileLength != -1);


### PR DESCRIPTION
fixes #666  proper message of missing blood game file