### PR TITLE
Blood: workaround for bat attack state

### DIFF
--- a/source/blood/src/aibat.cpp
+++ b/source/blood/src/aibat.cpp
@@ -74,6 +74,19 @@ static void BiteSeqCallback(int, int nXSprite)
 {
     XSPRITE *pXSprite = &xsprite[nXSprite];
     spritetype *pSprite = &sprite[pXSprite->reference];
+    /*
+     * workaround for
+     * pXSprite->target >= 0 && pXSprite->target < kMaxSprites in file NBlood/source/blood/src/aibat.cpp at line 85
+     * The value of pXSprite->target is -1.
+     * copied from thinkPonder()
+     * resolves this case, but may cause other issues?
+     */
+    if (pXSprite->target == -1)
+    {
+        aiNewState(pSprite, pXSprite, &batSearch);
+        return;
+    }
+
     spritetype *pTarget = &sprite[pXSprite->target];
     int dx = Cos(pSprite->ang) >> 16;
     int dy = Sin(pSprite->ang) >> 16;


### PR DESCRIPTION
This PR adds a sanity check for the bat attack state when loading/saving files.

This is referenced off of an earlier fix made to bone eels (00107feb0c310ce24a3d022bde3be18dc2d342a8) and the same fix is applied to bats.

This PR also fixes the report issues #444 #607 and #454

Fixes #444
Fixes #607
Fixes #454