### PR TITLE
Blood: Fix crouch toggle logic for underwater movement

### DIFF
--- a/source/blood/src/controls.cpp
+++ b/source/blood/src/controls.cpp
@@ -310,9 +310,11 @@ void ctrlGetInput(void)
     if (BUTTON(gamefunc_Crouch))
         gInput.buttonFlags.crouch = 1, gCrouchToggleState = 0;
 
-    if (BUTTON(gamefunc_Crouch_Toggle) && !gInput.buttonFlags.jump && gMe && !gMe->isUnderwater)
+    if (BUTTON(gamefunc_Crouch_Toggle) && !gInput.buttonFlags.jump)
     {
-        if (gCrouchToggleState <= 1) // start crouching
+        if (gMe && gMe->isUnderwater)
+            gCrouchToggleState = 0, gInput.buttonFlags.crouch = 1;
+        else if (gCrouchToggleState <= 1) // start crouching
             gCrouchToggleState = 1, gInput.buttonFlags.crouch = 1;
         else if (gCrouchToggleState == 2) // stop crouching
             gCrouchToggleState = 3;


### PR DESCRIPTION
This PR fixes the crouch toggle implementation for underwater movement, originally introduced in #783

Fixes a bug where it was not possible to swim downwards and required the use of the default crouch bind.