### PR TITLE
Blood: Fix error calculating frag HUD element for message height offset

### DIFF
--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -2033,7 +2033,7 @@ void viewResizeView(int size)
     videoSetViewableArea(gViewX0, gViewY0, gViewX1, gViewY1);
     if (gViewMode == 4) // 2D map view
     {
-        int nOffset = bDrawFragsBg ? tilesiz[2229].y*((gNetPlayers+3)/4) : 0;
+        int nOffset = bDrawFragsBg && !VanillaMode() ? (tilesiz[2229].y*ydim*((gNetPlayers+3)/4))/200 : 0;
         nOffset = divscale16(nOffset, yscale);
         nOffset += gGameOptions.nGameType == kGameTypeSinglePlayer && !VanillaMode() ? 6 : 1;
         gGameMessageMgr.SetCoordinates(1, nOffset);


### PR DESCRIPTION
This PR fixes an oversight calculation error introduced in commit 8658502070088cfbcc1a6b0729c8283086557ab8. When the view window is set to a small size, text will overlay the frag score counter HUD element, as it was not properly using the right calculation for the element.