### PR TITLE
Blood: Fix shadows crashing when rendered in mirrors

### DIFF
--- a/source/blood/src/mirrors.cpp
+++ b/source/blood/src/mirrors.cpp
@@ -35,6 +35,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "view.h"
 #include "warp.h"
 
+bool gMirrorDrawing;
+
 int mirrorcnt, mirrorsector, mirrorwall[4];
 
 typedef struct
@@ -85,6 +87,7 @@ void InitMirrors(void)
 #endif //  POLYMER
 
 #endif
+    gMirrorDrawing = false;
     mirrorcnt = 0;
     tilesiz[504].x = 0;
     tilesiz[504].y = 0;
@@ -360,6 +363,7 @@ void DrawMirrors(int x, int y, int z, fix16_t a, fix16_t horiz, int smooth, int 
             {
             case 0:
             {
+                gMirrorDrawing = true;
                 int nWall = mirror[i].at4;
                 int nSector = sectorofwall(nWall);
                 walltype *pWall = &wall[nWall];
@@ -406,6 +410,7 @@ void DrawMirrors(int x, int y, int z, fix16_t a, fix16_t horiz, int smooth, int 
                     TranslateMirrorColors(wall[nWall].shade, wall[nWall].pal);
                 pWall->nextwall = nNextWall;
                 pWall->nextsector = nNextSector;
+                gMirrorDrawing = false;
                 return;
             }
             case 1:
@@ -519,6 +524,7 @@ void MirrorLoadSave::Load(void)
     Read(&mirrorsector,sizeof(mirrorsector));
     Read(mirror, sizeof(mirror));
     Read(mirrorwall, sizeof(mirrorwall));
+    gMirrorDrawing = false;
     tilesiz[504].x = 0;
     tilesiz[504].y = 0;
 

--- a/source/blood/src/mirrors.h
+++ b/source/blood/src/mirrors.h
@@ -26,3 +26,5 @@ void InitMirrors(void);
 void sub_5571C(char mode);
 void sub_557C4(int x, int y, int interpolation);
 void DrawMirrors(int x, int y, int z, fix16_t a, fix16_t horiz, int smooth, int viewPlayer);
+
+extern bool gMirrorDrawing;

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -3000,7 +3000,7 @@ void viewProcessSprites(int32_t cX, int32_t cY, int32_t cZ, int32_t cA, int32_t 
                 }
             }
             
-            if (nSprite != gView->pSprite->index || gViewPos != VIEWPOS_0) {
+            if (nSprite != gView->pSprite->index || gViewPos != VIEWPOS_0 || (gMirrorDrawing && !VanillaMode())) {
                 if (getflorzofslope(pTSprite->sectnum, pTSprite->x, pTSprite->y) >= cZ)
                 {
                     viewAddEffect(nTSprite, kViewEffectShadow);

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -2406,12 +2406,24 @@ tspritetype *viewAddEffect(int nTSprite, VIEW_EFFECT nViewEffect)
         pNSprite->z = getflorzofslope(pTSprite->sectnum, pNSprite->x, pNSprite->y);
         if (!VanillaMode()) // support better floor detection for shadows (detect fake floors/allows ROR traversal)
         {
-            int ceilZ, ceilHit, floorZ, floorHit;
-            GetZRangeAtXYZ(pTSprite->x, pTSprite->y, pTSprite->z, pTSprite->sectnum, &ceilZ, &ceilHit, &floorZ, &floorHit, pTSprite->clipdist<<2, CLIPMASK0, PARALLAXCLIP_CEILING|PARALLAXCLIP_FLOOR);
-            if (((floorHit&0xc000) == 0xc000) && spriRangeIsFine(floorHit&0x3fff) && ((sprite[floorHit&0x3fff].cstat & (CSTAT_SPRITE_BLOCK|CSTAT_SPRITE_ALIGNMENT_FLOOR|CSTAT_SPRITE_INVISIBLE)) == (CSTAT_SPRITE_BLOCK|CSTAT_SPRITE_ALIGNMENT_FLOOR))) // if there is a fake floor under us, use fake floor as the shadow position
+            char bHitFakeFloor = 0;
+            short nFakeFloorSprite;
+            if (spriRangeIsFine(pTSprite->owner) && !gMirrorDrawing) // don't attempt to check for fake floors if we're rendering a mirror due to getzrange mirrorsector crash
+            {
+                spritetype *pSprite = &sprite[pTSprite->owner];
+                int bakCstat = pSprite->cstat;
+                pSprite->cstat &= ~257;
+                int ceilZ, ceilHit, floorZ, floorHit;
+                GetZRangeAtXYZ(pSprite->x, pSprite->y, pSprite->z, pSprite->sectnum, &ceilZ, &ceilHit, &floorZ, &floorHit, pSprite->clipdist<<2, CLIPMASK0, PARALLAXCLIP_CEILING|PARALLAXCLIP_FLOOR);
+                nFakeFloorSprite = floorHit&0x3fff;
+                if ((floorHit&0xc000) == 0xc000)
+                    bHitFakeFloor = (sprite[nFakeFloorSprite].cstat & (CSTAT_SPRITE_BLOCK|CSTAT_SPRITE_ALIGNMENT_FLOOR|CSTAT_SPRITE_INVISIBLE)) == (CSTAT_SPRITE_BLOCK|CSTAT_SPRITE_ALIGNMENT_FLOOR);
+                pSprite->cstat = bakCstat;
+            }
+            if (bHitFakeFloor) // if there is a fake floor under us, use fake floor as the shadow position
             {
                 int top, bottom;
-                GetSpriteExtents(&sprite[floorHit&0x3fff], &top, &bottom);
+                GetSpriteExtents(&sprite[nFakeFloorSprite], &top, &bottom);
                 pNSprite->z = top;
                 pNSprite->z--; // offset from fake floor so it isn't z-fighting when being rendered
             }


### PR DESCRIPTION
This PR fixes crashes when attempting to render shadows in mirror sectors, and improves the overall robustness for testing fake floors below the object casting a shadow. I've tested this with Bloodlines E1M1's fake floor, and Blood E2M5's fake floor in the house lobby.

The below pic would crash with the currently released build, this has since been fixed.

<img width="318" alt="mirrors" src="https://github.com/user-attachments/assets/683e87d6-f7bc-4e2f-ba56-9004aea0a6b9">