### PR TITLE
Blood: Add controller defaults

### DIFF
--- a/source/blood/src/_functio.h
+++ b/source/blood/src/_functio.h
@@ -303,6 +303,83 @@ static const char * joystickanalogdefaults[MAXJOYAXES] =
 static const char * joystickdigitaldefaults[MAXJOYDIGITAL] =
    {
    };
+#else
+static const char * joystickdefaults[MAXJOYBUTTONSANDHATS] =
+   {
+    "Jump",
+    "Crouch",
+    "Open",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "Turn_Around",
+    "Previous_Weapon",
+    "Next_Weapon",
+    "",
+    "Inventory_Use",
+    "Inventory_Left",
+    "Inventory_Right"
+   };
+
+
+static const char * joystickclickeddefaults[MAXJOYBUTTONSANDHATS] =
+   {
+   };
+
+
+static const char * joystickanalogdefaults[MAXJOYAXES] =
+   {
+   "analog_strafing",
+   "analog_moving",
+   "analog_turning",
+   "analog_lookingupanddown",
+   };
+
+
+static const int32_t joystickanalogscaledefaults[MAXJOYAXES] =
+   {
+   DEFAULTJOYSTICKANALOGUESCALE,
+   DEFAULTJOYSTICKANALOGUESCALE,
+   DEFAULTJOYSTICKANALOGUESCALE/2,
+   DEFAULTJOYSTICKANALOGUESCALE/4
+   };
+
+
+static const int32_t joystickanalogdeaddefaults[MAXJOYAXES] =
+   {
+   DEFAULTJOYSTICKANALOGUEDEAD*5,
+   DEFAULTJOYSTICKANALOGUEDEAD*4,
+   DEFAULTJOYSTICKANALOGUEDEAD*2,
+   DEFAULTJOYSTICKANALOGUEDEAD*2
+   };
+
+
+static const int32_t joystickanalogsaturatedefaults[MAXJOYAXES] =
+   {
+   DEFAULTJOYSTICKANALOGUESATURATE*3,
+   DEFAULTJOYSTICKANALOGUESATURATE*3,
+   DEFAULTJOYSTICKANALOGUESATURATE*2,
+   DEFAULTJOYSTICKANALOGUESATURATE*2
+   };
+
+
+static const char * joystickdigitaldefaults[MAXJOYDIGITAL] =
+   {
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "Weapon_Special_Fire",
+    "",
+    "Weapon_Fire",
+   };
 #endif
 
 #endif

--- a/source/blood/src/config.cpp
+++ b/source/blood/src/config.cpp
@@ -483,26 +483,26 @@ void CONFIG_SetDefaults(void)
 #else
     for (int i=0; i<MAXJOYBUTTONSANDHATS; i++)
     {
-        JoystickFunctions[i][0] = -1;
-        JoystickFunctions[i][1] = -1;
+        JoystickFunctions[i][0] = CONFIG_FunctionNameToNum(joystickdefaults[i]);
+        JoystickFunctions[i][1] = CONFIG_FunctionNameToNum(joystickclickeddefaults[i]);
         CONTROL_MapButton(JoystickFunctions[i][0], i, 0, controldevice_joystick);
         CONTROL_MapButton(JoystickFunctions[i][1], i, 1, controldevice_joystick);
     }
 
     for (int i=0; i<MAXJOYAXES; i++)
     {
-        JoystickAnalogueScale[i] = DEFAULTJOYSTICKANALOGUESCALE;
-        JoystickAnalogueDead[i] = DEFAULTJOYSTICKANALOGUEDEAD;
-        JoystickAnalogueSaturate[i] = DEFAULTJOYSTICKANALOGUESATURATE;
+        JoystickAnalogueScale[i] = joystickanalogscaledefaults[i];
+        JoystickAnalogueDead[i] = joystickanalogdeaddefaults[i];
+        JoystickAnalogueSaturate[i] = joystickanalogsaturatedefaults[i];
         CONTROL_SetAnalogAxisScale(i, JoystickAnalogueScale[i], controldevice_joystick);
         JOYSTICK_SetDeadZone(i, JoystickAnalogueDead[i], JoystickAnalogueSaturate[i]);
 
-        JoystickDigitalFunctions[i][0] = -1;
-        JoystickDigitalFunctions[i][1] = -1;
+        JoystickDigitalFunctions[i][0] = CONFIG_FunctionNameToNum(joystickdigitaldefaults[i*2]);
+        JoystickDigitalFunctions[i][1] = CONFIG_FunctionNameToNum(joystickdigitaldefaults[i*2+1]);
         CONTROL_MapDigitalAxis(i, JoystickDigitalFunctions[i][0], 0);
         CONTROL_MapDigitalAxis(i, JoystickDigitalFunctions[i][1], 1);
 
-        JoystickAnalogueAxes[i] = -1;
+        JoystickAnalogueAxes[i] = CONFIG_AnalogNameToNum(joystickanalogdefaults[i]);
         CONTROL_MapAnalogAxis(i, JoystickAnalogueAxes[i]);
 
         JoystickAnalogueInvert[i] = 0;


### PR DESCRIPTION
This PR restores the controller defaults that were removed in PR #642 for Blood. It uses a xbox controller as the basis for the default mappings.