### PR TITLE
Blood: Increase player name limit to 16 characters

### DIFF
--- a/source/blood/src/config.cpp
+++ b/source/blood/src/config.cpp
@@ -738,7 +738,7 @@ int CONFIG_ReadSetup(void)
 
     char nameBuf[64];
 
-    while (Bstrlen(OSD_StripColors(nameBuf, tempbuf)) > 10)
+    while (Bstrlen(OSD_StripColors(nameBuf, tempbuf)) >= MAXPLAYERNAME)
         tempbuf[Bstrlen(tempbuf) - 1] = '\0';
 
     Bstrncpyz(szPlayerName, tempbuf, sizeof(szPlayerName));


### PR DESCRIPTION
This PR fixes an incorrectly set string limit for the player name variable being loaded from the cfg file, as it would always cut the string length to 10 characters, despite the player name menu item and player struct member supporting names up to 16 characters long.