### PR TITLE
Blood: Fix NOONE_EXTENSIONS=0 build

### DIFF
--- a/source/blood/src/db.cpp
+++ b/source/blood/src/db.cpp
@@ -31,6 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "md4.h"
 
 //#include "actor.h"
+#include "blood.h"
 #include "globals.h"
 #include "db.h"
 #include "iob.h"


### PR DESCRIPTION
This PR adds a missing header to define `VanillaMode()` which is now part of `blood.h` instead of `globals.h`.