### PR TITLE
Blood: Use map name for blank save game names, optimize viewBurnTime() and use original calc for vanilla weapon sway

### DIFF
--- a/source/blood/src/actor.cpp
+++ b/source/blood/src/actor.cpp
@@ -5924,7 +5924,6 @@ spritetype * actSpawnSprite(spritetype *pSource, int nStat);
 
 spritetype *actSpawnDude(spritetype *pSource, short nType, int a3, int a4)
 {
-    XSPRITE* pXSource = &xsprite[pSource->extra];
     spritetype *pSprite2 = actSpawnSprite(pSource, kStatDude);
     if (!pSprite2) return NULL;
     XSPRITE *pXSprite2 = &xsprite[pSprite2->extra];
@@ -5960,6 +5959,7 @@ spritetype *actSpawnDude(spritetype *pSource, short nType, int a3, int a4)
     // add a way to inherit some values of spawner type 18 by dude.
     // This way designer can count enemies via switches and do many other interesting things.
     if (gModernMap && pSource->flags & kModernTypeFlag1) {
+        XSPRITE* pXSource = &xsprite[pSource->extra];
         switch (pSource->type) { // allow inheriting only for selected source types
             case kMarkerDudeSpawn:
                 //inherit pal?

--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -1567,11 +1567,6 @@ void ParseOptions(void)
 #endif
 }
 
-void ClockStrobe()
-{
-    //gGameClock++;
-}
-
 #if defined(_WIN32) && defined(DEBUGGINGAIDS)
 // See FILENAME_CASE_CHECK in cache1d.c
 static int32_t check_filename_casing(void)
@@ -1778,7 +1773,6 @@ int app_main(int argc, char const * const * argv)
     LOG_F(INFO, "Loading control setup");
     ctrlInit();
     timerInit(CLOCKTICKSPERSECOND);
-    timerSetCallback(ClockStrobe);
     enginecompatibilitymode = ENGINE_19960925;
 
     if (!hasSetupFilename)

--- a/source/blood/src/gamemenu.cpp
+++ b/source/blood/src/gamemenu.cpp
@@ -31,6 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "gui.h"
 #include "inifile.h"
 #include "levels.h"
+#include "loadsave.h"
 #include "menu.h"
 #include "qav.h"
 #include "resource.h"
@@ -2057,10 +2058,17 @@ void CGameMenuItemZEditBitmap::Draw(void)
     if (m_pzText)
         gMenuTextMgr.DrawText(m_pzText, m_nFont, m_nX, m_nY, shade, pal, false);
     int x = m_nX+m_nWidth-1-(at24+1)*width;
-    if (at20 && *at20)
+    if (at20 && (at20[0] != '\0' || strlen(gSaveGameOptions[at28].zLevelName)))
     {
         int width;
-        gMenuTextMgr.GetFontInfo(m_nFont, at20, &width, NULL);
+        char strEmptySave[16];
+        char *strSave = at20;
+        if ((at20[0] == '\0') && !bScan) // if save game name is blank, use level's name instead
+        {
+            snprintf(strEmptySave, sizeof(strEmptySave), "%s", gSaveGameOptions[at28].zLevelName);
+            strSave = strEmptySave;
+        }
+        gMenuTextMgr.GetFontInfo(m_nFont, strSave, &width, NULL);
         int shade2;
         if (at36)
         {
@@ -2076,7 +2084,7 @@ void CGameMenuItemZEditBitmap::Draw(void)
             else
                 shade2 = 32;
         }
-        gMenuTextMgr.DrawText(at20, m_nFont, x, m_nY, shade2, 0, false);
+        gMenuTextMgr.DrawText(strSave, m_nFont, x, m_nY, shade2, 0, false);
         x += width;
     }
     if (bScan && ((int)totalclock & 32))

--- a/source/blood/src/globals.cpp
+++ b/source/blood/src/globals.cpp
@@ -34,7 +34,6 @@ ud_setup_t gSetup;
 ClockTicks gFrameClock;
 ClockTicks gFrameTicks;
 int gFrame;
-//int volatile gGameClock;
 int gFrameRate;
 int gGamma;
 

--- a/source/blood/src/globals.h
+++ b/source/blood/src/globals.h
@@ -40,7 +40,6 @@ extern ud_setup_t gSetup;
 extern ClockTicks gFrameClock;
 extern ClockTicks gFrameTicks;
 extern int gFrame;
-//extern ClockTicks gGameClock;
 extern int gFrameRate;
 extern int gGamma;
 

--- a/source/blood/src/loadsave.cpp
+++ b/source/blood/src/loadsave.cpp
@@ -178,7 +178,7 @@ void LoadSave::LoadGame(char *pzFile)
     gFrameRate = 0;
     totalclock = 0;
     gPaused = 0;
-    gGameStarted = 1;    
+    gGameStarted = 1;
 
 #ifdef USE_STRUCT_TRACKERS
     Bmemset(sectorchanged, 0, sizeof(sectorchanged));

--- a/source/blood/src/mapedit.cpp
+++ b/source/blood/src/mapedit.cpp
@@ -12014,7 +12014,6 @@ static void (*keytimerstuff)(void) = NULL;
 static void timerCallback()
 {
     keytimerstuff();
-    //gGameClock = totalclock;
 }
 
 void ExtPostInit(void)

--- a/source/blood/src/network.cpp
+++ b/source/blood/src/network.cpp
@@ -1294,13 +1294,6 @@ void faketimerhandler(void)
 #ifndef NETCODE_DISABLE
     if (gNetMode != NETWORK_NONE && gNetENetInit)
         netUpdate();
-#if 0
-    if (gGameClock >= gNetFifoClock && ready2send)
-    {
-        gNetFifoClock += kTicsPerFrame;
-        netGetInput();
-    }
-#endif
 #endif
     //if (gNetMode != NETWORK_NONE && gNetENetInit)
     //    enet_host_service(gNetMode == NETWORK_SERVER ? gNetENetServer : gNetENetClient, NULL, 0);

--- a/source/blood/src/triggers.cpp
+++ b/source/blood/src/triggers.cpp
@@ -562,7 +562,7 @@ void OperateSprite(int nSprite, XSPRITE *pXSprite, const EVENT &event)
                 evPost(nSprite, 3, 18, kCmdOff, causerID);
             }
         }
-        break;    
+        break;
     case kThingArmedProxBomb:
         if (pSprite->statnum != kStatRespawn) {
             switch (event.cmd) {

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -3665,7 +3665,6 @@ void viewDrawScreen(void)
                 tmp--;
             }
             PLAYER *pOther = &gPlayer[i];
-            //othercameraclock = gGameClock;
             if (!waloff[CRYSTALBALLBUFFER])
             {
                 tileAllocTile(CRYSTALBALLBUFFER, 128, 128, 0, 0);
@@ -4026,13 +4025,7 @@ RORHACK:
     PLAYER *pPSprite = &gPlayer[gMe->pSprite->type-kDudePlayer1];
     if (IsPlayerSprite(gMe->pSprite) && pPSprite->hand == 1)
     {
-        //static int lastClock;
         gChoke.Draw(160, zn);
-        //if ((gGameClock % 5) == 0 && gGameClock != lastClock)
-        //{
-        //    gChoke.swayV(pPSprite);
-        //}
-        //lastClock = gGameClock;
     }
     if (byte_1A76C6)
     {

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -3904,8 +3904,16 @@ RORHACK:
             {
                 rotatesprite(160<<16, defaultHoriz<<16, 65536, 0, kCrosshairTile, 0, g_isAlterDefaultCrosshair ? CROSSHAIR_PAL : 0, 2, gViewX0, gViewY0, gViewX1, gViewY1);
             }
-            cX = (v4c<<8)+(160<<16);
-            cY = (v48<<8)+(220<<16)+(zDelta<<9);
+            if (!VanillaMode()) // smooth motion
+            {
+                cX = (v4c<<8)+(160<<16);
+                cY = (v48<<8)+(220<<16)+(zDelta<<9);
+            }
+            else // quantize like vanilla v1.21
+            {
+                cX = ((v4c>>8)+160)<<16;
+                cY = ((v48>>8)+220+(zDelta>>7))<<16;
+            }
             int nShade = sector[nSectnum].floorshade; int nPalette = 0;
             if (sector[gView->pSprite->sectnum].extra > 0) {
                 sectortype *pSector = &sector[gView->pSprite->sectnum];


### PR DESCRIPTION
This PR will automatically give saves with blank names a valid string, based off of the save file map name.

<img width="1280" alt="example" src="https://github.com/user-attachments/assets/84ad78bd-257f-4a7f-a2f6-45f647d00e92">

Additionally, this PR will also restore the original quantized, blocky movement for weapon sway when vanilla mode is enabled, and optimizes the widescreen scaling for burn flame HUD rendering.