### PR TITLE
Blood: Fix loading save info from mod directory

### DIFF
--- a/source/blood/src/loadsave.cpp
+++ b/source/blood/src/loadsave.cpp
@@ -490,7 +490,9 @@ void MyLoadSave::Save(void)
 
 void LoadSavedInfo(void)
 {
-    auto pList = klistpath("./", "game*.sav", BUILDVFS_FIND_FILE);
+    int const bakpathsearchmode = pathsearchmode;
+    pathsearchmode = 1;
+    auto pList = klistpath((g_modDir[0] != '/') ? g_modDir : "./", "game*.sav", BUILDVFS_FIND_FILE);
     int nCount = 0;
     for (auto pIterator = pList; pIterator != NULL && nCount < 10; pIterator = pIterator->next, nCount++)
     {
@@ -523,6 +525,7 @@ void LoadSavedInfo(void)
         kclose(hFile);
     }
     klistfree(pList);
+    pathsearchmode = bakpathsearchmode;
 }
 
 void UpdateSavedInfo(int nSlot)


### PR DESCRIPTION
This PR fixes an bug that occurs when loading a mod folder and searching for existing local saves.

It should now properly report saves found in the mod folder instead of the default location.