### PR TITLE
Blood: Inline VanillaMode()

### DIFF
--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -127,6 +127,8 @@ bool gSaveGameActive;
 int gCacheMiss;
 int gMenuPicnum = 2518; // default menu picnum
 
+bool bVanilla = 0;
+
 enum gametokens
 {
     T_INCLUDE = 0,
@@ -2782,14 +2784,8 @@ void LoadExtraArts(void)
     }
 }
 
-static bool bVanilla = 0;
-
 void VanillaModeUpdate(void) {
     bVanilla = gDemo.VanillaDemo() || (gVanilla && !gDemo.at0 && gGameOptions.nGameType == kGameTypeSinglePlayer && numplayers == 1);
-}
-
-bool VanillaMode(void) {
-    return bVanilla;
 }
 
 bool fileExistsRFF(int id, const char *ext) {

--- a/source/blood/src/blood.h
+++ b/source/blood/src/blood.h
@@ -72,6 +72,8 @@ extern int gCacheMiss;
 extern int gDoQuickSave;
 extern int gMenuPicnum;
 
+extern bool bVanilla;
+
 void QuitGame(void);
 void PreloadCache(void);
 void StartLevel(GAMEOPTIONS *gameOptions);
@@ -80,7 +82,7 @@ void ScanINIFiles(void);
 bool LoadArtFile(const char *pzFile);
 void LoadExtraArts(void);
 void VanillaModeUpdate(void);
-bool VanillaMode(void);
+inline bool VanillaMode(void) {return bVanilla;}
 bool fileExistsRFF(int id, const char* ext);
 int sndTryPlaySpecialMusic(int nMusic);
 void sndPlaySpecialMusicOrNothing(int nMusic);


### PR DESCRIPTION
This PR optimizes `VanillaMode()` by rewriting it as an inlined function.

While LTO does effectively turn this into an inlined function, it will not for non-LTO compiles. This will help performance for compiles for lower powered devices, as `VanillaMode()` is called upon many times per main loop.