### PR TITLE
SW: Add new alt reverb option for sound menu

### DIFF
--- a/source/sw/src/game.cpp
+++ b/source/sw/src/game.cpp
@@ -212,6 +212,7 @@ const GAME_SET gs_defaults =
     TRUE, // Music on
     TRUE, // talking
     TRUE, // ambient
+    FALSE, // alt reverb
     FALSE, // Flip Stereo
 
 // Network game settings

--- a/source/sw/src/menus.cpp
+++ b/source/sw/src/menus.cpp
@@ -198,10 +198,11 @@ MenuItem sound_i[] =
 
     //{DefButton(btn_talking, 0, "Talking"), OPT_XS,            OPT_LINE(4), 1, m_defshade, 0, NULL, MNU_FxCheck, NULL},
     {DefButton(btn_ambience, 0, "Ambience"), OPT_XS,          OPT_LINE(4), 1, m_defshade, 0, NULL, MNU_FxCheck, NULL},
+    {DefButton(btn_reverb, 0, "Alt Reverb"), OPT_XS,          OPT_LINE(5), 1, m_defshade, 0, NULL, MNU_FxCheck, NULL},
 #ifdef ASS_REVERSESTEREO
-    {DefButton(btn_flipstereo, 0, "Flip Stereo"), OPT_XS,     OPT_LINE(5), 1, m_defshade, 0, NULL, MNU_FxCheck, NULL},
+    {DefButton(btn_flipstereo, 0, "Flip Stereo"), OPT_XS,     OPT_LINE(6), 1, m_defshade, 0, NULL, MNU_FxCheck, NULL},
 #endif
-    //{DefButton(btn_playcd, 0, "Play CD"), OPT_XS,         OPT_LINE(6), 1, m_defshade, 0, NULL, NULL, NULL},
+    //{DefButton(btn_playcd, 0, "Play CD"), OPT_XS,         OPT_LINE(7), 1, m_defshade, 0, NULL, NULL, NULL},
     {DefNone}
 };
 
@@ -2103,6 +2104,7 @@ MNU_InitMenus(void)
 
     buttonsettings[btn_voxels] = gs.Voxels;
     buttonsettings[btn_ambience] = gs.Ambient;
+    buttonsettings[btn_reverb] = gs.AltReverb;
     buttonsettings[btn_playcd] = gs.PlayCD;
     buttonsettings[btn_flipstereo] = gs.FlipStereo;
     buttonsettings[btn_stats] = gs.Stats;
@@ -3340,6 +3342,10 @@ MNU_DoButton(MenuItem_p item, SWBOOL draw)
                         StopAmbientSound();
                 }
             }
+            break;
+        case btn_reverb:
+            last_value = gs.AltReverb;
+            gs.AltReverb = state = buttonsettings[item->button];
             break;
         case btn_flipstereo:
             last_value = gs.FlipStereo;

--- a/source/sw/src/menus.h
+++ b/source/sw/src/menus.h
@@ -206,7 +206,7 @@ typedef enum
 {
     btn_none, btn_auto_run, btn_crosshair, btn_auto_aim,
     btn_mouse_aim, btn_messages, btn_mouse_invert, btn_bobbing, btn_shadows,
-    btn_sound, btn_music, btn_talking, btn_ambience, btn_flipstereo,
+    btn_sound, btn_music, btn_talking, btn_ambience, btn_reverb, btn_flipstereo,
     btn_res0, btn_res1, btn_res2, btn_res3, btn_res4, btn_res5, btn_res6,
     btn_markers, btn_teamplay, btn_friendlyfire,btn_parental,btn_nuke,
     btn_voxels, btn_stats, btn_playcd,

--- a/source/sw/src/settings.h
+++ b/source/sw/src/settings.h
@@ -51,6 +51,7 @@ typedef struct
     SWBOOL MusicOn;
     SWBOOL Talking;
     SWBOOL Ambient;
+    SWBOOL AltReverb;
     SWBOOL FlipStereo;
 // Net Options from Menus
     uint8_t NetGameType;   // 0=DeathMatch [spawn], 1=Cooperative 2=DeathMatch [no spawn]

--- a/source/sw/src/sounds.cpp
+++ b/source/sw/src/sounds.cpp
@@ -1322,10 +1322,10 @@ void MusicStartup(void)
 
 void COVER_SetReverb(int amt)
 {
-    if (gs.AltReverb)
+    if (gs.AltReverb) // use reverb from blood
     {
         FX_SetReverb(amt ? 128 : 0);
-        FX_SetReverbDelay(amt ? 10 : 0);
+        FX_SetReverbDelay(10);
     }
     else
     {

--- a/source/sw/src/sounds.cpp
+++ b/source/sw/src/sounds.cpp
@@ -1322,7 +1322,15 @@ void MusicStartup(void)
 
 void COVER_SetReverb(int amt)
 {
-    FX_SetReverb(amt);
+    if (gs.AltReverb)
+    {
+        FX_SetReverb(amt ? 128 : 0);
+        FX_SetReverbDelay(amt ? 10 : 0);
+    }
+    else
+    {
+        FX_SetReverb(amt);
+    }
 }
 
 /*

--- a/source/sw/src/swconfig.cpp
+++ b/source/sw/src/swconfig.cpp
@@ -173,6 +173,10 @@ void ReadGameSetup(int32_t scripthandle)
     if (dummy != -1) gs.Ambient = dummy;
 
     dummy = -1;
+    SCRIPT_GetNumber(scripthandle, "Options", "AltReverb",&dummy);
+    if (dummy != -1) gs.AltReverb = dummy;
+
+    dummy = -1;
     SCRIPT_GetNumber(scripthandle, "Options", "FxOn",&dummy);
     if (dummy != -1) gs.FxOn = dummy;
 
@@ -314,6 +318,8 @@ void WriteGameSetup(int32_t scripthandle)
     SCRIPT_PutNumber(scripthandle, "Options", "Talking",dummy,FALSE,FALSE);
     dummy = gs.Ambient;
     SCRIPT_PutNumber(scripthandle, "Options", "Ambient",dummy,FALSE,FALSE);
+    dummy = gs.AltReverb;
+    SCRIPT_PutNumber(scripthandle, "Options", "AltReverb",dummy,FALSE,FALSE);
     dummy = gs.FxOn;
     SCRIPT_PutNumber(scripthandle, "Options", "FxOn",dummy,FALSE,FALSE);
     dummy = gs.MouseAimingType;


### PR DESCRIPTION
This PR adds a new option for shadow warrior, where it will use alternative settings for the reverb sound effect.

Comparison:

https://github.com/nukeykt/NBlood/assets/80724828/6c4513b9-66dd-4cb4-bbcf-f055c1506cec


https://github.com/nukeykt/NBlood/assets/80724828/5d7ff5e4-d778-4099-a06a-c207f194c057

