### PR TITLE
Added games to VS Code build & debug configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,8 +91,6 @@ xcuserdata/
 project.xcworkspace/
 *.dSYM/
 
-.vscode
-
 .DS_Store
 ._*
 /source/voidwrap/sdk/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,5 +37,29 @@
             },
             "cwd": "${workspaceRoot}",
         }
+        {
+            "name": "Debug ETekwar",
+            "type": "cppdbg",
+            "request": "launch",
+            "linux": {
+                "program": "${workspaceRoot}/etekwar",
+            },
+            "windows": {
+                "program": "${workspaceRoot}/etekwar.exe",
+            },
+            "cwd": "${workspaceRoot}",
+        },
+        {
+            "name": "Debug EWitchaven",
+            "type": "cppdbg",
+            "request": "launch",
+            "linux": {
+                "program": "${workspaceRoot}/ewitchaven",
+            },
+            "windows": {
+                "program": "${workspaceRoot}/ewitchaven.exe",
+            },
+            "cwd": "${workspaceRoot}",
+        }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,74 +2,38 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug EDuke32",
+            "name": "Debug Rednukem",
             "type": "cppdbg",
             "request": "launch",
             "linux": {
-                "program": "${workspaceRoot}/eduke32",
+                "program": "${workspaceRoot}/rednukem",
             },
             "windows": {
-                "program": "${workspaceRoot}/eduke32.exe",
+                "program": "${workspaceRoot}/rednukem.exe",
             },
             "cwd": "${workspaceRoot}",
         },
         {
-            "name": "Debug Mapster32",
+            "name": "Debug NBlood",
             "type": "cppdbg",
             "request": "launch",
             "linux": {
-                "program": "${workspaceRoot}/mapster32",
+                "program": "${workspaceRoot}/nblood",
             },
             "windows": {
-                "program": "${workspaceRoot}/mapster32.exe",
+                "program": "${workspaceRoot}/nblood.exe",
             },
             "cwd": "${workspaceRoot}",
         },
         {
-            "name": "Debug VoidSW",
+            "name": "Debug PCExhumed",
             "type": "cppdbg",
             "request": "launch",
             "linux": {
-                "program": "${workspaceRoot}/voidsw",
+                "program": "${workspaceRoot}/pcexhumed",
             },
             "windows": {
-                "program": "${workspaceRoot}/voidsw.exe",
-            },
-            "cwd": "${workspaceRoot}",
-        },
-        {
-            "name": "Debug Wangulator",
-            "type": "cppdbg",
-            "request": "launch",
-            "linux": {
-                "program": "${workspaceRoot}/wangulator",
-            },
-            "windows": {
-                "program": "${workspaceRoot}/wangulator.exe",
-            },
-            "cwd": "${workspaceRoot}",
-        },
-        {
-            "name": "Debug EKenBuild",
-            "type": "cppdbg",
-            "request": "launch",
-            "linux": {
-                "program": "${workspaceRoot}/ekenbuild",
-            },
-            "windows": {
-                "program": "${workspaceRoot}/ekenbuild.exe",
-            },
-            "cwd": "${workspaceRoot}",
-        },
-        {
-            "name": "Debug EKenBuild-Editor",
-            "type": "cppdbg",
-            "request": "launch",
-            "linux": {
-                "program": "${workspaceRoot}/ekenbuild-editor",
-            },
-            "windows": {
-                "program": "${workspaceRoot}/ekenbuild-editor.exe",
+                "program": "${workspaceRoot}/pcexhumed.exe",
             },
             "cwd": "${workspaceRoot}",
         }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,9 +3,9 @@
     "tasks": [
         {
             "type": "shell",
-            "label": "Build EDuke32 and Mapster32 Debug",
+            "label": "Build Rednukem Debug",
             "linux": {
-                "command": "make RELEASE=0",
+                "command": "make rr RELEASE=0",
                 "details": "GNU Make for Linux"
             },
             "windows": {
@@ -17,13 +17,13 @@
         },
         {
             "type": "shell",
-            "label": "Build VoidSW and Wangulator Debug",
+            "label": "Build NBlood Debug",
             "linux": {
-                "command": "make sw RELEASE=0",
+                "command": "make blood RELEASE=0",
                 "details": "GNU Make for Linux"
             },
             "windows": {
-                "command": "mingw32-make.exe sw RELEASE=0",
+                "command": "mingw32-make.exe blood RELEASE=0",
                 "detail": "GNU Make with mingw32 for Windows"
             },
             "group": "build",
@@ -31,13 +31,13 @@
         },
         {
             "type": "shell",
-            "label": "Build EKenbuild and EKenbuild-Editor Debug",
+            "label": "Build PCExhumed Debug",
             "linux": {
-                "command": "make kenbuild RELEASE=0",
+                "command": "make exhumed RELEASE=0",
                 "details": "GNU Make for Linux"
             },
             "windows": {
-                "command": "mingw32-make.exe kenbuild RELEASE=0",
+                "command": "mingw32-make.exe exhumed RELEASE=0",
                 "detail": "GNU Make with mingw32 for Windows"
             },
             "group": "build",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -45,6 +45,34 @@
         },
         {
             "type": "shell",
+            "label": "Build ETekwar Debug",
+            "linux": {
+                "command": "make tekwar RELEASE=0",
+                "details": "GNU Make for Linux"
+            },
+            "windows": {
+                "command": "mingw32-make.exe tekwar RELEASE=0",
+                "detail": "GNU Make with mingw32 for Windows"
+            },
+            "group": "build",
+            "problemMatcher": [],
+        },
+        {
+            "type": "shell",
+            "label": "Build EWitchaven Debug",
+            "linux": {
+                "command": "make witchaven RELEASE=0",
+                "details": "GNU Make for Linux"
+            },
+            "windows": {
+                "command": "mingw32-make.exe witchaven RELEASE=0",
+                "detail": "GNU Make with mingw32 for Windows"
+            },
+            "group": "build",
+            "problemMatcher": [],
+        },
+        {
+            "type": "shell",
             "label": "Clean all",
             "linux": {
                 "command": "make clean",


### PR DESCRIPTION
The following games can be build and debugged within VS Code with this change:
- Rednukem
- NBlood
- PCExhumed
- ETekwar
- EWitchaven

Removed configuration for:
- EDuke32
- Mapster32
- VoidSW
- Wangulator
- EKenbuild
- EKenBuild-Editor

Also removed .gitignore for .vscode folder.