### PR TITLE
Blood: Fix shotgun akimbo frame bug

### DIFF
--- a/source/blood/src/weapon.cpp
+++ b/source/blood/src/weapon.cpp
@@ -247,7 +247,12 @@ void WeaponDraw(PLAYER *pPlayer, int a2, int x, int y, int a5)
     QAV * pQAV = weaponQAV[pPlayer->weaponQav];
     int v4;
     if (pPlayer->weaponTimer == 0)
-        v4 = (int)totalclock % pQAV->at10;
+    {
+        if (((pPlayer->weaponState == -1) || (pPlayer->curWeapon == kWeaponShotgun && pPlayer->weaponState == 7)) && !VanillaMode()) // if shotgun with guns akimbo, or ran out of ammo, set to last seq frame
+            v4 = pQAV->at10-1;
+        else
+            v4 = (int)totalclock % pQAV->at10;
+    }
     else
         v4 = pQAV->at10 - pPlayer->weaponTimer;
     pQAV->x = x;


### PR DESCRIPTION
This PR fixes the invalid frame triggering when firing the shotgun with the akimbo powerup.

It is based off of BloodGDX's fix https://gitlab.com/m210/BloodGDX/-/commit/3cb4a17b2b987e8c08a50085042f06ad724ec4b3

Before

https://github.com/user-attachments/assets/dba44fbb-57e5-4f7b-9798-36db86dbe88e

After

https://github.com/user-attachments/assets/ab4b5689-5a19-4658-a2ee-d2de1639c0c5
