### PR TITLE
Blood: Precache baby spiders for mother spider

### DIFF
--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -260,8 +260,20 @@ void PrecacheDude(spritetype *pSprite)
     case kDudeSpiderBrown:
     case kDudeSpiderRed:
     case kDudeSpiderBlack:
-    case kDudeSpiderMother:
     case kDudeTchernobog:
+        seqPrecacheId(pDudeInfo->seqStartID+6);
+        seqPrecacheId(pDudeInfo->seqStartID+7);
+        seqPrecacheId(pDudeInfo->seqStartID+8);
+        break;
+    case kDudeSpiderMother:
+        seqPrecacheId(pDudeInfo->seqStartID+6);
+        seqPrecacheId(pDudeInfo->seqStartID+7);
+        seqPrecacheId(pDudeInfo->seqStartID+8);
+        pDudeInfo = getDudeInfo(kDudeSpiderBrown);
+        seqPrecacheId(pDudeInfo->seqStartID+6);
+        seqPrecacheId(pDudeInfo->seqStartID+7);
+        seqPrecacheId(pDudeInfo->seqStartID+8);
+        pDudeInfo = getDudeInfo(kDudeSpiderRed);
         seqPrecacheId(pDudeInfo->seqStartID+6);
         seqPrecacheId(pDudeInfo->seqStartID+7);
         seqPrecacheId(pDudeInfo->seqStartID+8);


### PR DESCRIPTION
This PR adds tile caching for baby spider types when a mother spider is present in the level. This should fix invalid sprites when these enemies are ignited on fire such as on E4M2.