### PR TITLE
Blood: Drop hand enemy after killing player for multiplayer

### DIFF
--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -750,8 +750,8 @@ void StartLevel(GAMEOPTIONS *gameOptions)
         }
         else if ((gGameOptions.nGameType == kGameTypeTeams) && !VanillaMode()) // if ctf mode and went to next level, reset scores
             playerResetScores(i);
-        gChokeCounter[i] = 0;
         playerStart(i, 1);
+        gChokeCounter[i] = 0;
     }
     if (gameOptions->uGameFlags&kGameFlagContinuing) // if episode is in progress, restore player stats
     {


### PR DESCRIPTION
This PR fixes an enemy count bug that was introduced by #864.

When hand enemies attach to players their sprite is removed, until the player is able to successfully throw the enemy off by tapping the use key. However if the player dies, the enemy will never be dropped and is forever removed. Normally this would never cause an issue for single player, but with #864 it exposes an issue with the enemy count.

Because multiplayer allows player respawns, the total enemies will become broken if a player dies to an hand enemy and will render the match impossible to kill every enemy.

By forcing the hand enemy to 'drop' on player death for multiplayer, it will fix the total enemy count breaking.