### PR TITLE
Blood: pre-cache SEQs for prone cultist enemy types

### DIFF
--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -223,7 +223,9 @@ void PrecacheDude(spritetype *pSprite)
     switch (pSprite->type)
     {
     case kDudeCultistTommy:
+    case kDudeCultistTommyProne:
     case kDudeCultistShotgun:
+    case kDudeCultistShotgunProne:
     case kDudeCultistTesla:
     case kDudeCultistTNT:
         seqPrecacheId(pDudeInfo->seqStartID+6);


### PR DESCRIPTION
This PR adds two prone type checks to the PrecacheDude() dude function when loading maps, so they are cached like the non-prone cultist types.