### PR TITLE
Add cubic interpolation for SF2 playback

### DIFF
--- a/source/audiolib/src/driver_sf2.cpp
+++ b/source/audiolib/src/driver_sf2.cpp
@@ -163,7 +163,7 @@ int SF2Drv_MIDI_StartPlayback(void)
 {
     SF2Drv_MIDI_HaltPlayback();
 
-    tsf_set_output(sf2_synth, MV_Channels == 1 ? TSF_MONO : TSF_STEREO_INTERLEAVED, MV_MixRate, 0);
+    tsf_set_output(sf2_synth, MV_Channels == 1 ? TSF_MONO : TSF_STEREO_INTERLEAVED, TSF_INTERP_CUBIC, MV_MixRate, 0);
     tsf_channel_set_bank_preset(sf2_synth, 9, 128, 0);
     tsf_reset(sf2_synth);
 

--- a/source/audiolib/src/tsf.h
+++ b/source/audiolib/src/tsf.h
@@ -1106,8 +1106,6 @@ static float tsf_voice_interpolate(float* input, unsigned int *pos, float alpha,
 	// Interpolation methods based off https://paulbourke.net/miscellaneous/interpolation/
 	switch (interpolatemode)
 	{
-		case TSF_INTERP_NEAREST:
-			return input[pos[1]];
 		case TSF_INTERP_LINEAR:
 			return (input[pos[1]] * (1.f - alpha) + input[pos[2]] * alpha);
 		case TSF_INTERP_CUBIC:
@@ -1122,6 +1120,9 @@ static float tsf_voice_interpolate(float* input, unsigned int *pos, float alpha,
 			a3 = pointb;
 			return (a0 * alpha * alpha2 + a1 * alpha2 + a2 * alpha + a3);
 		}
+		case TSF_INTERP_NEAREST:
+		default:
+			return input[pos[1]];
 	}
 }
 

--- a/source/audiolib/src/tsf.h
+++ b/source/audiolib/src/tsf.h
@@ -1138,9 +1138,10 @@ static void tsf_voice_render(tsf* f, struct tsf_voice* v, float* outputBuffer, i
 	TSF_BOOL updateModLFO = (v->modlfo.delta && (region->modLfoToPitch || region->modLfoToFilterFc || region->modLfoToVolume));
 	TSF_BOOL updateVibLFO = (v->viblfo.delta && (region->vibLfoToPitch));
 	TSF_BOOL isLooping    = (v->loopStart < v->loopEnd);
-	unsigned int tmpLoopStart = v->loopStart, tmpLoopEnd = v->loopEnd;
+	unsigned int tmpLoopStart = v->loopStart, tmpLoopEnd = v->loopEnd, pos[4] = {0};
 	double tmpSampleEndDbl = (double)region->end, tmpLoopEndDbl = (double)tmpLoopEnd + 1.0;
 	double tmpSourceSamplePosition = v->sourceSamplePosition;
+	float alpha           = 0;
 	struct tsf_voice_lowpass tmpLowpass = v->lowpass;
 
 	TSF_BOOL dynamicLowpass = (region->modLfoToFilterFc || region->modEnvToFilterFc);
@@ -1164,9 +1165,8 @@ static void tsf_voice_render(tsf* f, struct tsf_voice* v, float* outputBuffer, i
 
 	while (numSamples)
 	{
-		float gainMono, gainLeft, gainRight, alpha;
+		float gainMono, gainLeft, gainRight;
 		int blockSamples = (numSamples > TSF_RENDER_EFFECTSAMPLEBLOCK ? TSF_RENDER_EFFECTSAMPLEBLOCK : numSamples);
-		unsigned int pos[4];
 		numSamples -= blockSamples;
 
 		if (dynamicLowpass)

--- a/source/audiolib/src/tsf.h
+++ b/source/audiolib/src/tsf.h
@@ -1107,9 +1107,9 @@ static float tsf_voice_interpolate(float* input, unsigned int *pos, float alpha,
 	switch (interpolatemode)
 	{
 		case TSF_INTERP_NEAREST:
-			return input[pos[0]];
+			return input[pos[1]];
 		case TSF_INTERP_LINEAR:
-			return (input[pos[0]] * (1.f - alpha) + input[pos[1]] * alpha);
+			return (input[pos[1]] * (1.f - alpha) + input[pos[2]] * alpha);
 		case TSF_INTERP_CUBIC:
 		{
 			const float pointa = input[pos[0]], pointb = input[pos[1]], pointc = input[pos[2]], pointd = input[pos[3]];
@@ -1199,13 +1199,13 @@ static void tsf_voice_render(tsf* f, struct tsf_voice* v, float* outputBuffer, i
 				while (blockSamples-- && tmpSourceSamplePosition < tmpSampleEndDbl)
 				{
 					// Get samples.
-					pos[0] = (unsigned int)tmpSourceSamplePosition;
+					pos[1] = (unsigned int)tmpSourceSamplePosition;
 					if (f->interpolatemode != TSF_INTERP_NEAREST)
 					{
-						alpha = (float)(tmpSourceSamplePosition - pos[0]);
-						pos[1] = (pos[0] >= tmpLoopEnd && isLooping ? tmpLoopStart : pos[0] + 1);
+						alpha = (float)(tmpSourceSamplePosition - pos[1]);
+						pos[2] = isLooping ? (pos[1] >= tmpLoopEnd ? tmpLoopStart : pos[1] + 1) : (pos[1] + 1 == region->end ? pos[1] : pos[1] + 1);
 						if (f->interpolatemode == TSF_INTERP_CUBIC)
-							pos[2] = (pos[1] >= tmpLoopEnd && isLooping ? tmpLoopStart : pos[1] + 1), pos[3] = (pos[2] >= tmpLoopEnd && isLooping ? tmpLoopStart : pos[2] + 1);
+							pos[0] = (pos[1] == tmpLoopStart && isLooping ? tmpLoopEnd : pos[1] == 0 ? 0 : pos[1] - 1), pos[3] = isLooping ? (pos[2] >= tmpLoopEnd ? tmpLoopStart : pos[2] + 1) : (pos[2] + 1 == region->end ? pos[2] : pos[2] + 1);
 					}
 
 					// Interpolation.
@@ -1228,13 +1228,13 @@ static void tsf_voice_render(tsf* f, struct tsf_voice* v, float* outputBuffer, i
 				while (blockSamples-- && tmpSourceSamplePosition < tmpSampleEndDbl)
 				{
 					// Get samples.
-					pos[0] = (unsigned int)tmpSourceSamplePosition;
+					pos[1] = (unsigned int)tmpSourceSamplePosition;
 					if (f->interpolatemode != TSF_INTERP_NEAREST)
 					{
-						alpha = (float)(tmpSourceSamplePosition - pos[0]);
-						pos[1] = (pos[0] >= tmpLoopEnd && isLooping ? tmpLoopStart : pos[0] + 1);
+						alpha = (float)(tmpSourceSamplePosition - pos[1]);
+						pos[2] = isLooping ? (pos[1] >= tmpLoopEnd ? tmpLoopStart : pos[1] + 1) : (pos[1] + 1 == region->end ? pos[1] : pos[1] + 1);
 						if (f->interpolatemode == TSF_INTERP_CUBIC)
-							pos[2] = (pos[1] >= tmpLoopEnd && isLooping ? tmpLoopStart : pos[1] + 1), pos[3] = (pos[2] >= tmpLoopEnd && isLooping ? tmpLoopStart : pos[2] + 1);
+							pos[0] = (pos[1] == tmpLoopStart && isLooping ? tmpLoopEnd : pos[1] == 0 ? 0 : pos[1] - 1), pos[3] = isLooping ? (pos[2] >= tmpLoopEnd ? tmpLoopStart : pos[2] + 1) : (pos[2] + 1 == region->end ? pos[2] : pos[2] + 1);
 					}
 
 					// Interpolation.
@@ -1256,13 +1256,13 @@ static void tsf_voice_render(tsf* f, struct tsf_voice* v, float* outputBuffer, i
 				while (blockSamples-- && tmpSourceSamplePosition < tmpSampleEndDbl)
 				{
 					// Get samples.
-					pos[0] = (unsigned int)tmpSourceSamplePosition;
+					pos[1] = (unsigned int)tmpSourceSamplePosition;
 					if (f->interpolatemode != TSF_INTERP_NEAREST)
 					{
-						alpha = (float)(tmpSourceSamplePosition - pos[0]);
-						pos[1] = (pos[0] >= tmpLoopEnd && isLooping ? tmpLoopStart : pos[0] + 1);
+						alpha = (float)(tmpSourceSamplePosition - pos[1]);
+						pos[2] = isLooping ? (pos[1] >= tmpLoopEnd ? tmpLoopStart : pos[1] + 1) : (pos[1] + 1 == region->end ? pos[1] : pos[1] + 1);
 						if (f->interpolatemode == TSF_INTERP_CUBIC)
-							pos[2] = (pos[1] >= tmpLoopEnd && isLooping ? tmpLoopStart : pos[1] + 1), pos[3] = (pos[2] >= tmpLoopEnd && isLooping ? tmpLoopStart : pos[2] + 1);
+							pos[0] = (pos[1] == tmpLoopStart && isLooping ? tmpLoopEnd : pos[1] == 0 ? 0 : pos[1] - 1), pos[3] = isLooping ? (pos[2] >= tmpLoopEnd ? tmpLoopStart : pos[2] + 1) : (pos[2] + 1 == region->end ? pos[2] : pos[2] + 1);
 					}
 
 					// Interpolation.

--- a/source/blood/src/messages.cpp
+++ b/source/blood/src/messages.cpp
@@ -447,16 +447,19 @@ void CGameMessageMgr::Display(void)
 
 void CGameMessageMgr::Clear(void)
 {
+#if 0 // we have the CPU cycles with current-day hardware to delete every message now, don't use this old method
     if (VanillaMode())
     {
         messagesIndex = nextMessagesIndex = numberOfDisplayedMessages = 0;
     }
     else
+#endif
     {
         for (int i = 0; i < kMessageLogSize; i++)
         {
             messageStruct* pMessage = &messages[i];
             pMessage->deleted = true;
+            pMessage->lastTickWhenVisible = 0;
         }
     }
 }


### PR DESCRIPTION
This PR adds nearest neighbor and cubic interpolation for soundfont playback, and improves the overall sound quality for low frequency notes.

The default interpolation method is set to cubic, however the option for selecting which interpolation method (NEAREST/LINEAR/CUBIC) can be added in the future with the new interpolatemode option argument.