### PR TITLE
Blood: Reset weapon state when switching weapons

### DIFF
--- a/source/blood/src/weapon.cpp
+++ b/source/blood/src/weapon.cpp
@@ -630,7 +630,8 @@ void WeaponLower(PLAYER *pPlayer)
     if (checkLitSprayOrTNT(pPlayer))
         return;
     pPlayer->throwPower = 0;
-    int prevState = pPlayer->weaponState;
+    const int prevState = pPlayer->weaponState;
+    const int prevWeapon = pPlayer->curWeapon;
     switch (pPlayer->curWeapon)
     {
     case kWeaponPitchfork:
@@ -800,6 +801,9 @@ void WeaponLower(PLAYER *pPlayer)
     }
     pPlayer->curWeapon = kWeaponNone;
     pPlayer->qavLoop = 0;
+
+    if ((prevWeapon != kWeaponTNT && prevWeapon != kWeaponSprayCan) && !VanillaMode()) // reset weapon state after switching weapon (except when switching from tnt/spray)
+        pPlayer->weaponState = 0;
 }
 
 void WeaponUpdateState(PLAYER *pPlayer)


### PR DESCRIPTION
This PR resets the weapon state when switching weapon (this is based off of [BloodGDX's logic](https://gitlab.com/m210/BloodGDX/-/blob/942c07f31c61b6b2402ec393596ac414f683bc74/core/src/ru/m210projects/Blood/Weapon.java#L1552-1555)), and fixes issue #799