### PR TITLE
Various accuracy tweaks from Blood-RE

### DIFF
--- a/source/blood/src/actor.cpp
+++ b/source/blood/src/actor.cpp
@@ -5392,9 +5392,10 @@ void actProcessSprites(void)
 
                             switch (pSprite->type) {
                                 case kThingDroppedLifeLeech:
-                                    if (!Chance(0x4000) && nNextSprite >= 0) continue;
-                                    if (pSprite2->cstat & CLIPMASK0) pXSprite->target = pSprite2->index;
-                                    else continue;
+                                    if ((Chance(0x4000) || nNextSprite < 0) && (pSprite2->cstat & CLIPMASK0))
+                                        pXSprite->target = pSprite2->index;
+                                    else
+                                        continue;
                                     break;
                                 #ifdef NOONE_EXTENSIONS
                                 case kModernThingTNTProx:

--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -780,6 +780,8 @@ void StartLevel(GAMEOPTIONS *gameOptions)
     viewResizeView(gViewSize);
     if ((gGameOptions.nGameType == kGameTypeTeams) && VanillaMode())
         gGameMessageMgr.SetCoordinates(gViewX0S+1,gViewY0S+15);
+    if (!VanillaMode())
+        viewClearInterpolations();
     netWaitForEveryone(0);
     totalclock = 0;
     gPaused = 0;

--- a/source/blood/src/db.cpp
+++ b/source/blood/src/db.cpp
@@ -1231,7 +1231,7 @@ int dbLoadMap(const char *pPath, int *pX, int *pY, int *pZ, short *pAngle, short
             xsprite[sprite[i].extra].reference = i;
             xsprite[sprite[i].extra].busy = xsprite[sprite[i].extra].state << 16;
             if (!byte_1A76C8) {
-                xsprite[sprite[i].extra].lT |= xsprite[sprite[i].extra].lB;
+                xsprite[sprite[i].extra].lT = xsprite[sprite[i].extra].lB;
             }
 
             #ifdef NOONE_EXTENSIONS

--- a/source/blood/src/endgame.cpp
+++ b/source/blood/src/endgame.cpp
@@ -129,6 +129,15 @@ CKillMgr::CKillMgr()
     Clear();
 }
 
+bool CKillMgr::AllowedType(spritetype *pSprite)
+{
+    if (!pSprite)
+        return false;
+    if (pSprite->statnum != kStatDude)
+        return false;
+    return pSprite->type != kDudeBat && pSprite->type != kDudeRat && pSprite->type != kDudeInnocent && pSprite->type != kDudeBurningInnocent;
+}
+
 void CKillMgr::SetCount(int nCount)
 {
     at0 = nCount;
@@ -142,14 +151,14 @@ void CKillMgr::AddCount(int nCount)
 void CKillMgr::AddCount(spritetype* pSprite)
 {
     dassert(pSprite != NULL);
-    if (pSprite->statnum == kStatDude && pSprite->type != kDudeBat && pSprite->type != kDudeRat && pSprite->type != kDudeInnocent && pSprite->type != kDudeBurningInnocent)
+    if (VanillaMode() || AllowedType(pSprite))// check type before adding to enemy count
         at0++;
 }
 
 void CKillMgr::AddKill(spritetype* pSprite)
 {
     dassert(pSprite != NULL);
-    if (pSprite->statnum == kStatDude && pSprite->type != kDudeBat && pSprite->type != kDudeRat && pSprite->type != kDudeInnocent && pSprite->type != kDudeBurningInnocent)
+    if (VanillaMode() || AllowedType(pSprite)) // check type before adding to enemy kills
         at4++;
 }
 
@@ -158,7 +167,7 @@ void CKillMgr::RemoveKill(spritetype* pSprite)
     if (gKillMgr.at4 <= 0)
         return;
     dassert(pSprite != NULL);
-    if (pSprite->statnum == kStatDude && pSprite->type != kDudeBat && pSprite->type != kDudeRat && pSprite->type != kDudeInnocent && pSprite->type != kDudeBurningInnocent)
+    if (VanillaMode() || AllowedType(pSprite)) // check type before removing from enemy kills
         at4--;
 }
 

--- a/source/blood/src/endgame.h
+++ b/source/blood/src/endgame.h
@@ -39,6 +39,7 @@ class CKillMgr {
 public:
     int at0, at4;
     CKillMgr();
+    bool AllowedType(spritetype *pSprite);
     void SetCount(int);
     void AddCount(int);
     void AddCount(spritetype *pSprite);


### PR DESCRIPTION
This PR changes the following:
* Rewrote kThingDroppedLifeLeech logic to look closer to original (functionally the same)
* Undo XSprite lT |= operation during map load
* Moved enemy filter for kill counter to CKillMgr class function
* Clear interpolations at start of game (fixes doors appearing open at multiplayer start)