### PR TITLE
Blood: Update logic used to redraw screen border and add new -s CLI argument

### DIFF
--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -1229,6 +1229,7 @@ SWITCH switches[] = {
     { "c", 43, 1 },
     { "conf", 43, 1 },
     { "noconsole", 43, 0 },
+    { "s", 44, 1 },
     { NULL, 0, 0 }
 };
 
@@ -1257,6 +1258,7 @@ void PrintHelp(void)
         "-pname\t\tOverride player name setting from config file\n"
         "-record\t\tRecord demo\n"
         "-rff\t\tSpecify an RFF file for Blood game resources\n"
+        "-s\t\tStart game on difficulty level; Range:0..4; Default:2;\n\n"
         "-server [players]\tStart a multiplayer server\n"
 #ifdef STARTUP_SETUP_WINDOW
         "-setup/nosetup\tEnable or disable startup window\n"
@@ -1445,11 +1447,7 @@ void ParseOptions(void)
         case 10:
             if (OptArgc < 1)
                 ThrowError("Missing argument");
-            gSkill = strtoul(OptArgv[0], NULL, 0);
-            if (gSkill < 0)
-                gSkill = 0;
-            else if (gSkill > 4)
-                gSkill = 4;
+            gSkill = ClipRange(strtoul(OptArgv[0], NULL, 0), 0, 4);
             break;
         case 15:
             break;
@@ -1542,6 +1540,14 @@ void ParseOptions(void)
             G_AddPath(OptArgv[0]);
             break;
         case 43: // conf, noconsole
+            break;
+        case 44:
+            if (OptArgc < 1)
+                ThrowError("Missing argument");
+            gSkill = ClipRange(strtoul(OptArgv[0], NULL, 0), 0, 4);
+            gGameOptions.nDifficulty = gSkill;
+            gGameOptions.nDifficultyQuantity = gSkill;
+            gGameOptions.nDifficultyHealth = gSkill;
             break;
         }
     }

--- a/source/blood/src/loadsave.cpp
+++ b/source/blood/src/loadsave.cpp
@@ -166,6 +166,7 @@ void LoadSave::LoadGame(char *pzFile)
         gGameMessageMgr.Clear();
     viewSetErrorMessage("");
     viewResizeView(gViewSize);
+    viewUpdatePages();
     if (!gGameStarted)
     {
         netWaitForEveryone(0);

--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -2699,6 +2699,7 @@ void SaveGame(CGameMenuItemZEditBitmap *pItem, CGameMenuEvent *event)
     UpdateSaveGameItemText(nSlot);
     gGameMenuMgr.Deactivate();
     viewSetMessage("Game saved");
+    viewUpdatePages();
 }
 
 void QuickSaveGame(void)
@@ -2726,6 +2727,7 @@ void QuickSaveGame(void)
     UpdateSaveGameItemText(gQuickSaveSlot);
     gGameMenuMgr.Deactivate();
     viewSetMessage("Game saved");
+    viewUpdatePages();
 }
 
 void LoadGame(CGameMenuItemZEditBitmap *pItem, CGameMenuEvent *event)

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -1290,10 +1290,9 @@ WEAPONICON gWeaponIconVoxel[] = {
     { -1, 0 },
 };
 
-int dword_14C508;
-
 void viewDrawStats(PLAYER *pPlayer, int x, int y)
 {
+    static int gLastPageTimeStats = 0;
     const int nFont = 3;
     char buffer[128];
     if (!gLevelStats)
@@ -1316,6 +1315,9 @@ void viewDrawStats(PLAYER *pPlayer, int x, int y)
     y += nHeight+1;
     sprintf(buffer, "S:%d/%d", gSecretMgr.nNormalSecretsFound, max(gSecretMgr.nNormalSecretsFound, gSecretMgr.nAllSecrets)); // if we found more than there are, increase the total - some levels have a bugged counter
     viewDrawText(3, buffer, x, y, 20, 0, 0, true, 256);
+    if (gViewMode == 3 && gViewSize > 3 && gLastPageTimeStats != gLevelTime) // redraw borders
+        viewUpdatePages();
+    gLastPageTimeStats = gLevelTime;
 }
 
 #define kPowerUps 11
@@ -1398,6 +1400,15 @@ void viewDrawPowerUps(PLAYER* pPlayer)
         DrawStatNumber("%d", nTime, kSBarNumberInv, x + 15, y, 0, nTime > nWarning ? 0 : 2, 256, fix16_from_float(0.5f));
         y += 20;
     }
+    static int gLastPageTimePowerup = 0;
+    static int gLastPageTimePowerupCount = 0;
+    if (gViewMode == 3 && gViewSize > 3) // redraw borders
+    {
+        if (gLastPageTimePowerup != gLevelTime && nSortCount || gLastPageTimePowerupCount != nSortCount)
+            viewUpdatePages();
+    }
+    gLastPageTimePowerup = gLevelTime;
+    gLastPageTimePowerupCount = nSortCount;
 }
 
 void viewDrawMapTitle(void)
@@ -1474,11 +1485,10 @@ void viewDrawPack(PLAYER *pPlayer, int x, int y)
             x += tilesiz[gPackIcons[nPack]].x + 1;
         }
     }
-    if (pPlayer->packItemTime != dword_14C508)
-    {
+    static int gLastPageTimePack = 0;
+    if (pPlayer->packItemTime != gLastPageTimePack) // redraw borders
         viewUpdatePages();
-    }
-    dword_14C508 = pPlayer->packItemTime;
+    gLastPageTimePack = pPlayer->packItemTime;
 }
 
 void DrawPackItemInStatusBar(PLAYER *pPlayer, int x, int y, int x2, int y2, int nStat)
@@ -1640,6 +1650,11 @@ void viewDrawCtfHud(ClockTicks arg)
     else if (redFlagTaken)
         DrawStatMaskedSprite(4097, 307, 111, 0, redFlagCarrierColor ? 2 : 10, 512, 65536);
     flashTeamScore(arg, 1, true);
+
+    static int gLastPageTimeFlag = 0;
+    if (gViewMode == 3 && gViewSize > 3 && (gLastPageTimeFlag != gLevelTime)) // redraw borders
+        viewUpdatePages();
+    gLastPageTimeFlag = gLevelTime;
 }
 
 void UpdateStatusBar(ClockTicks arg)
@@ -2068,7 +2083,8 @@ void UpdateFrame(void)
 
 void viewDrawInterface(ClockTicks arg)
 {
-    if (gViewMode == 3/* && gViewSize >= 3*/ && (pcBackground != 0 || videoGetRenderMode() >= REND_POLYMOST))
+    const char bDrawFragsBg = (gGameOptions.nGameType != kGameTypeSinglePlayer) && (!VanillaMode() || gGameOptions.nGameType != kGameTypeTeams);
+    if (gViewMode == 3 && (gViewSize >= 3 || bDrawFragsBg) && (pcBackground != 0 || videoGetRenderMode() >= REND_POLYMOST))
     {
         UpdateFrame();
         pcBackground--;


### PR DESCRIPTION
This PR fixes issue #506 as well as fixing the bo~~a~~rders for classic renderer while powerups and stats are being drawn.

Additionally, this PR also fulfills #818

Fixes #506
Fixes #818