### PR TITLE
Blood: Implement autorun/run functionality for controller input

### DIFF
--- a/source/blood/src/controls.cpp
+++ b/source/blood/src/controls.cpp
@@ -486,6 +486,11 @@ void ctrlGetInput(void)
     {
         input.strafe -= info.dx>>1;
         input.forward -= info.dz>>1;
+        if (!run) // when autorun is off/run is not held, reduce overall speed for controller
+        {
+            input.strafe = clamp(input.strafe, -256, 256);
+            input.forward = clamp(input.forward, -256, 256);
+        }
         if (info.mousey == 0)
         {
             if (gMouseAim)


### PR DESCRIPTION
Add autorun/run functionality for controller input. This should have no effect on non-autorun keyboard input while controller is plugged in - regardless it should be tested before merging (compare in_joystick 0 and 1 walking speed).