### PR TITLE
Rednukem: Start text input when save file overwrite verified "Y"

### DIFF
--- a/source/duke3d/src/menus.cpp
+++ b/source/duke3d/src/menus.cpp
@@ -4527,6 +4527,12 @@ static void Menu_Verify(int32_t input)
 
             ((MenuString_t*)M_SAVE.entrylist[M_SAVE.currentEntry]->entry)->editfield = NULL;
         }
+        else
+        {
+            KB_FlushKeyboardQueue();
+            KB_ClearKeysDown();
+        }
+
         break;
 
     case MENU_LOADDELVERIFY:

--- a/source/rr/src/menus.cpp
+++ b/source/rr/src/menus.cpp
@@ -4835,6 +4835,11 @@ static void Menu_Verify(int32_t input)
 
             ((MenuString_t*)M_SAVE.entrylist[M_SAVE.currentEntry]->entry)->editfield = NULL;
         }
+        else
+        {
+            KB_FlushKeyboardQueue();
+            KB_ClearKeysDown();
+        }
         break;
 
     case MENU_LOADDELVERIFY:


### PR DESCRIPTION
Fix for issue #699.

This fixes the main issue and also fixes the enter key not allowing users to type a save file name on overwrite (since they have the same cause).