### PR TITLE
Blood: Remove directory path characters for levelGetTitle()

### DIFF
--- a/source/blood/src/levels.cpp
+++ b/source/blood/src/levels.cpp
@@ -193,6 +193,11 @@ char * levelGetTitle(void)
     char *pTitle = gEpisodeInfo[nEpisode].levelsInfo[nLevel].Title;
     if (*pTitle == 0)
         return NULL;
+    for (int i = Bstrlen(pTitle)-1; i > 0; i--)
+    {
+        if ((pTitle[i] == '/') || (pTitle[i] == '\\'))
+            return &pTitle[i+1];
+    }
     return pTitle;
 }
 


### PR DESCRIPTION
This will only show the map filename instead of the full directory path for map title