### PR TITLE
Blood: Fix broken sprites in E2M4

### DIFF
--- a/source/blood/src/actor.cpp
+++ b/source/blood/src/actor.cpp
@@ -2594,6 +2594,8 @@ void actInit(bool bSaveLoad) {
                         default:
                             pSprite->clipdist = dudeInfo[nType].clipdist;
                             pSprite->cstat |= 4096 + CSTAT_SPRITE_BLOCK_HITSCAN + CSTAT_SPRITE_BLOCK;
+                            if (((pSprite->cstat & CSTAT_SPRITE_ALIGNMENT_MASK) != CSTAT_SPRITE_ALIGNMENT_FACING) && !bVanilla) // fix flat enemy sprites in E2M4
+                                pSprite->cstat &= ~(pSprite->cstat & CSTAT_SPRITE_ALIGNMENT_MASK);
                             break;
                     }
                 }


### PR DESCRIPTION
This PR fixes flat enemies cstat for levels such as E2M4's enemies outside of the fireplace room.