### PR TITLE
Blood: Undo CanMove() inaccuracy

### DIFF
--- a/source/blood/src/ai.cpp
+++ b/source/blood/src/ai.cpp
@@ -203,8 +203,17 @@ bool CanMove(spritetype *pSprite, int a2, int nAngle, int nRange)
         if (Underwater)
             return true;
         break;
-    case kDudeCerberusTwoHead:
     case kDudeCerberusOneHead:
+        if (VanillaMode())
+        {
+            if (Crusher)
+                return false;
+            if ((nXSector < 0 || (!xsector[nXSector].Underwater && !xsector[nXSector].Depth)) && floorZ - bottom > 0x2000)
+                return false;
+            break;
+        }
+        fallthrough__;
+    case kDudeCerberusTwoHead:
         // by NoOne: a quick fix for Cerberus spinning in E3M7-like maps, where damage sectors is used.
         // It makes ignore danger if enemy immune to N damageType. As result Cerberus start acting like
         // in Blood 1.0 so it can move normally to player. It's up to you for adding rest of enemies here as


### PR DESCRIPTION
This PR reverts a potential inaccuracy introduced in commit ed9b6f28fdfc6d3c00d0a5e412f8d30a79aa09b1. As the switch casement does not handle kDudeCerberusOneHead, an exception needs to be added so it is properly handled for `VanillaMode()`.