### PR TITLE
Blood: Fix enemy count for vanilla mode

### DIFF
--- a/source/blood/src/endgame.cpp
+++ b/source/blood/src/endgame.cpp
@@ -158,7 +158,7 @@ void CKillMgr::AddCount(spritetype* pSprite)
 void CKillMgr::AddKill(spritetype* pSprite)
 {
     dassert(pSprite != NULL);
-    if (VanillaMode() || AllowedType(pSprite)) // check type before adding to enemy kills
+    if (AllowedType(pSprite)) // check type before adding to enemy kills
         at4++;
 }
 
@@ -179,7 +179,8 @@ void CKillMgr::CountTotalKills(void)
         spritetype* pSprite = &sprite[nSprite];
         if (pSprite->type < kDudeBase || pSprite->type >= kDudeMax)
             ThrowError("Non-enemy sprite (%d) in the enemy sprite list.", nSprite);
-        AddCount(pSprite);
+        if (AllowedType(pSprite))
+            AddCount(1);
     }
 }
 


### PR DESCRIPTION
This PR fixes an inaccuracy introduced in commit bd03c40c57575c04015336dfcc83774c7b770f67. As vanilla mode **only** checks the enemy type at start, it should directly call AllowedType() and use AddCount(int) instead of AddCount(spritetype).