### PR TITLE
Blood: Various tweaks

### DIFF
--- a/source/blood/src/db.cpp
+++ b/source/blood/src/db.cpp
@@ -306,6 +306,7 @@ int InsertSprite(int nSector, int nStat)
     pSprite->extra = -1;
     pSprite->index = nSprite;
     xvel[nSprite] = yvel[nSprite] = zvel[nSprite] = 0;
+    qsprite_filler[nSprite] = 0;
 
 #ifdef POLYMER
     gPolymerLight[nSprite].lightId = -1;
@@ -750,6 +751,9 @@ int dbLoadMap(const char *pPath, int *pX, int *pY, int *pZ, short *pAngle, short
     memset(zvel,0,sizeof(zvel));
     memset(xsprite,0,kMaxXSprites*sizeof(XSPRITE));
     memset(sprite,0,kMaxSprites*sizeof(spritetype));
+
+    memset(qsprite_filler,0,sizeof(qsprite_filler));
+    memset(qsector_filler,0,sizeof(qsector_filler));
 
     #ifdef NOONE_EXTENSIONS
     gModernMap = false;

--- a/source/blood/src/levels.cpp
+++ b/source/blood/src/levels.cpp
@@ -82,6 +82,8 @@ void levelOverrideINI(const char *pzIni)
     strcpy(BloodIniFile, pzIni);
 }
 
+static char zSmkPath[BMAX_PATH], zWavPath[BMAX_PATH];
+
 void levelPlayIntroScene(int nEpisode)
 {
     gGameOptions.uGameFlags &= ~kGameFlagPlayIntro;
@@ -91,7 +93,12 @@ void levelPlayIntroScene(int nEpisode)
     ambKillAll();
     seqKillAll();
     EPISODEINFO *pEpisode = &gEpisodeInfo[nEpisode];
-    credPlaySmk(pEpisode->cutsceneASmkPath, pEpisode->cutsceneAWavPath, pEpisode->cutsceneAWavRsrcID);
+    if (!credPlaySmk(pEpisode->cutsceneASmkPath, pEpisode->cutsceneAWavPath, pEpisode->cutsceneAWavRsrcID)) // if failed (files not found), reattempt in movie directory
+    {
+        snprintf(zSmkPath, BMAX_PATH, "movie/%s", pEpisode->cutsceneASmkPath);
+        snprintf(zWavPath, BMAX_PATH, "movie/%s", pEpisode->cutsceneAWavPath);
+        credPlaySmk(zSmkPath, zWavPath, pEpisode->cutsceneAWavRsrcID);
+    }
     scrSetDac();
     viewResizeView(gViewSize);
     credReset();
@@ -110,7 +117,12 @@ void levelPlayEndScene(int nEpisode)
     ambKillAll();
     seqKillAll();
     EPISODEINFO *pEpisode = &gEpisodeInfo[nEpisode];
-    credPlaySmk(pEpisode->cutsceneBSmkPath, pEpisode->cutsceneBWavPath, pEpisode->cutsceneBWavRsrcID);
+    if (!credPlaySmk(pEpisode->cutsceneBSmkPath, pEpisode->cutsceneBWavPath, pEpisode->cutsceneBWavRsrcID)) // if failed (files not found), reattempt in movie directory
+    {
+        snprintf(zSmkPath, BMAX_PATH, "movie/%s", pEpisode->cutsceneBSmkPath);
+        snprintf(zWavPath, BMAX_PATH, "movie/%s", pEpisode->cutsceneBWavPath);
+        credPlaySmk(zSmkPath, zWavPath, pEpisode->cutsceneBWavRsrcID);
+    }
     scrSetDac();
     viewResizeView(gViewSize);
     credReset();

--- a/source/blood/src/loadsave.cpp
+++ b/source/blood/src/loadsave.cpp
@@ -110,8 +110,13 @@ void LoadSave::LoadGame(char *pzFile)
     seqKillAll();
     if (!gGameStarted)
     {
-        memset(xsprite, 0, sizeof(xsprite));
+        memset(xvel,0,sizeof(xvel[0])*kMaxSprites);
+        memset(yvel,0,sizeof(yvel[0])*kMaxSprites);
+        memset(zvel,0,sizeof(zvel[0])*kMaxSprites);
+        memset(xsprite, 0, sizeof(XSPRITE)*kMaxXSprites);
         memset(sprite, 0, sizeof(spritetype)*kMaxSprites);
+        memset(qsprite_filler,0,sizeof(qsprite_filler[0])*kMaxSprites);
+        memset(qsector_filler,0,sizeof(qsector_filler[0])*kMaxSectors);
         automapping = 1;
     }
     hLFile = kopen4load(pzFile, 0);
@@ -276,6 +281,8 @@ void MyLoadSave::Load(void)
     memset(wall, 0, sizeof(wall[0])*kMaxWalls);
     memset(sprite, 0, sizeof(sprite[0])*kMaxSprites);
     memset(spriteext, 0, sizeof(spriteext[0])*kMaxSprites);
+    memset(qsprite_filler,0,sizeof(qsprite_filler[0])*kMaxSprites);
+    memset(qsector_filler,0,sizeof(qsector_filler[0])*kMaxSectors);
     Read(sector, sizeof(sector[0])*numsectors);
     Read(wall, sizeof(wall[0])*numwalls);
     Read(sprite, sizeof(sprite[0])*kMaxSprites);

--- a/source/blood/src/map2d.cpp
+++ b/source/blood/src/map2d.cpp
@@ -135,7 +135,7 @@ void sub_2541C(int x, int y, int z, short a)
             spritetype *pSprite = pPlayer->pSprite;
             int px = pSprite->x-x;
             int py = pSprite->y-y;
-            int pa = (pSprite->ang-a)&2047;
+            int pa = (pSprite->ang-a)&kAngMask;
             if (i == gView->nPlayer)
             {
                 px = 0;

--- a/source/blood/src/player.cpp
+++ b/source/blood/src/player.cpp
@@ -558,7 +558,7 @@ void packPrevItem(PLAYER *pPlayer)
 {
     if (pPlayer->packItemTime > 0)
     {
-        for (int nPrev = ClipLow(pPlayer->packItemId-1,kPackMedKit); nPrev >= kPackMedKit; nPrev--)
+        for (int nPrev = ClipLow(pPlayer->packItemId-1,kPackBase); nPrev >= kPackBase; nPrev--)
         {
             if (pPlayer->packSlots[nPrev].curAmount)
             {
@@ -675,7 +675,7 @@ void playerStart(int nPlayer, int bNewLevel)
     // normal start position
     if (gGameOptions.nGameType <= 1)
         pStartZone = &gStartZone[nPlayer];
-    
+
     #ifdef NOONE_EXTENSIONS
     // let's check if there is positions of teams is specified
     // if no, pick position randomly, just like it works in vanilla.

--- a/source/blood/src/player.cpp
+++ b/source/blood/src/player.cpp
@@ -764,8 +764,10 @@ void playerStart(int nPlayer, int bNewLevel)
     pPlayer->aimTarget = -1;
     pPlayer->zViewVel = pPlayer->zWeaponVel;
     if (!(gGameOptions.nGameType == kGameTypeCoop && gGameOptions.bPlayerKeys > PLAYERKEYSMODE::LOSTONDEATH && !bNewLevel))
+    {
         for (int i = 0; i < 8; i++)
             pPlayer->hasKey[i] = gGameOptions.nGameType >= kGameTypeBloodBath;
+    }
     pPlayer->hasFlag = 0;
     for (int i = 0; i < 8; i++)
         pPlayer->used2[i] = -1;

--- a/source/blood/src/player.h
+++ b/source/blood/src/player.h
@@ -56,7 +56,8 @@ enum
 // inventory pack
 enum
 {
-    kPackMedKit      = 0,
+    kPackBase        = 0,
+    kPackMedKit      = kPackBase,
     kPackDivingSuit  = 1,
     kPackCrystalBall = 2,
     kPackBeastVision = 3,

--- a/source/blood/src/player.h
+++ b/source/blood/src/player.h
@@ -182,7 +182,7 @@ struct PLAYER
     int                 deathTime;
     int                 pwUpTime[kMaxPowerUps];
     int                 fragCount;
-    int                 fragInfo[8];
+    int                 fragInfo[kMaxPlayers];
     int                 teamId;
     int                 fraggerId;
     int                 underwaterTime;

--- a/source/blood/src/screen.cpp
+++ b/source/blood/src/screen.cpp
@@ -281,20 +281,20 @@ void scrSetupUnfade(void)
 
 void scrFadeAmount(int amount)
 {
-	for (int i = 0; i < 256; i++)
-	{
-		curDAC[i].red = interpolate(fromDAC[i].red, toRGB.red, amount);
+    for (int i = 0; i < 256; i++)
+    {
+        curDAC[i].red = interpolate(fromDAC[i].red, toRGB.red, amount);
         curDAC[i].green = interpolate(fromDAC[i].green, toRGB.green, amount);
         curDAC[i].blue = interpolate(fromDAC[i].blue, toRGB.blue, amount);
-	}
-	gSetDacRange(0, 256, curDAC);
+    }
+    gSetDacRange(0, 256, curDAC);
 }
 
 void scrSetDac(void)
 {
-	if (DacInvalid)
-		gSetDacRange(0, 256, baseDAC);
-	DacInvalid = 0;
+    if (DacInvalid)
+        gSetDacRange(0, 256, baseDAC);
+    DacInvalid = 0;
 }
 
 void scrInit(void)

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -2492,9 +2492,10 @@ void viewProcessSprites(int32_t cX, int32_t cY, int32_t cZ, int32_t cA, int32_t 
     {
         tspritetype *pTSprite = &tsprite[nTSprite];
         //int nXSprite = pTSprite->extra;
-        int nXSprite = sprite[pTSprite->owner].extra;
+        int nSprite = pTSprite->owner;
+        int nXSprite = sprite[nSprite].extra;
         XSPRITE *pTXSprite = NULL;
-        if (qsprite_filler[pTSprite->owner] > gDetail)
+        if ((qsprite_filler[nSprite] > gDetail) || (sprite[nSprite].sectnum == -1))
         {
             pTSprite->xrepeat = 0;
             continue;
@@ -2509,7 +2510,6 @@ void viewProcessSprites(int32_t cX, int32_t cY, int32_t cZ, int32_t cA, int32_t 
             continue;
         }
 
-        int nSprite = pTSprite->owner;
         if (gViewInterpolate && TestBitString(gInterpolateSprite, nSprite) && !(pTSprite->flags&512))
         {
             LOCATION *pPrevLoc = &gPrevSpriteLoc[nSprite];
@@ -2627,7 +2627,7 @@ void viewProcessSprites(int32_t cX, int32_t cY, int32_t cZ, int32_t cA, int32_t 
         {
             int const nRootTile = pTSprite->picnum;
 #if 0
-            int nAnimTile = pTSprite->picnum + animateoffs_replace(pTSprite->picnum, 32768+pTSprite->owner);
+            int nAnimTile = pTSprite->picnum + animateoffs_replace(pTSprite->picnum, 32768+nSprite);
             if (tiletovox[nAnimTile] != -1)
             {
                 pTSprite->yoffset += picanm[nAnimTile].yofs;
@@ -2645,7 +2645,7 @@ void viewProcessSprites(int32_t cX, int32_t cY, int32_t cZ, int32_t cA, int32_t 
         if ((pTSprite->cstat&48) != 48 && usemodels && !(spriteext[nSprite].flags&SPREXT_NOTMD))
         {
             int const nRootTile = pTSprite->picnum;
-            int nAnimTile = pTSprite->picnum + animateoffs_replace(pTSprite->picnum, 32768+pTSprite->owner);
+            int nAnimTile = pTSprite->picnum + animateoffs_replace(pTSprite->picnum, 32768+nSprite);
 
             if (usemodels && tile2model[Ptile2tile(nAnimTile, pTSprite->pal)].modelid >= 0 &&
                 tile2model[Ptile2tile(nAnimTile, pTSprite->pal)].framenum >= 0)
@@ -2680,7 +2680,7 @@ void viewProcessSprites(int32_t cX, int32_t cY, int32_t cZ, int32_t cA, int32_t 
         }
         nShade += tileShade[pTSprite->picnum];
         pTSprite->shade = ClipRange(nShade, -128, 127);
-        if ((pTSprite->flags&kHitagRespawn) && sprite[pTSprite->owner].owner == 3)
+        if ((pTSprite->flags&kHitagRespawn) && sprite[nSprite].owner == 3)
         {
             dassert(pTXSprite != NULL);
             pTSprite->xrepeat = 48;
@@ -2881,7 +2881,7 @@ void viewProcessSprites(int32_t cX, int32_t cY, int32_t cZ, int32_t cA, int32_t 
                 }
             }
             
-            if (pTSprite->owner != gView->pSprite->index || gViewPos != VIEWPOS_0) {
+            if (nSprite != gView->pSprite->index || gViewPos != VIEWPOS_0) {
                 if (getflorzofslope(pTSprite->sectnum, pTSprite->x, pTSprite->y) >= cZ)
                 {
                     viewAddEffect(nTSprite, kViewEffectShadow);

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -3505,7 +3505,7 @@ void viewDrawScreen(void)
             CalcPosition(gView->pSprite, (int*)&cX, (int*)&cY, (int*)&cZ, &nSectnum, fix16_to_int(cA), q16horiz);
         }
         const char bLink = CheckLink((int*)&cX, (int*)&cY, (int*)&cZ, &nSectnum);
-        int v78 = gViewInterpolate ? interpolateang(gScreenTiltO, gScreenTilt, gInterpolate) : gScreenTilt;
+        int nTilt = gViewInterpolate ? interpolateang(gScreenTiltO, gScreenTilt, gInterpolate) : gScreenTilt;
         char nPalCrystalBall = 0;
         bool bDelirium = powerupCheck(gView, kPwUpDeliriumShroom) > 0;
         static bool bDeliriumOld = false;
@@ -3514,7 +3514,7 @@ void viewDrawScreen(void)
 #ifdef USE_OPENGL
         renderSetRollAngle(0);
 #endif
-        if (v78 || bDelirium)
+        if (nTilt || bDelirium)
         {
             if (videoGetRenderMode() == REND_CLASSIC)
             {
@@ -3530,7 +3530,7 @@ void viewDrawScreen(void)
                     tiltdim = 640;
                 }
                 renderSetTarget(TILTBUFFER, tiltdim, tiltdim);
-                int nAng = v78&(kAng90-1);
+                int nAng = nTilt&(kAng90-1);
                 if (nAng > kAng45)
                 {
                     nAng = kAng90-nAng;
@@ -3539,7 +3539,7 @@ void viewDrawScreen(void)
             }
 #ifdef USE_OPENGL
             else
-                renderSetRollAngle(v78);
+                renderSetRollAngle(nTilt);
 #endif
         }
         else if (bCrystalBall)
@@ -3731,7 +3731,7 @@ RORHACK:
         renderDrawMasks();
         gView->pSprite->cstat = bakCstat;
 
-        if (v78 || bDelirium)
+        if (nTilt || bDelirium)
         {
             if (videoGetRenderMode() == REND_CLASSIC)
             {
@@ -3742,13 +3742,13 @@ RORHACK:
                 {
                     vrc = 64+32+4+2+1+1024;
                 }
-                int nAng = v78 & (kAng90-1);
+                int nAng = nTilt & (kAng90-1);
                 if (nAng > kAng45)
                 {
                     nAng = kAng90 - nAng;
                 }
                 int nScale = dmulscale32(Cos(nAng), 262144, Sin(nAng), 163840)>>tiltcs;
-                rotatesprite(160<<16, 100<<16, nScale, v78+512, TILTBUFFER, 0, 0, vrc, gViewX0, gViewY0, gViewX1, gViewY1);
+                rotatesprite(160<<16, 100<<16, nScale, nTilt+512, TILTBUFFER, 0, 0, vrc, gViewX0, gViewY0, gViewX1, gViewY1);
             }
 #ifdef USE_OPENGL
             else


### PR DESCRIPTION
This is a collection of tweaks/fixes for Blood. They include fixing the unused implementation of the detail sprite option, attempting to load cutscene files from movie directory as per install instructions, and renaming/redefining variables. Also included is improving the shadow position calculation as it'll now test for fake floor objects.