### PR TITLE
Mact: Add single axis deadzone flag for analog stick distance calculation

### DIFF
--- a/source/blood/src/_functio.h
+++ b/source/blood/src/_functio.h
@@ -356,7 +356,7 @@ static const int32_t joystickanalogdeaddefaults[MAXJOYAXES] =
    };
 
 
-static const int32_t joystickanalogaxissolodeadzone[MAXJOYAXES] =
+static const int32_t joystickanalogdecoupledaxes[MAXJOYAXES] =
    {
    1,
    0,

--- a/source/blood/src/config.cpp
+++ b/source/blood/src/config.cpp
@@ -65,7 +65,7 @@ int32_t JoystickAnalogueScale[MAXJOYAXES];
 int32_t JoystickAnalogueDead[MAXJOYAXES];
 int32_t JoystickAnalogueSaturate[MAXJOYAXES];
 int32_t JoystickAnalogueInvert[MAXJOYAXES];
-int32_t JoystickAnalogueAxisSoloDeadZone[MAXJOYAXES];
+int32_t JoystickAnalogueDecoupledAxes[MAXJOYAXES];
 uint8_t KeyboardKeys[NUMGAMEFUNCTIONS][2];
 int32_t scripthandle;
 int32_t setupread;
@@ -483,8 +483,8 @@ void CONFIG_SetDefaults(void)
         JoystickAnalogueInvert[i] = 0;
         CONTROL_SetAnalogAxisInvert(i, JoystickAnalogueInvert[i]);
 
-        JoystickAnalogueAxisSoloDeadZone[i] = 0;
-        JOYSTICK_SetAxisSoloDeadZone(i, JoystickAnalogueAxisSoloDeadZone[i]);
+        JoystickAnalogueDecoupledAxes[i] = 0;
+        JOYSTICK_SetDecoupleAxis(i, JoystickAnalogueDecoupledAxes[i]);
     }
 #else
     for (int i=0; i<MAXJOYBUTTONSANDHATS; i++)
@@ -514,8 +514,8 @@ void CONFIG_SetDefaults(void)
         JoystickAnalogueInvert[i] = 0;
         CONTROL_SetAnalogAxisInvert(i, JoystickAnalogueInvert[i]);
 
-        JoystickAnalogueAxisSoloDeadZone[i] = joystickanalogaxissolodeadzone[i];
-        JOYSTICK_SetAxisSoloDeadZone(i, JoystickAnalogueAxisSoloDeadZone[i]);
+        JoystickAnalogueDecoupledAxes[i] = joystickanalogdecoupledaxes[i];
+        JOYSTICK_SetDecoupleAxis(i, JoystickAnalogueDecoupledAxes[i]);
     }
 #endif
 }
@@ -678,10 +678,10 @@ void CONFIG_SetupJoystick(void)
         SCRIPT_GetNumber(scripthandle, "Controls", str,&scale);
         JoystickAnalogueInvert[i] = scale;
 
-        Bsprintf(str,"JoystickAnalogAxisSoloDeadZone%d",i);
-        scale = JoystickAnalogueAxisSoloDeadZone[i];
+        Bsprintf(str,"JoystickAnalogDecoupledAxes%d",i);
+        scale = JoystickAnalogueDecoupledAxes[i];
         SCRIPT_GetNumber(scripthandle, "Controls", str,&scale);
-        JoystickAnalogueAxisSoloDeadZone[i] = scale;
+        JoystickAnalogueDecoupledAxes[i] = scale;
     }
 
     for (i=0; i<MAXJOYBUTTONSANDHATS; i++)
@@ -697,7 +697,7 @@ void CONFIG_SetupJoystick(void)
         CONTROL_SetAnalogAxisScale(i, JoystickAnalogueScale[i], controldevice_joystick);
         JOYSTICK_SetDeadZone(i, JoystickAnalogueDead[i], JoystickAnalogueSaturate[i]);
         CONTROL_SetAnalogAxisInvert(i, JoystickAnalogueInvert[i]);
-        JOYSTICK_SetAxisSoloDeadZone(i, JoystickAnalogueAxisSoloDeadZone[i]);
+        JOYSTICK_SetDecoupleAxis(i, JoystickAnalogueDecoupledAxes[i]);
     }
 }
 
@@ -999,8 +999,8 @@ void CONFIG_WriteSetup(uint32_t flags)
             Bsprintf(buf, "JoystickAnalogInvert%d", dummy);
             SCRIPT_PutNumber(scripthandle, "Controls", buf, JoystickAnalogueInvert[dummy], FALSE, FALSE);
 
-            Bsprintf(buf, "JoystickAnalogAxisSoloDeadZone%d", dummy);
-            SCRIPT_PutNumber(scripthandle, "Controls", buf, JoystickAnalogueAxisSoloDeadZone[dummy], FALSE, FALSE);
+            Bsprintf(buf, "JoystickAnalogDecoupledAxes%d", dummy);
+            SCRIPT_PutNumber(scripthandle, "Controls", buf, JoystickAnalogueDecoupledAxes[dummy], FALSE, FALSE);
         }
     }
 

--- a/source/blood/src/config.h
+++ b/source/blood/src/config.h
@@ -46,7 +46,7 @@ extern int32_t JoystickAnalogueScale[MAXJOYAXES];
 extern int32_t JoystickAnalogueDead[MAXJOYAXES];
 extern int32_t JoystickAnalogueSaturate[MAXJOYAXES];
 extern int32_t JoystickAnalogueInvert[MAXJOYAXES];
-extern int32_t JoystickAnalogueAxisSoloDeadZone[MAXJOYAXES];
+extern int32_t JoystickAnalogueDecoupledAxes[MAXJOYAXES];
 extern uint8_t KeyboardKeys[NUMGAMEFUNCTIONS][2];
 extern int32_t scripthandle;
 extern int32_t setupread;

--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -706,7 +706,7 @@ void SetJoystickDigitalPos(CGameMenuItemZCycle* pItem);
 void SetJoystickDigitalNeg(CGameMenuItemZCycle* pItem);
 void SetJoystickDeadzone(CGameMenuItemSlider* pItem);
 void SetJoystickSaturate(CGameMenuItemSlider* pItem);
-void SetJoystickSoloDeadzone(CGameMenuItemZBool* pItem);
+void SetJoystickDecoupledAxes(CGameMenuItemZBool* pItem);
 
 const char *pzTurnAccelerationStrings[] = {
     "OFF",
@@ -839,7 +839,7 @@ CGameMenuItemZCycle *pItemOptionsControlJoystickAxisDigitalPos[MAXJOYAXES];
 CGameMenuItemZCycle *pItemOptionsControlJoystickAxisDigitalNeg[MAXJOYAXES];
 CGameMenuItemSlider *pItemOptionsControlJoystickAxisDeadzone[MAXJOYAXES];
 CGameMenuItemSlider *pItemOptionsControlJoystickAxisSaturate[MAXJOYAXES];
-CGameMenuItemZBool *pItemOptionsControlJoystickAxisSoloDeadzone[MAXJOYAXES];
+CGameMenuItemZBool *pItemOptionsControlJoystickAxisDecouple[MAXJOYAXES];
 
 void SetupLoadingScreen(void)
 {
@@ -1592,9 +1592,9 @@ void SetupJoystickMenu(void)
         dassert(pItemOptionsControlJoystickAxisSaturate[nAxis] != NULL);
         menuOptionsControlJoystickAxis[nAxis].Add(pItemOptionsControlJoystickAxisSaturate[nAxis], false);
         y += 17;
-        pItemOptionsControlJoystickAxisSoloDeadzone[nAxis] = new CGameMenuItemZBool("SINGLE AXIS DEAD ZONE:", 1, 18, y, 280, false, SetJoystickSoloDeadzone, NULL, NULL); // get isolated dead
-        dassert(pItemOptionsControlJoystickAxisSoloDeadzone[nAxis] != NULL);
-        menuOptionsControlJoystickAxis[nAxis].Add(pItemOptionsControlJoystickAxisSoloDeadzone[nAxis], false);
+        pItemOptionsControlJoystickAxisDecouple[nAxis] = new CGameMenuItemZBool("DECOUPLED AXES:", 1, 18, y, 280, false, SetJoystickDecoupledAxes, NULL, NULL); // get decoupled axes
+        dassert(pItemOptionsControlJoystickAxisDecouple[nAxis] != NULL);
+        menuOptionsControlJoystickAxis[nAxis].Add(pItemOptionsControlJoystickAxisDecouple[nAxis], false);
         menuOptionsControlJoystickAxis[nAxis].Add(&itemBloodQAV, false);
     }
 }
@@ -2406,7 +2406,7 @@ void SetupJoystickAxesMenu(CGameMenuItemChain *pItem)
         }
         pItemOptionsControlJoystickAxisDeadzone[nAxis]->nValue = JoystickAnalogueDead[nAxis];
         pItemOptionsControlJoystickAxisSaturate[nAxis]->nValue = JoystickAnalogueSaturate[nAxis];
-        pItemOptionsControlJoystickAxisSoloDeadzone[nAxis]->at20 = JoystickAnalogueAxisSoloDeadZone[nAxis];
+        pItemOptionsControlJoystickAxisDecouple[nAxis]->at20 = JoystickAnalogueDecoupledAxes[nAxis];
     }
 }
 
@@ -2533,14 +2533,14 @@ void SetJoystickSaturate(CGameMenuItemSlider* pItem)
     }
 }
 
-void SetJoystickSoloDeadzone(CGameMenuItemZBool* pItem)
+void SetJoystickDecoupledAxes(CGameMenuItemZBool* pItem)
 {
     for (int nAxis = 0; nAxis < MAXJOYAXES; nAxis++)
     {
-        if (pItem == pItemOptionsControlJoystickAxisSoloDeadzone[nAxis])
+        if (pItem == pItemOptionsControlJoystickAxisDecouple[nAxis])
         {
-            JoystickAnalogueAxisSoloDeadZone[nAxis] = pItem->at20;
-            JOYSTICK_SetAxisSoloDeadZone(nAxis, JoystickAnalogueAxisSoloDeadZone[nAxis]);
+            JoystickAnalogueDecoupledAxes[nAxis] = pItem->at20;
+            JOYSTICK_SetDecoupleAxis(nAxis, JoystickAnalogueDecoupledAxes[nAxis]);
             break;
         }
     }

--- a/source/mact/include/_control.h
+++ b/source/mact/include/_control.h
@@ -126,7 +126,7 @@ typedef struct ControllerAxis
     uint16_t deadzone;
     uint16_t saturation;
     bool invert;
-    bool solodeadzone;
+    bool decoupledaxis;
 } ControllerAxis_t;
 
 typedef struct UserInputState

--- a/source/mact/include/joystick.h
+++ b/source/mact/include/joystick.h
@@ -54,7 +54,7 @@ int32_t	JOYSTICK_GetControllerButtons( void );
 void	JOYSTICK_ClearAllButtons( void );
 int32_t	JOYSTICK_GetHat( int32_t h );
 void JOYSTICK_SetDeadZone(int32_t axis, uint16_t dead, uint16_t satur);
-void JOYSTICK_SetAxisSoloDeadZone(int32_t axis, bool dead);
+void JOYSTICK_SetDecoupleAxis(int32_t axis, bool status);
 
 #ifdef __cplusplus
 }

--- a/source/mact/src/control.cpp
+++ b/source/mact/src/control.cpp
@@ -267,9 +267,9 @@ void JOYSTICK_SetDeadZone(int32_t axis, uint16_t dead, uint16_t satur)
     joyAxes[axis].saturation = satur;
 }
 
-void JOYSTICK_SetAxisSoloDeadZone(int32_t axis, bool dead)
+void JOYSTICK_SetDecoupleAxis(int32_t axis, bool status)
 {
-    joyAxes[axis].solodeadzone = dead;
+    joyAxes[axis].decoupledaxis = status;
 }
 
 void CONTROL_SetAnalogAxisScale(int32_t whichaxis, int32_t axisscale, controldevice device)
@@ -492,8 +492,8 @@ static void controlUpdateAxisState(int index, ControlInfo *const info)
         out->analog = 32767 * ksgn(in);
     else
     {
-        // this assumes there are two sticks comprised of axes 0 and 1, and 2 and 3... because when isGameController is true, there are
-        if (!a.solodeadzone && (index <= CONTROLLER_AXIS_LEFTY || (joystick.isGameController && (index <= CONTROLLER_AXIS_RIGHTY))))
+        // this assumes there are two sticks comprised of axes 0 and 1, and 2 and 3... because when isGameController is true, there are (unless axis is flagged as decoupled)
+        if (!a.decoupledaxis && (index <= CONTROLLER_AXIS_LEFTY || (joystick.isGameController && (index <= CONTROLLER_AXIS_RIGHTY))))
             axisScaled10k = min(10000, joydist(joystick.pAxis[index & ~1], joystick.pAxis[index | 1]) * 10000 / 32767);
 
         if (axisScaled10k < a.deadzone)


### PR DESCRIPTION
This PR adds a new flag to joysticks deadzone calculation, and helps with general analog stick movement such as the ability to walk perfectly straight when tilted fully forward on the left stick.

Originally the mact library would calculate deadzone based on the total axes input for a single analog stick instead of treating this as two independent axis for the deadzones. This is usually fine for looking left/right and up/down, however when it comes to strafing this can make it can become difficult to walk in a perfect line while also fully tilting the analog stick forward.

Here is a comparison with the setting off and on, and attempting to walk forward.

https://github.com/user-attachments/assets/60fd14b5-da82-4fb2-b20e-46d8881eb7b3

https://github.com/user-attachments/assets/219d9cd6-c68d-4c93-a296-9c0ff221fc96

New settings for axis option menu.

<img width="672" alt="Untitled" src="https://github.com/user-attachments/assets/1ada6960-f4ce-46f8-b7b6-fe5cb62b3353">