### PR TITLE
Blood: Load mouse/joystick values from non-OSD cfg

### DIFF
--- a/source/blood/src/config.cpp
+++ b/source/blood/src/config.cpp
@@ -748,6 +748,8 @@ int CONFIG_ReadSetup(void)
     SCRIPT_GetNumber(scripthandle, "Setup", "ConfigVersion", &configversion);
     SCRIPT_GetNumber(scripthandle, "Setup", "ForceSetup", &gSetup.forcesetup);
     SCRIPT_GetNumber(scripthandle, "Setup", "NoAutoLoad", &gSetup.noautoload);
+    SCRIPT_GetNumber(scripthandle, "Setup", "InputJoystick", &gSetup.usejoystick);
+    SCRIPT_GetNumber(scripthandle, "Setup", "InputMouse", &gSetup.usemouse);
 
     int32_t cachesize;
     SCRIPT_GetNumber(scripthandle, "Setup", "CacheSize", &cachesize);
@@ -881,6 +883,8 @@ void CONFIG_WriteSetup(uint32_t flags)
     SCRIPT_PutNumber(scripthandle, "Setup", "ConfigVersion", BYTEVERSION, FALSE, FALSE);
     SCRIPT_PutNumber(scripthandle, "Setup", "ForceSetup", gSetup.forcesetup, FALSE, FALSE);
     SCRIPT_PutNumber(scripthandle, "Setup", "NoAutoLoad", gSetup.noautoload, FALSE, FALSE);
+    SCRIPT_PutNumber(scripthandle, "Setup", "InputJoystick", gSetup.usejoystick, FALSE, FALSE);
+    SCRIPT_PutNumber(scripthandle, "Setup", "InputMouse", gSetup.usemouse, FALSE, FALSE);
 
 #ifdef POLYMER
     SCRIPT_PutNumber(scripthandle, "Screen Setup", "Polymer", glrendmode == REND_POLYMER, FALSE, FALSE);

--- a/source/blood/src/osdcmd.cpp
+++ b/source/blood/src/osdcmd.cpp
@@ -825,14 +825,6 @@ static int osdcmd_cvar_set_game(osdcmdptr_t parm)
             r_ambientlightrecip = 256.f;
         else r_ambientlightrecip = 1.f/r_ambientlight;
     }
-    else if (!Bstrcasecmp(parm->name, "in_mouse"))
-    {
-        CONTROL_MouseEnabled = (gSetup.usemouse && CONTROL_MousePresent);
-    }
-    else if (!Bstrcasecmp(parm->name, "in_joystick"))
-    {
-        CONTROL_JoystickEnabled = (gSetup.usejoystick && CONTROL_JoyPresent);
-    }
     else if (!Bstrcasecmp(parm->name, "vid_gamma"))
     {
         gBrightness = GAMMA_CALC;
@@ -1029,8 +1021,6 @@ int32_t registerosdcommands(void)
         { "horizcenter", "enable/disable centered horizon line", (void *)&gCenterHoriz, CVAR_BOOL, 0, 1 },
         { "deliriumblur", "enable/disable delirium blur effect(polymost)", (void *)&gDeliriumBlur, CVAR_BOOL, 0, 1 },
         { "fov", "change the field of view", (void *)&gFov, CVAR_INT|CVAR_FUNCPTR, 75, 140 },
-        { "in_joystick","enables input from the joystick if it is present",(void *)&gSetup.usejoystick, CVAR_BOOL|CVAR_FUNCPTR, 0, 1 },
-        { "in_mouse","enables input from the mouse if it is present",(void *)&gSetup.usemouse, CVAR_BOOL|CVAR_FUNCPTR, 0, 1 },
 
         { "in_aimmode", "0: toggle, 1: hold to aim", (void *)&gMouseAiming, CVAR_BOOL, 0, 1 },
         {


### PR DESCRIPTION
This PR forces `gSetup.usejoystick` and `gSetup.usemouse` to be loaded from `nblood.cfg` instead of `nblood_cvars.cfg`, as the OSD subsystem is initialized after the start window has closed, and thus the use mouse/joystick settings are never loaded.

Fixes #794