### PR TITLE
Blood: Fix interpolated sprite offsets for room over room transitions

### DIFF
--- a/source/blood/src/view.h
+++ b/source/blood/src/view.h
@@ -202,3 +202,19 @@ inline void viewBackupSpriteLoc(int nSprite, spritetype *pSprite)
         SetBitString(gInterpolateSprite, nSprite);
     }
 }
+
+inline void viewCorrectSpriteInterpolateOffsets(int nSprite, spritetype *pSprite, vec3_t const *oldpos)
+{
+    if (TestBitString(gInterpolateSprite, nSprite))
+    {
+        if (!gViewInterpolate) // view interpolation is off, clear interpolation flag
+        {
+            ClearBitString(gInterpolateSprite, nSprite);
+            return;
+        }
+        LOCATION *pPrevLoc = &gPrevSpriteLoc[nSprite];
+        pPrevLoc->x = pSprite->x+(pPrevLoc->x-oldpos->x);
+        pPrevLoc->y = pSprite->y+(pPrevLoc->y-oldpos->y);
+        pPrevLoc->z = pSprite->z+(pPrevLoc->z-oldpos->z);
+    }
+}

--- a/source/blood/src/warp.cpp
+++ b/source/blood/src/warp.cpp
@@ -200,6 +200,7 @@ int CheckLink(spritetype *pSprite)
             spritetype *pLower = &sprite[nLower];
             dassert(pLower->sectnum >= 0 && pLower->sectnum < kMaxSectors);
             ChangeSpriteSect(pSprite->index, pLower->sectnum);
+            vec3_t const oldpos = pSprite->xyz;
             pSprite->x += pLower->x-pUpper->x;
             pSprite->y += pLower->y-pUpper->y;
             int z2;
@@ -208,7 +209,10 @@ int CheckLink(spritetype *pSprite)
             else
                 z2 = getceilzofslope(pSprite->sectnum, pSprite->x, pSprite->y);
             pSprite->z += z2-z;
-            ClearBitString(gInterpolateSprite, pSprite->index);
+            if (!VanillaMode()) // if sprite is set to be interpolated, update previous position
+                viewCorrectSpriteInterpolateOffsets(pSprite->index, pSprite, &oldpos);
+            else
+                ClearBitString(gInterpolateSprite, pSprite->index);
             return pUpper->type;
         }
     }
@@ -227,6 +231,7 @@ int CheckLink(spritetype *pSprite)
             spritetype *pUpper = &sprite[nUpper];
             dassert(pUpper->sectnum >= 0 && pUpper->sectnum < kMaxSectors);
             ChangeSpriteSect(pSprite->index, pUpper->sectnum);
+            vec3_t const oldpos = pSprite->xyz;
             pSprite->x += pUpper->x-pLower->x;
             pSprite->y += pUpper->y-pLower->y;
             int z2;
@@ -235,7 +240,10 @@ int CheckLink(spritetype *pSprite)
             else
                 z2 = getflorzofslope(pSprite->sectnum, pSprite->x, pSprite->y);
             pSprite->z += z2-z;
-            ClearBitString(gInterpolateSprite, pSprite->index);
+            if (!VanillaMode()) // if sprite is set to be interpolated, update previous position
+                viewCorrectSpriteInterpolateOffsets(pSprite->index, pSprite, &oldpos);
+            else
+                ClearBitString(gInterpolateSprite, pSprite->index);
             return pLower->type;
         }
     }


### PR DESCRIPTION
This PR restores the interpolated state for sprites that are transitioned through room-over-room links, much like how 71519e9edf7fa3a9fbecf5f097fee29a26b2da94 did for player view momentum.

Before

https://github.com/user-attachments/assets/58ec8d69-fa88-4d68-99bb-eea34401a747

After

https://github.com/user-attachments/assets/4414fbf8-b067-43ee-87e8-09fec1d6d461