### PR TITLE
Blood: Add range check for target extra index

### DIFF
--- a/source/blood/src/aizomba.cpp
+++ b/source/blood/src/aizomba.cpp
@@ -177,6 +177,11 @@ static void thinkPonder(spritetype *pSprite, XSPRITE *pXSprite)
     DUDEINFO *pDudeInfo = getDudeInfo(pSprite->type);
     dassert(pXSprite->target >= 0 && pXSprite->target < kMaxSprites);
     spritetype *pTarget = &sprite[pXSprite->target];
+    if (!VanillaMode() && !xspriRangeIsFine(pTarget->extra))
+    {
+        aiNewState(pSprite, pXSprite, &zombieASearch);
+        return;
+    }
     XSPRITE *pXTarget = &xsprite[pTarget->extra];
     int dx = pTarget->x-pSprite->x;
     int dy = pTarget->y-pSprite->y;


### PR DESCRIPTION
This PR adds an additional sanity check to the extra field range used for zombie target process logic. A vanilla mode check is also used, to ensure demos do not desync (I have a demo that does require extra to be set to -1).

Fixes #24