### PR TITLE
Blood: Fix shotgun bug with akimbo

### DIFF
--- a/source/blood/src/weapon.cpp
+++ b/source/blood/src/weapon.cpp
@@ -934,7 +934,9 @@ void WeaponUpdateState(PLAYER *pPlayer)
             {
                 sfxPlay3DSound(pPlayer->pSprite, 410, 3, 2);
                 StartQAV(pPlayer, 57, nClientEjectShell, 0);
-                if (gInfiniteAmmo || pPlayer->ammoCount[2] > 1)
+                if (powerupCheck(pPlayer, kPwUpTwoGuns) && (gInfiniteAmmo || CheckAmmo(pPlayer, 2, 4)) && !VanillaMode()) // if we now have enough ammo to carry two shotguns, update the gun state and give back our second shotgun
+                    pPlayer->weaponState = 7;
+                else if (gInfiniteAmmo || pPlayer->ammoCount[2] > 1)
                     pPlayer->weaponState = 3;
                 else
                     pPlayer->weaponState = 2;


### PR DESCRIPTION
This PR fixes this bug reported here. https://github.com/nukeykt/NBlood/issues/199

When a player drops below 4 shells while the akimbo powerup is active, they'll be locked to a single shotgun regardless if they pick up more ammo. This fix will force a ammo check for the shotgun upon every reload, and will switch back to two shotguns if the akimbo powerup is still active.