### PR TITLE
Blood: Add option to show stats on automap only

### DIFF
--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -444,6 +444,7 @@ const char *pzLevelStatsStrings[] = {
 };
 
 void SetAutoAim(CGameMenuItemZCycle *);
+void SetAutoRun(CGameMenuItemZBool *);
 void SetLevelStats(CGameMenuItemZCycle *);
 void SetPowerupDuration(CGameMenuItemZBool *);
 void SetShowMapTitle(CGameMenuItemZBool*);
@@ -456,13 +457,14 @@ CGameMenuItemZCycle itemOptionsGameShowWeapons("SHOW WEAPONS:", 3, 66, 70, 180, 
 CGameMenuItemZBool itemOptionsGameBoolSlopeTilting("SLOPE TILTING:", 3, 66, 80, 180, gSlopeTilting, SetSlopeTilting, NULL, NULL);
 CGameMenuItemZBool itemOptionsGameBoolViewBobbing("VIEW BOBBING:", 3, 66, 90, 180, gViewVBobbing, SetViewBobbing, NULL, NULL);
 CGameMenuItemZBool itemOptionsGameBoolViewSwaying("VIEW SWAYING:", 3, 66, 100, 180, gViewHBobbing, SetViewSwaying, NULL, NULL);
-CGameMenuItemZCycle itemOptionsGameBoolAutoAim("AUTO AIM:", 3, 66, 110, 180, 0, SetAutoAim, pzAutoAimStrings, ARRAY_SSIZE(pzAutoAimStrings), 0);
-CGameMenuItemZCycle itemOptionsGameWeaponSwitch("EQUIP PICKUPS:", 3, 66, 120, 180, 0, SetWeaponSwitch, pzWeaponSwitchStrings, ARRAY_SSIZE(pzWeaponSwitchStrings), 0);
-CGameMenuItemChain itemOptionsGameChainParentalLock("PARENTAL LOCK", 3, 0, 130, 320, 1, &menuParentalLock, -1, NULL, 0);
+CGameMenuItemZCycle itemOptionsGameCycleAutoAim("AUTO AIM:", 3, 66, 110, 180, 0, SetAutoAim, pzAutoAimStrings, ARRAY_SSIZE(pzAutoAimStrings), 0);
+CGameMenuItemZBool itemOptionsGameBoolAutoRun("AUTO RUN:", 3, 66, 120, 180, gAutoRun, SetAutoRun, NULL, NULL);
+CGameMenuItemZCycle itemOptionsGameWeaponSwitch("EQUIP PICKUPS:", 3, 66, 130, 180, 0, SetWeaponSwitch, pzWeaponSwitchStrings, ARRAY_SSIZE(pzWeaponSwitchStrings), 0);
+//CGameMenuItemChain itemOptionsGameChainParentalLock("PARENTAL LOCK", 3, 0, 140, 320, 1, &menuParentalLock, -1, NULL, 0);
 
 ///////////////
-CGameMenuItemZBool itemOptionsGameBoolWeaponsV10X("V1.0x WEAPONS BALANCE:", 3, 66, 130, 180, gWeaponsV10x, SetWeaponsV10X, NULL, NULL);
-CGameMenuItemZBool itemOptionsGameBoolVanillaMode("VANILLA MODE:", 3, 66, 140, 180, gVanilla, SetVanillaMode, NULL, NULL);
+CGameMenuItemZBool itemOptionsGameBoolWeaponsV10X("V1.0x WEAPONS BALANCE:", 3, 66, 140, 180, gWeaponsV10x, SetWeaponsV10X, NULL, NULL);
+CGameMenuItemZBool itemOptionsGameBoolVanillaMode("VANILLA MODE:", 3, 66, 150, 180, gVanilla, SetVanillaMode, NULL, NULL);
 ///////////////////
 
 CGameMenuItemTitle itemOptionsDisplayTitle("DISPLAY SETUP", 1, 160, 20, 2038);
@@ -1256,7 +1258,8 @@ void SetupOptionsMenu(void)
     menuOptionsGame.Add(&itemOptionsGameBoolSlopeTilting, false);
     menuOptionsGame.Add(&itemOptionsGameBoolViewBobbing, false);
     menuOptionsGame.Add(&itemOptionsGameBoolViewSwaying, false);
-    menuOptionsGame.Add(&itemOptionsGameBoolAutoAim, false);
+    menuOptionsGame.Add(&itemOptionsGameCycleAutoAim, false);
+    menuOptionsGame.Add(&itemOptionsGameBoolAutoRun, false);
     menuOptionsGame.Add(&itemOptionsGameWeaponSwitch, false);
 
     //////////////////////
@@ -1271,7 +1274,8 @@ void SetupOptionsMenu(void)
     itemOptionsGameBoolSlopeTilting.at20 = gSlopeTilting;
     itemOptionsGameBoolViewBobbing.at20 = gViewVBobbing;
     itemOptionsGameBoolViewSwaying.at20 = gViewHBobbing;
-    itemOptionsGameBoolAutoAim.m_nFocus = gAutoAim;
+    itemOptionsGameCycleAutoAim.m_nFocus = gAutoAim;
+    itemOptionsGameBoolAutoRun.at20 = gAutoRun;
     itemOptionsGameWeaponSwitch.m_nFocus = (gWeaponSwitch&1) ? ((gWeaponSwitch&2) ? 1 : 2) : 0;
 
     ///////
@@ -1774,6 +1778,11 @@ void SetAutoAim(CGameMenuItemZCycle *pItem)
         gProfile[myconnectindex].nAutoAim = gAutoAim;
         netBroadcastPlayerInfo(myconnectindex);
     }
+}
+
+void SetAutoRun(CGameMenuItemZBool *pItem)
+{
+    gAutoRun = pItem->at20;
 }
 
 void SetLevelStats(CGameMenuItemZCycle *pItem)

--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -437,8 +437,14 @@ const char *pzWeaponSwitchStrings[] = {
     "BY RATING"
 };
 
+const char *pzLevelStatsStrings[] = {
+    "OFF",
+    "ON",
+    "AUTOMAP ONLY"
+};
+
 void SetAutoAim(CGameMenuItemZCycle *);
-void SetLevelStats(CGameMenuItemZBool *);
+void SetLevelStats(CGameMenuItemZCycle *);
 void SetPowerupDuration(CGameMenuItemZBool *);
 void SetShowMapTitle(CGameMenuItemZBool*);
 void SetWeaponSwitch(CGameMenuItemZCycle *pItem);
@@ -464,7 +470,7 @@ CGameMenuItemChain itemOptionsDisplayColor("COLOR CORRECTION", 3, 66, 60, 180, 0
 CGameMenuItemChain itemOptionsDisplayMode("VIDEO MODE", 3, 66, 70, 180, 0, &menuOptionsDisplayMode, -1, SetupVideoModeMenu, 0);
 CGameMenuItemZBool itemOptionsDisplayBoolCrosshair("CROSSHAIR:", 3, 66, 80, 180, gAimReticle, SetCrosshair, NULL, NULL);
 CGameMenuItemZBool itemOptionsDisplayBoolCenterHoriz("CENTER HORIZON LINE:", 3, 66, 90, 180, gCenterHoriz, SetCenterHoriz, NULL, NULL);
-CGameMenuItemZBool itemOptionsDisplayBoolLevelStats("LEVEL STATS:", 3, 66, 100, 180, gLevelStats, SetLevelStats, NULL, NULL);
+CGameMenuItemZCycle itemOptionsDisplayCycleLevelStats("LEVEL STATS:", 3, 66, 100, 180, gLevelStats, SetLevelStats, pzLevelStatsStrings, ARRAY_SSIZE(pzLevelStatsStrings), 0);
 CGameMenuItemZBool itemOptionsDisplayBoolPowerupDuration("POWERUP DURATION:", 3, 66, 110, 180, gPowerupDuration, SetPowerupDuration, NULL, NULL);
 CGameMenuItemZBool itemOptionsDisplayBoolShowMapTitle("MAP TITLE:", 3, 66, 120, 180, gShowMapTitle, SetShowMapTitle, NULL, NULL);
 CGameMenuItemZBool itemOptionsDisplayBoolMessages("MESSAGES:", 3, 66, 130, 180, gMessageState, SetMessages, NULL, NULL);
@@ -1278,7 +1284,7 @@ void SetupOptionsMenu(void)
     menuOptionsDisplay.Add(&itemOptionsDisplayMode, false);
     menuOptionsDisplay.Add(&itemOptionsDisplayBoolCrosshair, false);
     menuOptionsDisplay.Add(&itemOptionsDisplayBoolCenterHoriz, false);
-    menuOptionsDisplay.Add(&itemOptionsDisplayBoolLevelStats, false);
+    menuOptionsDisplay.Add(&itemOptionsDisplayCycleLevelStats, false);
     menuOptionsDisplay.Add(&itemOptionsDisplayBoolPowerupDuration, false);
     menuOptionsDisplay.Add(&itemOptionsDisplayBoolShowMapTitle, false);
     menuOptionsDisplay.Add(&itemOptionsDisplayBoolMessages, false);
@@ -1290,7 +1296,7 @@ void SetupOptionsMenu(void)
     menuOptionsDisplay.Add(&itemBloodQAV, false);
     itemOptionsDisplayBoolCrosshair.at20 = gAimReticle;
     itemOptionsDisplayBoolCenterHoriz.at20 = gCenterHoriz;
-    itemOptionsDisplayBoolLevelStats.at20 = gLevelStats;
+    itemOptionsDisplayCycleLevelStats.m_nFocus = gLevelStats;
     itemOptionsDisplayBoolPowerupDuration.at20 = gPowerupDuration;
     itemOptionsDisplayBoolShowMapTitle.at20 = gShowMapTitle;
     itemOptionsDisplayBoolMessages.at20 = gMessageState;
@@ -1770,9 +1776,9 @@ void SetAutoAim(CGameMenuItemZCycle *pItem)
     }
 }
 
-void SetLevelStats(CGameMenuItemZBool *pItem)
+void SetLevelStats(CGameMenuItemZCycle *pItem)
 {
-    gLevelStats = pItem->at20;
+    gLevelStats = pItem->m_nFocus;
 }
 
 void SetPowerupDuration(CGameMenuItemZBool* pItem)

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -1295,7 +1295,7 @@ void viewDrawStats(PLAYER *pPlayer, int x, int y)
     static int gLastPageTimeStats = 0;
     const int nFont = 3;
     char buffer[128];
-    if (!gLevelStats)
+    if (!gLevelStats || ((gLevelStats == 2) && (gViewMode == 3)))
         return;
 
     int nHeight;


### PR DESCRIPTION
This PR adds the option to only allow stats to appear on the automap.

<img width="1280" alt="example" src="https://github.com/user-attachments/assets/7c4d65cb-8c8d-4124-9f24-d80c15b02be0">