### PR TITLE
Blood: Assign unique channel to cultist death cry

### DIFF
--- a/source/blood/src/actor.cpp
+++ b/source/blood/src/actor.cpp
@@ -3137,9 +3137,10 @@ void actKillDude(int nKillerSprite, spritetype *pSprite, DAMAGE_TYPE damageType,
     case kDudeCultistShotgun:
     case kDudeCultistTesla:
     case kDudeCultistTNT:
-        if (!VanillaMode()) // mute all cultist alerts sfx on death
-            sfxKill3DSound(pSprite, kMaxSprites+pSprite->index, -1); // cultist alert sfx use kMaxSprites+sprite index as channel
-        sfxPlay3DSound(pSprite, 1018+Random(2), -1, 0);
+        if (!VanillaMode()) // trigger cultist death scream sfx over cultist alerts sfx channel
+            sfxPlay3DSound(pSprite, 1018+Random(2), kMaxSprites+pSprite->index, 1|8); // cultist alert sfx use kMaxSprites+sprite index as channel
+        else
+            sfxPlay3DSound(pSprite, 1018+Random(2), -1, 0);
         if (nSeq == 3)
             seqSpawn(dudeInfo[nType].seqStartID+nSeq, 3, nXSprite, nDudeToGibClient2);
         else

--- a/source/blood/src/sfx.cpp
+++ b/source/blood/src/sfx.cpp
@@ -195,7 +195,7 @@ void sfxPlay3DSound(spritetype *pSprite, int soundId, int chanId, int nFlags)
                 return;
             pBonkle = BonkleCache[nBonkles++];
         }
-        pBonkle->pSndSpr = pSprite;
+        pBonkle->pSndSpr = !(nFlags & 8) ? pSprite : NULL;
         pBonkle->chanId = chanId;
     }
     else
@@ -306,7 +306,7 @@ void sfxPlay3DSoundCP(spritetype* pSprite, int soundId, int chanId, int nFlags, 
                 return;
             pBonkle = BonkleCache[nBonkles++];
         }
-        pBonkle->pSndSpr = pSprite;
+        pBonkle->pSndSpr = !(nFlags & 8) ? pSprite : NULL;
         pBonkle->chanId = chanId;
     }
     else


### PR DESCRIPTION
This PR fixes an oversight introduced in #854

I fixed it by giving cultist death callout sfx their own unique channel, and created a new bitflag (8) for sfx so it won't assign a tracking pointer to the sprite. This means it'll behave exactly like a channel-less sfx but won't be free'd until the sfx has finished playing.

Fixes #804