### PR TITLE
Blood: Fix enemy death sfx getting cut and fix cultist sfx not getting cut on death

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -811,9 +811,9 @@ blood_game_objs := \
 
 ifeq ($(NOONE_EXTENSIONS),1)
     blood_game_objs += nnextsif.cpp
-	blood_game_objs += nnexts.cpp
-	blood_game_objs += nnextstr.cpp
-	blood_game_objs += nnextcdud.cpp
+    blood_game_objs += nnexts.cpp
+    blood_game_objs += nnextstr.cpp
+    blood_game_objs += nnextcdud.cpp
     blood_game_objs += aicdud.cpp
 endif
 

--- a/source/blood/src/actor.cpp
+++ b/source/blood/src/actor.cpp
@@ -5845,7 +5845,7 @@ void actProcessSprites(void)
                 {
                     const char bDivingSuit = packItemActive(pPlayer, kPackDivingSuit);
                     if (bDivingSuit || pPlayer->godMode)
-                        pPlayer->underwaterTime = 1200;
+                        pPlayer->underwaterTime = kTicRate*10;
                     else
                         pPlayer->underwaterTime = ClipLow(pPlayer->underwaterTime-kTicsPerFrame, 0);
                     if (pPlayer->underwaterTime < 1080 && packCheckItem(pPlayer, kPackDivingSuit) && !bDivingSuit)

--- a/source/blood/src/actor.cpp
+++ b/source/blood/src/actor.cpp
@@ -3137,6 +3137,8 @@ void actKillDude(int nKillerSprite, spritetype *pSprite, DAMAGE_TYPE damageType,
     case kDudeCultistShotgun:
     case kDudeCultistTesla:
     case kDudeCultistTNT:
+        if (!VanillaMode()) // mute all cultist alerts sfx on death
+            sfxKill3DSound(pSprite, kMaxSprites+pSprite->index, -1); // cultist alert sfx use kMaxSprites+sprite index as channel
         sfxPlay3DSound(pSprite, 1018+Random(2), -1, 0);
         if (nSeq == 3)
             seqSpawn(dudeInfo[nType].seqStartID+nSeq, 3, nXSprite, nDudeToGibClient2);

--- a/source/blood/src/ai.cpp
+++ b/source/blood/src/ai.cpp
@@ -97,7 +97,7 @@ void aiPlay3DSound(spritetype *pSprite, int soundId, AI_SFX_PRIORITY nPriority, 
         sfxKill3DSound(pSprite, -1, -1);
         sfxPlay3DSound(pSprite, soundId, chanId, 0);
         pDudeExtra->sfx_priority = nPriority;
-        pDudeExtra->clock = (int)gFrameClock+120;
+        pDudeExtra->clock = (int)gFrameClock+kTicRate;
     }
 }
 

--- a/source/blood/src/ai.cpp
+++ b/source/blood/src/ai.cpp
@@ -87,16 +87,16 @@ bool dudeIsPlayingSeq(spritetype *pSprite, int nSeq)
     return false;
 }
 
-void aiPlay3DSound(spritetype *pSprite, int a2, AI_SFX_PRIORITY a3, int a4)
+void aiPlay3DSound(spritetype *pSprite, int soundId, AI_SFX_PRIORITY nPriority, int chanId)
 {
     DUDEEXTRA *pDudeExtra = &gDudeExtra[pSprite->extra];
-    if (a3 == AI_SFX_PRIORITY_0)
-        sfxPlay3DSound(pSprite, a2, a4, 2);
-    else if (a3 > pDudeExtra->sfx_priority || pDudeExtra->clock <= (int)gFrameClock)
+    if (nPriority == AI_SFX_PRIORITY_0)
+        sfxPlay3DSound(pSprite, soundId, chanId, 2);
+    else if (nPriority > pDudeExtra->sfx_priority || pDudeExtra->clock <= (int)gFrameClock)
     {
         sfxKill3DSound(pSprite, -1, -1);
-        sfxPlay3DSound(pSprite, a2, a4, 0);
-        pDudeExtra->sfx_priority = a3;
+        sfxPlay3DSound(pSprite, soundId, chanId, 0);
+        pDudeExtra->sfx_priority = nPriority;
         pDudeExtra->clock = (int)gFrameClock+120;
     }
 }

--- a/source/blood/src/ai.cpp
+++ b/source/blood/src/ai.cpp
@@ -372,6 +372,7 @@ void aiActivateDude(spritetype *pSprite, XSPRITE *pXSprite)
     case kDudeCultistTNT:
     case kDudeCultistBeast:
     {
+        const int nChannel = !VanillaMode() ? kMaxSprites+pSprite->index : -1; // use kMaxSprites+sprite index as channel, so cultist alerts can be muted on death/hurt state
         DUDEEXTRA_STATS *pDudeExtraE = &gDudeExtra[pSprite->extra].stats;
         pDudeExtraE->active = 1;
         if (pXSprite->target == -1) {
@@ -379,8 +380,8 @@ void aiActivateDude(spritetype *pSprite, XSPRITE *pXSprite)
                 case kMediumNormal:
                     aiNewState(pSprite, pXSprite, &cultistSearch);
                     if (Chance(0x8000)) {
-                        if (pSprite->type == kDudeCultistTommy) aiPlay3DSound(pSprite, 4008+Random(5), AI_SFX_PRIORITY_1, -1);
-                        else aiPlay3DSound(pSprite, 1008+Random(5), AI_SFX_PRIORITY_1, -1);
+                        if (pSprite->type == kDudeCultistTommy) aiPlay3DSound(pSprite, 4008+Random(5), AI_SFX_PRIORITY_1, nChannel);
+                        else aiPlay3DSound(pSprite, 1008+Random(5), AI_SFX_PRIORITY_1, nChannel);
                     }
                     break;
                 case kMediumWater:
@@ -390,8 +391,8 @@ void aiActivateDude(spritetype *pSprite, XSPRITE *pXSprite)
             }
         } else {
             if (Chance(0x8000)) {
-                if (pSprite->type == kDudeCultistTommy) aiPlay3DSound(pSprite, 4003+Random(4), AI_SFX_PRIORITY_1, -1);
-                else aiPlay3DSound(pSprite, 1003+Random(4), AI_SFX_PRIORITY_1, -1);
+                if (pSprite->type == kDudeCultistTommy) aiPlay3DSound(pSprite, 4003+Random(4), AI_SFX_PRIORITY_1, nChannel);
+                else aiPlay3DSound(pSprite, 1003+Random(4), AI_SFX_PRIORITY_1, nChannel);
             }
             switch (pXSprite->medium) {
                 case kMediumNormal:
@@ -412,6 +413,7 @@ void aiActivateDude(spritetype *pSprite, XSPRITE *pXSprite)
         return;
 #endif
     case kDudeCultistTommyProne: {
+        const int nChannel = !VanillaMode() ? kMaxSprites+pSprite->index : -1; // use kMaxSprites+sprite index as channel, so cultist alerts can be muted on death/hurt state
         DUDEEXTRA_STATS *pDudeExtraE = &gDudeExtra[pSprite->extra].stats;
         pDudeExtraE->active = 1;
         pSprite->type = kDudeCultistTommy;
@@ -420,7 +422,7 @@ void aiActivateDude(spritetype *pSprite, XSPRITE *pXSprite)
                 case 0:
                     aiNewState(pSprite, pXSprite, &cultistSearch);
                     if (Chance(0x8000))
-                        aiPlay3DSound(pSprite, 4008+Random(5), AI_SFX_PRIORITY_1, -1);
+                        aiPlay3DSound(pSprite, 4008+Random(5), AI_SFX_PRIORITY_1, nChannel);
                     break;
                 case kMediumWater:
                 case kMediumGoo:
@@ -429,8 +431,7 @@ void aiActivateDude(spritetype *pSprite, XSPRITE *pXSprite)
             }
         } else {
             if (Chance(0x8000))
-                aiPlay3DSound(pSprite, 4008+Random(5), AI_SFX_PRIORITY_1, -1);
-            
+                aiPlay3DSound(pSprite, 4008+Random(5), AI_SFX_PRIORITY_1, nChannel);
             switch (pXSprite->medium) {
                 case kMediumNormal:
                     aiNewState(pSprite, pXSprite, &cultistProneChase);
@@ -445,6 +446,7 @@ void aiActivateDude(spritetype *pSprite, XSPRITE *pXSprite)
     }
     case kDudeCultistShotgunProne:
     {
+        const int nChannel = !VanillaMode() ? kMaxSprites+pSprite->index : -1; // use kMaxSprites+sprite index as channel, so cultist alerts can be muted on death/hurt state
         DUDEEXTRA_STATS *pDudeExtraE = &gDudeExtra[pSprite->extra].stats;
         pDudeExtraE->active = 1;
         pSprite->type = kDudeCultistShotgun;
@@ -455,7 +457,7 @@ void aiActivateDude(spritetype *pSprite, XSPRITE *pXSprite)
             case kMediumNormal:
                 aiNewState(pSprite, pXSprite, &cultistSearch);
                 if (Chance(0x8000))
-                    aiPlay3DSound(pSprite, 1008+Random(5), AI_SFX_PRIORITY_1, -1);
+                    aiPlay3DSound(pSprite, 1008+Random(5), AI_SFX_PRIORITY_1, nChannel);
                 break;
             case kMediumWater:
             case kMediumGoo:
@@ -466,7 +468,7 @@ void aiActivateDude(spritetype *pSprite, XSPRITE *pXSprite)
         else
         {
             if (Chance(0x8000))
-                aiPlay3DSound(pSprite, 1003+Random(4), AI_SFX_PRIORITY_1, -1);
+                aiPlay3DSound(pSprite, 1003+Random(4), AI_SFX_PRIORITY_1, nChannel);
             switch (pXSprite->medium)
             {
             case kMediumNormal:

--- a/source/blood/src/ai.h
+++ b/source/blood/src/ai.h
@@ -79,7 +79,7 @@ extern int gDudeSlope[];
 extern int cumulDamage[];
 
 bool dudeIsPlayingSeq(spritetype *pSprite, int nSeq);
-void aiPlay3DSound(spritetype *pSprite, int a2, AI_SFX_PRIORITY a3, int a4);
+void aiPlay3DSound(spritetype *pSprite, int soundId, AI_SFX_PRIORITY nPriority, int chanId);
 void aiNewState(spritetype *pSprite, XSPRITE *pXSprite, AISTATE *pAIState);
 void aiChooseDirection(spritetype *pSprite, XSPRITE *pXSprite, int a3);
 void aiMoveForward(spritetype *pSprite, XSPRITE *pXSprite);

--- a/source/blood/src/callback.cpp
+++ b/source/blood/src/callback.cpp
@@ -416,9 +416,10 @@ void fxBloodBits(int nSprite) // 14
     gFX.fxSpawn(FX_48, pSprite->sectnum, x, y, pSprite->z);
     if (pSprite->ang == 1024)
     {
-        int nChannel = 28+(pSprite->index&2);
+        const int nChannel = 28+(pSprite->index&2);
+        const int nFlags = !VanillaMode() ? 1|4 : 1; // don't cut off if channel is already occupied
         dassert(nChannel < 32);
-        sfxPlay3DSound(pSprite, 385, nChannel, 1);
+        sfxPlay3DSound(pSprite, 385, nChannel, nFlags);
     }
     if (Chance(0x5000))
     {


### PR DESCRIPTION
This PR fixes a common issue of channels being cut out upon an enemy's death, and resolves an original game bug of cultist alerts continuing to play on death.

When an enemy is killed by a hitscan weapon such as the shotgun or tommy gun, it'll spawn a spurt of blood that has a random chance of triggering a splattering sfx upon hitting the ground - and cutting off the still ongoing enemy death sfx. This PR will set the sound effect trigger to only play if the channel is available, instead of cutting off the voice.

For cultists, when they are killed at point blank range with the shotgun, it'll trigger the activate callout sfx, then the death sfx in the same tick. This PR resolves this by setting all cultists to use their own unique channel slot for callouts, so they are cut off upon dying or getting hurt.

Fixes #804