### PR TITLE
Blood: Add turn speed slider for keyboard input

### DIFF
--- a/source/blood/src/config.cpp
+++ b/source/blood/src/config.cpp
@@ -76,6 +76,7 @@ int32_t useprecache;
 char CommbatMacro[MAXRIDECULE][MAXRIDECULELENGTH];
 char szPlayerName[MAXPLAYERNAME];
 int32_t gTurnSpeed;
+int32_t gTurnAcceleration;
 int32_t gDetail;
 int32_t gMouseAim;
 int32_t gAutoAim;
@@ -384,6 +385,7 @@ void CONFIG_SetDefaults(void)
     gDeliriumBlur = 1;
     gViewSize = 2;
     gTurnSpeed = 92;
+    gTurnAcceleration = 1;
     gDetail = 4;
     gAutoRun = 0;
     gViewInterpolate = 1;

--- a/source/blood/src/config.h
+++ b/source/blood/src/config.h
@@ -57,6 +57,7 @@ extern int32_t useprecache;
 extern char CommbatMacro[MAXRIDECULE][MAXRIDECULELENGTH];
 extern char szPlayerName[MAXPLAYERNAME];
 extern int32_t gTurnSpeed;
+extern int32_t gTurnAcceleration;
 extern int32_t gDetail;
 extern int32_t gAutoAim;
 extern int32_t gWeaponSwitch;

--- a/source/blood/src/controls.cpp
+++ b/source/blood/src/controls.cpp
@@ -487,7 +487,7 @@ void ctrlGetInput(void)
     if (turnRight)
         input.q16turn = fix16_sadd(input.q16turn, fix16_from_float(scaleAdjustmentToInterval(ClipHigh(12 * turnHeldTime, gTurnSpeed)>>2)));
 
-    if ((run2 || run) && turnHeldTime > 24)
+    if (!gTurnAcceleration || (((gTurnAcceleration == 2) || run2 || run) && (turnHeldTime > 24)))
         input.q16turn <<= 1;
 
     if (BUTTON(gamefunc_Strafe))

--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -713,9 +713,10 @@ CGameMenuItemChain itemOptionsControlJoystickButtons("JOYSTICK BUTTONS SETUP", 1
 CGameMenuItemChain itemOptionsControlJoystickAxes("JOYSTICK AXES SETUP", 1, 0, 140, 320, 1, &menuOptionsControlJoystickListAxes, -1, SetupJoystickAxesMenu, 0);
 
 CGameMenuItemTitle itemOptionsControlKeyboardTitle("KEYBOARD SETUP", 1, 160, 20, 2038);
-CGameMenuItemChain itemOptionsControlKeyboardList("Configure Keys...", 1, 0, 60, 320, 1, &menuKeys, -1, NULL, 0);
-CGameMenuItemChain itemOptionsControlKeyboardReset("Reset Keys (default)...", 1, 0, 80, 320, 1, &menuKeys, -1, ResetKeys, 0);
-CGameMenuItemChain itemOptionsControlKeyboardResetClassic("Reset Keys (classic)...", 1, 0, 100, 320, 1, &menuKeys, -1, ResetKeysClassic, 0);
+CGameMenuItemSlider itemOptionsControlKeyboardSliderTurnSpeed("Key Turn Speed:", 1, 18, 50, 280, &gTurnSpeed, 64, 128, 4, SetTurnSpeed, -1, -1);
+CGameMenuItemChain itemOptionsControlKeyboardList("Configure Keys...", 1, 0, 110, 320, 1, &menuKeys, -1, NULL, 0);
+CGameMenuItemChain itemOptionsControlKeyboardReset("Reset Keys (default)...", 1, 0, 135, 320, 1, &menuKeys, -1, ResetKeys, 0);
+CGameMenuItemChain itemOptionsControlKeyboardResetClassic("Reset Keys (classic)...", 1, 0, 155, 320, 1, &menuKeys, -1, ResetKeysClassic, 0);
 
 void SetMouseAimMode(CGameMenuItemZBool *pItem);
 void SetMouseVerticalAim(CGameMenuItemZBool *pItem);
@@ -1417,11 +1418,13 @@ void SetupOptionsMenu(void)
     menuOptionsControl.Add(&itemBloodQAV, false);
 
     menuOptionsControlKeyboard.Add(&itemOptionsControlKeyboardTitle, false);
-    menuOptionsControlKeyboard.Add(&itemOptionsControlKeyboardList, true);
+    menuOptionsControlKeyboard.Add(&itemOptionsControlKeyboardSliderTurnSpeed, true);
+    menuOptionsControlKeyboard.Add(&itemOptionsControlKeyboardList, false);
     menuOptionsControlKeyboard.Add(&itemOptionsControlKeyboardReset, false);
     menuOptionsControlKeyboard.Add(&itemOptionsControlKeyboardResetClassic, false);
     menuOptionsControlKeyboard.Add(&itemBloodQAV, false);
 
+    itemOptionsControlKeyboardSliderTurnSpeed.nValue = gTurnSpeed;
     menuOptionsControlMouse.Add(&itemOptionsControlMouseTitle, false);
     menuOptionsControlMouse.Add(&itemOptionsControlMouseButton, true);
     menuOptionsControlMouse.Add(&itemOptionsControlMouseSensitivity, false);

--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -66,6 +66,7 @@ void SetViewSwaying(CGameMenuItemZBool *);
 void SetMouseSensitivity(CGameMenuItemSliderFloat *);
 void SetMouseAimFlipped(CGameMenuItemZBool *);
 void SetTurnSpeed(CGameMenuItemSlider *);
+void SetTurnAcceleration(CGameMenuItemZCycle *);
 void ResetKeys(CGameMenuItemChain *);
 void ResetKeysClassic(CGameMenuItemChain *);
 void SetMessages(CGameMenuItemZBool *);
@@ -706,6 +707,12 @@ void SetJoystickDigitalNeg(CGameMenuItemZCycle* pItem);
 void SetJoystickDeadzone(CGameMenuItemSlider* pItem);
 void SetJoystickSaturate(CGameMenuItemSlider* pItem);
 
+const char *pzTurnAccelerationStrings[] = {
+    "OFF",
+    "ON RUNNING",
+    "ALWAYS ON",
+};
+
 CGameMenuItemTitle itemOptionsControlTitle("CONTROL SETUP", 1, 160, 20, 2038);
 CGameMenuItemChain itemOptionsControlKeyboard("KEYBOARD SETUP", 1, 0, 60, 320, 1, &menuOptionsControlKeyboard, -1, NULL, 0);
 CGameMenuItemChain itemOptionsControlMouse("MOUSE SETUP", 1, 0, 80, 320, 1, &menuOptionsControlMouse, -1, SetupMouseMenu, 0);
@@ -714,6 +721,7 @@ CGameMenuItemChain itemOptionsControlJoystickAxes("JOYSTICK AXES SETUP", 1, 0, 1
 
 CGameMenuItemTitle itemOptionsControlKeyboardTitle("KEYBOARD SETUP", 1, 160, 20, 2038);
 CGameMenuItemSlider itemOptionsControlKeyboardSliderTurnSpeed("Key Turn Speed:", 1, 18, 50, 280, &gTurnSpeed, 64, 128, 4, SetTurnSpeed, -1, -1);
+CGameMenuItemZCycle itemOptionsControlKeyboardCycleTurnAcceleration("Key Turn Acceleration:", 1, 18, 70, 280, 0, SetTurnAcceleration, pzTurnAccelerationStrings, ARRAY_SIZE(pzTurnAccelerationStrings), 0);
 CGameMenuItemChain itemOptionsControlKeyboardList("Configure Keys...", 1, 0, 110, 320, 1, &menuKeys, -1, NULL, 0);
 CGameMenuItemChain itemOptionsControlKeyboardReset("Reset Keys (default)...", 1, 0, 135, 320, 1, &menuKeys, -1, ResetKeys, 0);
 CGameMenuItemChain itemOptionsControlKeyboardResetClassic("Reset Keys (classic)...", 1, 0, 155, 320, 1, &menuKeys, -1, ResetKeysClassic, 0);
@@ -1419,12 +1427,15 @@ void SetupOptionsMenu(void)
 
     menuOptionsControlKeyboard.Add(&itemOptionsControlKeyboardTitle, false);
     menuOptionsControlKeyboard.Add(&itemOptionsControlKeyboardSliderTurnSpeed, true);
+    menuOptionsControlKeyboard.Add(&itemOptionsControlKeyboardCycleTurnAcceleration, false);
     menuOptionsControlKeyboard.Add(&itemOptionsControlKeyboardList, false);
     menuOptionsControlKeyboard.Add(&itemOptionsControlKeyboardReset, false);
     menuOptionsControlKeyboard.Add(&itemOptionsControlKeyboardResetClassic, false);
     menuOptionsControlKeyboard.Add(&itemBloodQAV, false);
 
     itemOptionsControlKeyboardSliderTurnSpeed.nValue = gTurnSpeed;
+    itemOptionsControlKeyboardCycleTurnAcceleration.m_nFocus = gTurnAcceleration;
+
     menuOptionsControlMouse.Add(&itemOptionsControlMouseTitle, false);
     menuOptionsControlMouse.Add(&itemOptionsControlMouseButton, true);
     menuOptionsControlMouse.Add(&itemOptionsControlMouseSensitivity, false);
@@ -1771,6 +1782,11 @@ void SetMouseAimFlipped(CGameMenuItemZBool *pItem)
 void SetTurnSpeed(CGameMenuItemSlider *pItem)
 {
     gTurnSpeed = pItem->nValue;
+}
+
+void SetTurnAcceleration(CGameMenuItemZCycle *pItem)
+{
+    gTurnAcceleration = pItem->m_nFocus;
 }
 
 void SetAutoAim(CGameMenuItemZCycle *pItem)

--- a/source/blood/src/osdcmd.cpp
+++ b/source/blood/src/osdcmd.cpp
@@ -1030,8 +1030,8 @@ int32_t registerosdcommands(void)
         { "in_mousedeadzone", "amount of mouse movement to filter out", (void *)&MouseDeadZone, CVAR_INT, 0, 512 },
         { "in_mouseflip", "invert vertical mouse movement", (void *)&gMouseAimingFlipped, CVAR_BOOL, 0, 1 },
         { "in_mousemode", "toggles vertical mouse view", (void *)&gMouseAim, CVAR_BOOL, 0, 1 },
-        { "in_turnacceleration", "set keyboard turning acceleration (0: off, 1: only when running, 2: always on)", (void *)&gTurnAcceleration, CVAR_INT, 0, 2 },
-        { "in_turnsensitivity", "keyboard turning sensitivity multiplier", (void *)&gTurnSpeed, CVAR_INT, 64, 124 },
+        { "in_turnaccelmode", "set keyboard turning acceleration mode (0: off, 1: only when running, 2: always on)", (void *)&gTurnAcceleration, CVAR_INT, 0, 2 },
+        { "in_turnspeed", "keyboard turning speed", (void *)&gTurnSpeed, CVAR_INT, 64, 124 },
 //
         { "mus_enabled", "enables/disables music", (void *)&MusicToggle, CVAR_BOOL, 0, 1 },
         { "mus_restartonload", "restart the music when loading a saved game with the same map or not", (void *)&MusicRestartsOnLoadToggle, CVAR_BOOL, 0, 1 },

--- a/source/blood/src/osdcmd.cpp
+++ b/source/blood/src/osdcmd.cpp
@@ -1030,6 +1030,7 @@ int32_t registerosdcommands(void)
         { "in_mousedeadzone", "amount of mouse movement to filter out", (void *)&MouseDeadZone, CVAR_INT, 0, 512 },
         { "in_mouseflip", "invert vertical mouse movement", (void *)&gMouseAimingFlipped, CVAR_BOOL, 0, 1 },
         { "in_mousemode", "toggles vertical mouse view", (void *)&gMouseAim, CVAR_BOOL, 0, 1 },
+        { "in_turnsensitivity", "keyboard turning sensitivity multiplier", (void *)&gTurnSpeed, CVAR_INT, 64, 124 },
 //
         { "mus_enabled", "enables/disables music", (void *)&MusicToggle, CVAR_BOOL, 0, 1 },
         { "mus_restartonload", "restart the music when loading a saved game with the same map or not", (void *)&MusicRestartsOnLoadToggle, CVAR_BOOL, 0, 1 },

--- a/source/blood/src/osdcmd.cpp
+++ b/source/blood/src/osdcmd.cpp
@@ -1030,6 +1030,7 @@ int32_t registerosdcommands(void)
         { "in_mousedeadzone", "amount of mouse movement to filter out", (void *)&MouseDeadZone, CVAR_INT, 0, 512 },
         { "in_mouseflip", "invert vertical mouse movement", (void *)&gMouseAimingFlipped, CVAR_BOOL, 0, 1 },
         { "in_mousemode", "toggles vertical mouse view", (void *)&gMouseAim, CVAR_BOOL, 0, 1 },
+        { "in_turnacceleration", "set keyboard turning acceleration (0: off, 1: only when running, 2: always on)", (void *)&gTurnAcceleration, CVAR_INT, 0, 2 },
         { "in_turnsensitivity", "keyboard turning sensitivity multiplier", (void *)&gTurnSpeed, CVAR_INT, 64, 124 },
 //
         { "mus_enabled", "enables/disables music", (void *)&MusicToggle, CVAR_BOOL, 0, 1 },


### PR DESCRIPTION
This PR adds the ability to change turn speed and turn off turn speed acceleration for Blood much like BloodGDX.

<img width="736" alt="turnspeed" src="https://github.com/user-attachments/assets/2117cf81-d737-42e4-8d0f-dba24216f8a8">