### PR TITLE
Blood: Expose quick save/load functionality as buttons

### DIFF
--- a/source/blood/src/_functio.h
+++ b/source/blood/src/_functio.h
@@ -94,6 +94,8 @@ char gamefunctions[NUMGAMEFUNCTIONS][MAXGAMEFUNCLEN] =
    "ProximityBombs",
    "RemoteBombs",
    "Show_Console",
+   "Quick_Save",
+   "Quick_Load",
    };
 
 #ifdef __SETUP__
@@ -155,6 +157,8 @@ const char keydefaults[NUMGAMEFUNCTIONS*2][MAXGAMEFUNCLEN] =
    "P", "",
    "R", "",
    "`", "",
+   "F6", "",
+   "F9", "",
    };
 
 const char oldkeydefaults[NUMGAMEFUNCTIONS*2][MAXGAMEFUNCLEN] =
@@ -214,6 +218,8 @@ const char oldkeydefaults[NUMGAMEFUNCTIONS*2][MAXGAMEFUNCLEN] =
    "P", "",
    "R", "",
    "`", "",
+   "F6", "",
+   "F9", "",
    };
 
 static const char * mousedefaults[MAXMOUSEBUTTONS] =

--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -889,6 +889,8 @@ void LocalKeys(void)
     if (gDoQuickSave)
     {
         keyFlushScans();
+        CONTROL_ClearButton(gamefunc_Quick_Save);
+        CONTROL_ClearButton(gamefunc_Quick_Load);
         switch (gDoQuickSave)
         {
         case 1:
@@ -900,6 +902,20 @@ void LocalKeys(void)
         }
         gDoQuickSave = 0;
         return;
+    }
+    if (BUTTON(gamefunc_Quick_Save))
+    {
+        keyFlushScans();
+        CONTROL_ClearButton(gamefunc_Quick_Save);
+        if (gGameOptions.nGameType == kGameTypeSinglePlayer)
+            return DoQuickSave();
+    }
+    if (BUTTON(gamefunc_Quick_Load))
+    {
+        keyFlushScans();
+        CONTROL_ClearButton(gamefunc_Quick_Load);
+        if (gGameOptions.nGameType == kGameTypeSinglePlayer)
+            return DoQuickLoad();
     }
     char key;
     if ((key = keyGetScan()) != 0)

--- a/source/blood/src/function.h
+++ b/source/blood/src/function.h
@@ -35,7 +35,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 extern "C" {
 #endif
 
-#define NUMGAMEFUNCTIONS 55
+#define NUMGAMEFUNCTIONS 57
 #define MAXGAMEFUNCLEN 32
 
 extern char gamefunctions[NUMGAMEFUNCTIONS][MAXGAMEFUNCLEN];
@@ -99,6 +99,8 @@ enum GameFunction_t
    gamefunc_ProximityBombs,
    gamefunc_RemoteBombs,
    gamefunc_Show_Console,
+   gamefunc_Quick_Save,
+   gamefunc_Quick_Load,
    };
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR will add two new buttons to the list of inputs, and default bind F6 and F9 to quick save and quick load, thus allowing controller players to use a function that is semi-required to enjoy Blood on difficulties above lightly broiled. It will also leave the F6 and F9 hardcoded as their respective quick save and quick load keys, so users updating NBlood won't suddenly be unable to quick save and quick load.