### PR TITLE
Blood: Fix fragInfo inaccuracy

### DIFF
--- a/source/blood/src/player.cpp
+++ b/source/blood/src/player.cpp
@@ -1946,7 +1946,7 @@ void playerFrag(PLAYER *pKiller, PLAYER *pVictim)
         if (VanillaMode() || gGameOptions.nGameType != kGameTypeCoop)
         {
             pKiller->fragCount++;
-            pKiller->fragInfo[nKiller]++;
+            pKiller->fragInfo[nVictim]++;
         }
         if (gGameOptions.nGameType == kGameTypeTeams)
         {


### PR DESCRIPTION
This PR reverts a inaccuracy introduced in commit 1efe584afcbb682550bbeab5b1caae469999994e. fragInfo array is used to store player kills by current player, while the commit changed it so all kills will only increase the same player index.