### PR TITLE
Blood: Allow tileGetSurfType() to return ceiling type if supplied nType bitflag

### DIFF
--- a/source/blood/src/actor.cpp
+++ b/source/blood/src/actor.cpp
@@ -3922,7 +3922,7 @@ void actTouchFloor(spritetype *pSprite, int nSector)
             nDamage = 1000;
         actDamageSprite(pSprite->index, pSprite, nDamageType, scale(4, nDamage, 120) << 4);
     }
-    if (tileGetSurfType(nSector + 0x4000) == kSurfLava)
+    if (tileGetSurfType(nSector, 0x4000) == kSurfLava)
     {
         actDamageSprite(pSprite->index, pSprite, kDamageBurn, 16);
         sfxPlay3DSound(pSprite, 352, 5, 2);

--- a/source/blood/src/nnexts.cpp
+++ b/source/blood/src/nnexts.cpp
@@ -1609,7 +1609,7 @@ int getSpriteMassBySize(spritetype* pSprite) {
     short xrepeat = pSprite->xrepeat; 	short yrepeat = pSprite->yrepeat;
 
     // take surface type into account
-    switch (tileGetSurfType(pSprite->index + 0xc000)) {
+    switch (tileGetSurfType(pSprite->index, 0xc000)) {
         case 1:  massDiv = 16; break; // stone
         case 2:  massDiv = 18; break; // metal
         case 3:  massDiv = 21; break; // wood

--- a/source/blood/src/seq.cpp
+++ b/source/blood/src/seq.cpp
@@ -301,7 +301,7 @@ void SEQINST::Update(ACTIVE *pActive)
         if (!VanillaMode() && pSequence->frames[frameIndex].surfaceSound && zvel[pSprite->index] == 0 && xvel[pSprite->index] != 0) {
             
             if (gUpperLink[pSprite->sectnum] >= 0) break; // don't play surface sound for stacked sectors
-            int surf = tileGetSurfType(pSprite->sectnum + 0x4000); if (!surf) break;
+            int surf = tileGetSurfType(pSprite->sectnum, 0x4000); if (!surf) break;
             static int surfSfxMove[15][4] = {
                 /* {snd1, snd2, gameVolume, myVolume} */
                 {800,801,80,25},

--- a/source/blood/src/tile.cpp
+++ b/source/blood/src/tile.cpp
@@ -268,10 +268,13 @@ void tilePrecacheTile(int nTile, int nType)
     }
 }
 
-char tileGetSurfType(int hit)
+char tileGetSurfType(int hit, int nType)
 {
     int n = hit & 0x3fff;
-    switch (hit&0xc000)
+    if (nType == 0) // no type supplied, get type from hit index
+        nType = hit & 0xc000;
+
+    switch (nType)
     {
     case 0x4000:
         return surfType[sector[n].floorpicnum];

--- a/source/blood/src/tile.h
+++ b/source/blood/src/tile.h
@@ -63,4 +63,4 @@ char * tileLoadTile(int nTile);
 char * tileAllocTile(int nTile, int x, int y, int ox, int oy);
 void tilePreloadTile(int nTile);
 void tilePrecacheTile(int nTile, int nType = 1);
-char tileGetSurfType(int hit);
+char tileGetSurfType(int hit, int nType = 0);


### PR DESCRIPTION
This PR addresses a possible issue when attempting to derive ceiling sector type from `tileGetSurfType()`.

When the sprite limit was increased for NBlood, `tileGetSurfType()`'s switch statement could no longer hit 0x6000. While no active code does use `tileGetSurfType()` to get ceiling surface type, it is now possible by supplying nType with the surface bitflag type.