### PR TITLE
Blood: Reset player sfx velocity on spawn/teleport/ror transition, and refactor sfxUpdate3DSounds()

### DIFF
--- a/source/blood/src/actor.cpp
+++ b/source/blood/src/actor.cpp
@@ -4615,7 +4615,11 @@ void MoveDude(spritetype *pSprite)
             if (VanillaMode())
                 playerResetInertia(pPlayer);
             else
+            {
                 playerCorrectInertia(pPlayer, &oldpos);
+                if (pPlayer == gMe) // if player is listener, update ear position so audio pitch of surrounding sfx does not freak out when transitioning between ror sectors
+                    sfxCorrectListenerPos();
+            }
         }
         switch (nLink) {
         case kMarkerLowStack:

--- a/source/blood/src/nnexts.cpp
+++ b/source/blood/src/nnexts.cpp
@@ -3130,6 +3130,8 @@ void useTeleportTarget(XSPRITE* pXSource, spritetype* pSprite) {
         playerResetInertia(pPlayer);
         if (pXSource->data2 == 1)
             pPlayer->zViewVel = pPlayer->zWeaponVel = 0;
+        if (pPlayer == gMe) // if player is listener, update ear position/reset ear velocity so audio pitch of surrounding sfx does not freak out when teleporting player
+            sfxResetListener();
     }
 }
 

--- a/source/blood/src/player.cpp
+++ b/source/blood/src/player.cpp
@@ -988,6 +988,8 @@ void playerStart(int nPlayer, int bNewLevel)
         gViewMap.x = pPlayer->pSprite->x;
         gViewMap.y = pPlayer->pSprite->y;
         gViewMap.angle = pPlayer->pSprite->ang;
+        if (!VanillaMode())
+            sfxResetListener(); // player is listener, update ear position/reset ear velocity so audio pitch of surrounding sfx does not freak out when respawning player
     }
     if (IsUnderwaterSector(pSprite->sectnum))
     {

--- a/source/blood/src/sfx.cpp
+++ b/source/blood/src/sfx.cpp
@@ -440,20 +440,26 @@ void sfxKillSpriteSounds(spritetype *pSprite)
     }
 }
 
-void sfxUpdate3DSounds(void)
+inline void sfxUpdateListenerPos(void)
 {
     const int dx = mulscale30(Cos(gMe->pSprite->ang + kAng90), kEarDist>>1);
     const int dy = mulscale30(Sin(gMe->pSprite->ang + kAng90), kEarDist>>1);
     earL0 = earL;
     earR0 = earR;
-    earL.x = gMe->pSprite->x - dx;
-    earL.y = gMe->pSprite->y - dy;
-    earR.x = gMe->pSprite->x + dx;
-    earR.y = gMe->pSprite->y + dy;
-    earVL.dx = earL.x - earL0.x;
-    earVL.dy = earL.y - earL0.y;
-    earVR.dx = earR.x - earR0.x;
-    earVR.dy = earR.y - earR0.y;
+    earL = {gMe->pSprite->x - dx, gMe->pSprite->y - dy};
+    earR = {gMe->pSprite->x + dx, gMe->pSprite->y + dy};
+}
+
+inline void sfxUpdateListenerVel(void)
+{
+    earVL = {earL.x - earL0.x, earL.y - earL0.y};
+    earVR = {earR.x - earR0.x, earR.y - earR0.y};
+}
+
+void sfxUpdate3DSounds(void)
+{
+    sfxUpdateListenerPos();
+    sfxUpdateListenerVel();
     for (int i = nBonkles - 1; i >= 0; i--)
     {
         BONKLE *pBonkle = BonkleCache[i];

--- a/source/blood/src/sfx.cpp
+++ b/source/blood/src/sfx.cpp
@@ -34,6 +34,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "sound.h"
 #include "trig.h"
 
+#define kEarDist (int)((32<<4) * 0.17) // distance between ears (17cm)
+
 static POINT2D earL, earR, earL0, earR0; // Ear position
 static VECTOR2D earVL, earVR; // Ear velocity
 static int lPhase, rPhase, lVol, rVol, lPitch, rPitch;
@@ -440,9 +442,9 @@ void sfxKillSpriteSounds(spritetype *pSprite)
 
 void sfxUpdate3DSounds(void)
 {
-    int dx = mulscale30(Cos(gMe->pSprite->ang + 512), 43);
+    const int dx = mulscale30(Cos(gMe->pSprite->ang + kAng90), kEarDist>>1);
+    const int dy = mulscale30(Sin(gMe->pSprite->ang + kAng90), kEarDist>>1);
     earL0 = earL;
-    int dy = mulscale30(Sin(gMe->pSprite->ang + 512), 43);
     earR0 = earR;
     earL.x = gMe->pSprite->x - dx;
     earL.y = gMe->pSprite->y - dy;

--- a/source/blood/src/sfx.cpp
+++ b/source/blood/src/sfx.cpp
@@ -456,6 +456,12 @@ inline void sfxUpdateListenerVel(void)
     earVR = {earR.x - earR0.x, earR.y - earR0.y};
 }
 
+void sfxResetListener(void)
+{
+    sfxUpdateListenerPos(); // update ear position
+    earVL = earVR = {0, 0}; // reset ear velocity
+}
+
 void sfxUpdate3DSounds(void)
 {
     sfxUpdateListenerPos();

--- a/source/blood/src/sfx.cpp
+++ b/source/blood/src/sfx.cpp
@@ -456,6 +456,17 @@ inline void sfxUpdateListenerVel(void)
     earVR = {earR.x - earR0.x, earR.y - earR0.y};
 }
 
+void sfxCorrectListenerPos(void)
+{
+    sfxUpdateListenerPos();
+    earL0 = earL;
+    earR0 = earR;
+    earL0.x += -earVL.dx;
+    earL0.y += -earVL.dy;
+    earR0.x += -earVR.dx;
+    earR0.y += -earVR.dy;
+}
+
 void sfxResetListener(void)
 {
     sfxUpdateListenerPos(); // update ear position

--- a/source/blood/src/sfx.cpp
+++ b/source/blood/src/sfx.cpp
@@ -34,9 +34,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "sound.h"
 #include "trig.h"
 
-POINT2D earL, earR, earL0, earR0; // Ear position
-VECTOR2D earVL, earVR; // Ear velocity ?
-int lPhase, rPhase, lVol, rVol, lPitch, rPitch;
+static POINT2D earL, earR, earL0, earR0; // Ear position
+static VECTOR2D earVL, earVR; // Ear velocity
+static int lPhase, rPhase, lVol, rVol, lPitch, rPitch;
 
 BONKLE Bonkle[256];
 BONKLE *BonkleCache[256];

--- a/source/blood/src/sfx.h
+++ b/source/blood/src/sfx.h
@@ -51,6 +51,7 @@ void sfxPlay3DSoundCP(spritetype* pSprite, int soundId, int chanId = -1, int nFl
 void sfxKill3DSound(spritetype *pSprite, int chanId = -1, int soundId = -1);
 void sfxKillAllSounds(void);
 void sfxKillSpriteSounds(spritetype *pSprite);
+void sfxCorrectListenerPos(void);
 void sfxResetListener(void);
 void sfxUpdate3DSounds(void);
 void sfxSetReverb(bool toggle);

--- a/source/blood/src/sfx.h
+++ b/source/blood/src/sfx.h
@@ -51,6 +51,7 @@ void sfxPlay3DSoundCP(spritetype* pSprite, int soundId, int chanId = -1, int nFl
 void sfxKill3DSound(spritetype *pSprite, int chanId = -1, int soundId = -1);
 void sfxKillAllSounds(void);
 void sfxKillSpriteSounds(spritetype *pSprite);
+void sfxResetListener(void);
 void sfxUpdate3DSounds(void);
 void sfxSetReverb(bool toggle);
 void sfxSetReverb2(bool toggle);

--- a/source/blood/src/triggers.cpp
+++ b/source/blood/src/triggers.cpp
@@ -1587,6 +1587,8 @@ void OperateTeleport(unsigned int nSector, XSECTOR *pXSector)
                     {
                         pPlayer->angold = pSprite->ang;
                         pPlayer->q16ang = fix16_from_int(pSprite->ang);
+                        if (pPlayer == gMe) // if player is listener, update ear position/reset ear velocity so audio pitch of surrounding sfx does not freak out when teleporting player
+                            sfxResetListener();
                     }
                 }
             }


### PR DESCRIPTION
This PR changes/fixes the following

* Player listening velocity breaking doppler on respawn/map start
* Doppler calculation breaking when teleporting across great distances
* Use `kEarDist` constant for doppler calculation
* Define internal sfx.cpp listening position variables as static

Before

https://github.com/user-attachments/assets/47feb2f2-1b95-4572-b49e-849e9e12a231

https://github.com/user-attachments/assets/76943dde-8f47-4009-8fa7-b75e89cedb38

After

https://github.com/user-attachments/assets/e6071e3e-11b0-4313-a21b-474768cd41ca