### PR TITLE
Blood: Alert to user if new key bind conflicts with existing key function

### DIFF
--- a/source/blood/src/gamemenu.cpp
+++ b/source/blood/src/gamemenu.cpp
@@ -1140,6 +1140,8 @@ CGameMenuItemKeyList::CGameMenuItemKeyList()
     nTopDelta = 0;
     nFocus = 0;
     nGameFuncs = 0;
+    nConflictKeys[0] = nConflictKeys[1] = nConflictKeys[2] = -1;
+    bCheckConflict = true;
     bScan = false;
 }
 
@@ -1156,6 +1158,8 @@ CGameMenuItemKeyList::CGameMenuItemKeyList(const char *a1, int a2, int a3, int a
     nRows = a6;
     pCallback = a8;
     nGameFuncs = a7;
+    nConflictKeys[0] = nConflictKeys[1] = nConflictKeys[2] = -1;
+    bCheckConflict = true;
 }
 
 void CGameMenuItemKeyList::Scan(void)
@@ -1165,6 +1169,36 @@ void CGameMenuItemKeyList::Scan(void)
     KB_ClearKeysDown();
     KB_LastScan = 0;
     bScan = true;
+}
+
+void CGameMenuItemKeyList::CheckKeyConflict(void)
+{
+    nConflictKeys[0] = nConflictKeys[1] = nConflictKeys[2] = -1;
+    bCheckConflict = false;
+    for (int j = 0; j < NUMGAMEFUNCTIONS; j++) // check every key
+    {
+        for (int i = 0; i < NUMGAMEFUNCTIONS; i++) // check if new key bind conflicts with existing key bind
+        {
+            if (i == j)
+                continue;
+            const char bKey1 = KeyboardKeys[i][0] > 0 && KeyboardKeys[i][0] < 255;
+            const char bKey2 = KeyboardKeys[i][1] > 0 && KeyboardKeys[i][1] < 255;
+            if ((bKey1 && KeyboardKeys[j][0] == KeyboardKeys[i][0]) || (bKey2 && KeyboardKeys[j][0] == KeyboardKeys[i][1]))
+            {
+                nConflictKeys[0] = KeyboardKeys[j][0];
+                nConflictKeys[1] = i;
+                nConflictKeys[2] = j;
+                return;
+            }
+            if ((bKey2 && KeyboardKeys[j][1] == KeyboardKeys[i][1]) || (bKey1 && KeyboardKeys[j][1] == KeyboardKeys[i][0]))
+            {
+                nConflictKeys[0] = KeyboardKeys[j][1];
+                nConflictKeys[1] = i;
+                nConflictKeys[2] = j;
+                return;
+            }
+        }
+    }
 }
 
 extern uint8_t KeyboardKeys[NUMGAMEFUNCTIONS][2];
@@ -1241,6 +1275,23 @@ void CGameMenuItemKeyList::Draw(void)
             }
         }
     }
+    if (bCheckConflict)
+        CheckKeyConflict();
+    if (nConflictKeys[0] >= 0)
+    {
+        char buffer3[80];
+        sprintf(buffer, "%s", nFocus == nConflictKeys[2] ? CONFIG_FunctionNumToName(nConflictKeys[1]) : CONFIG_FunctionNumToName(nConflictKeys[2]));
+        for (int j = 0; j < 40; j++)
+        {
+            if (buffer[j] == '\0')
+                break;
+            if (buffer[j] == '_')
+                buffer[j] = ' ';
+        }
+        Bsnprintf(buffer3, sizeof(buffer3), "%s already set to %s", nConflictKeys[0] == sc_Tilde ? "Tilde" : KB_ScanCodeToString(nConflictKeys[0]), buffer);
+        gMenuTextMgr.GetFontInfo(m_nFont, buffer3, &width, 0);
+        viewDrawText(3, buffer3, (320/2)+2-(width/2), 185, 0, 8, 0, true);
+    }
     nTopDelta += nNewFocus-nFocus;
     nFocus = nNewFocus;
     if (bClick)
@@ -1277,6 +1328,7 @@ bool CGameMenuItemKeyList::Event(CGameMenuEvent &event)
             KeyboardKeys[nFocus][0] = key1;
             KeyboardKeys[nFocus][1] = key2;
             CONFIG_MapKey(nFocus, key1, oldKey[0], key2, oldKey[1]);
+            CheckKeyConflict();
             KB_FlushKeyboardQueue();
             KB_FlushKeyboardQueueScans();
             KB_ClearKeysDown();
@@ -1321,6 +1373,7 @@ bool CGameMenuItemKeyList::Event(CGameMenuEvent &event)
         KeyboardKeys[nFocus][0] = 0;
         KeyboardKeys[nFocus][1] = 0;
         CONFIG_MapKey(nFocus, 0, oldKey[0], 0, oldKey[1]);
+        CheckKeyConflict();
         return false;
     case kMenuEventScrollUp:
         if (nFocus-nTopDelta > 0)
@@ -1344,6 +1397,9 @@ bool CGameMenuItemKeyList::Event(CGameMenuEvent &event)
             }
         }
         return false;
+    case kMenuEventEscape:
+        bCheckConflict = true; // check next time user opens key list
+        break;
     }
     return CGameMenuItem::Event(event);
 }

--- a/source/blood/src/gamemenu.h
+++ b/source/blood/src/gamemenu.h
@@ -240,10 +240,13 @@ public:
     int nTopDelta;
     int nFocus;
     int nGameFuncs;
+    int nConflictKeys[3];
+    bool bCheckConflict;
     bool bScan;
     CGameMenuItemKeyList();
     CGameMenuItemKeyList(const char * a1, int a2, int a3, int a4, int a5, int a6, int a7, void(*a8)(CGameMenuItemKeyList *));
     void Scan(void);
+    void CheckKeyConflict(void);
     virtual void Draw(void);
     virtual bool Event(CGameMenuEvent &);
     virtual bool MouseEvent(CGameMenuEvent &);


### PR DESCRIPTION
This PR adds a check to the keyboard control settings, so the user is alerted when a conflicting key has been bound.

Example, backspace has been bound to crouch toggle, while it already used for turn around function.

<img width="1280" alt="rset" src="https://github.com/user-attachments/assets/c867f64f-6617-44ac-9f0d-4421c74f141f" />