### PR TITLE
Blood: Fix game state on client time out

### DIFF
--- a/source/blood/src/network.cpp
+++ b/source/blood/src/network.cpp
@@ -1082,6 +1082,7 @@ void netInitialize(bool bConsole)
         {
             initprintf("Could not connect to %s:%i\n", gNetAddress, gNetPort);
             netDeinitialize();
+            netResetToSinglePlayer();
             return;
         }
         bool bWaitServer = true;


### PR DESCRIPTION
Properly resets gNetMode and other various net states when client is unable to connect to address.