### PR TITLE
Blood: Save gSongId/gSkyCount variables and use constants for map decrypting

### DIFF
--- a/source/blood/src/barf.cpp
+++ b/source/blood/src/barf.cpp
@@ -539,6 +539,7 @@ void ParseScript(const char *scriptFileName)
                         rfs.SkipBeyondValue('\n');
                     }
                 }
+                break;
             }
             case kTagResource: // really light blue..
             {

--- a/source/blood/src/common_game.h
+++ b/source/blood/src/common_game.h
@@ -44,7 +44,7 @@ extern int g_useCwd;
 
 #define BLOODWIDESCREENDEF "blood_widescreen.def"
 
-#define BYTEVERSION 106
+#define BYTEVERSION 107
 
 void _SetErrorLoc(const char *pzFile, int nLine);
 void _ThrowError(const char *pzFormat, ...);

--- a/source/blood/src/db.cpp
+++ b/source/blood/src/db.cpp
@@ -41,6 +41,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "view.h"
 #endif
 
+#define kMapHeaderNew 0x7474614D // 'ttaM' signature
+#define kMapHeaderOld 0x4D617474 // 'Matt' signature
+
 #ifdef NOONE_EXTENSIONS
 uint8_t gModernMap = false;
 #endif // !NOONE_EXTENSIONS
@@ -873,8 +876,8 @@ int dbLoadMap(const char *pPath, int *pX, int *pY, int *pZ, short *pAngle, short
 
     MAPHEADER mapHeader;
     IOBuffer1.Read(&mapHeader,37/* sizeof(mapHeader)*/);
-    if (mapHeader.at16 != 0 && mapHeader.at16 != 0x7474614d && mapHeader.at16 != 0x4d617474) {
-        dbCrypt((char*)&mapHeader, sizeof(mapHeader), 0x7474614d);
+    if (mapHeader.at16 != 0 && mapHeader.at16 != kMapHeaderNew && mapHeader.at16 != kMapHeaderOld) {
+        dbCrypt((char*)&mapHeader, sizeof(mapHeader), kMapHeaderNew);
         byte_1A76C7 = 1;
     }
 
@@ -906,7 +909,7 @@ int dbLoadMap(const char *pPath, int *pX, int *pY, int *pZ, short *pAngle, short
     gSongId = mapHeader.at16;
     if (byte_1A76C8)
     {
-        if (mapHeader.at16 == 0x7474614d || mapHeader.at16 == 0x4d617474)
+        if (mapHeader.at16 == kMapHeaderNew || mapHeader.at16 == kMapHeaderOld)
         {
             byte_1A76C6 = 1;
         }
@@ -1087,7 +1090,7 @@ int dbLoadMap(const char *pPath, int *pX, int *pY, int *pZ, short *pAngle, short
         IOBuffer1.Read(pWall, sizeof(walltype));
         if (byte_1A76C8)
         {
-            dbCrypt((char*)pWall, sizeof(walltype), (gMapRev*sizeof(sectortype)) | 0x7474614d);
+            dbCrypt((char*)pWall, sizeof(walltype), (gMapRev*sizeof(sectortype)) | kMapHeaderNew);
         }
 #if B_BIG_ENDIAN == 1
         pWall->x = B_LITTLE32(pWall->x);
@@ -1164,7 +1167,7 @@ int dbLoadMap(const char *pPath, int *pX, int *pY, int *pZ, short *pAngle, short
         IOBuffer1.Read(pSprite, sizeof(spritetype));
         if (byte_1A76C8)
         {
-            dbCrypt((char*)pSprite, sizeof(spritetype), (gMapRev*sizeof(spritetype)) | 0x7474614d);
+            dbCrypt((char*)pSprite, sizeof(spritetype), (gMapRev*sizeof(spritetype)) | kMapHeaderNew);
         }
 #if B_BIG_ENDIAN == 1
         pSprite->x = B_LITTLE32(pSprite->x);
@@ -1316,7 +1319,7 @@ int dbLoadMap(const char *pPath, int *pX, int *pY, int *pZ, short *pAngle, short
     PropagateMarkerReferences();
     if (byte_1A76C8)
     {
-        if (gSongId == 0x7474614d || gSongId == 0x4d617474)
+        if (gSongId == kMapHeaderNew || gSongId == kMapHeaderOld)
         {
             byte_1A76C6 = 1;
         }
@@ -1484,7 +1487,7 @@ int dbSaveMap(const char *pPath, int nX, int nY, int nZ, short nAngle, short nSe
     mapheader.at12 = B_LITTLE32(gVisibility);
     if (byte_1A76C6)
     {
-        gSongId = 0x7474614d;
+        gSongId = kMapHeaderNew;
     }
     else
     {
@@ -1498,7 +1501,7 @@ int dbSaveMap(const char *pPath, int nX, int nY, int nZ, short nAngle, short nSe
     mapheader.at23 = B_LITTLE16(nSpriteNum);
     if (byte_1A76C7)
     {
-        dbCrypt((char*)&mapheader, sizeof(MAPHEADER), 'ttaM');
+        dbCrypt((char*)&mapheader, sizeof(MAPHEADER), kMapHeaderNew);
     }
     IOBuffer1.Write(&mapheader, sizeof(MAPHEADER));
     if (byte_1A76C8)
@@ -1620,12 +1623,12 @@ int dbSaveMap(const char *pPath, int nX, int nY, int nZ, short nAngle, short nSe
     {
         if (byte_1A76C8)
         {
-            dbCrypt((char*)&wall[i], sizeof(walltype), gMapRev*sizeof(sectortype) | 0x7474614d);
+            dbCrypt((char*)&wall[i], sizeof(walltype), gMapRev*sizeof(sectortype) | kMapHeaderNew);
         }
         IOBuffer1.Write(&wall[i], sizeof(walltype));
         if (byte_1A76C8)
         {
-            dbCrypt((char*)&wall[i], sizeof(walltype), gMapRev*sizeof(sectortype) | 0x7474614d);
+            dbCrypt((char*)&wall[i], sizeof(walltype), gMapRev*sizeof(sectortype) | kMapHeaderNew);
         }
         if (wall[i].extra > 0)
         {
@@ -1672,12 +1675,12 @@ int dbSaveMap(const char *pPath, int nX, int nY, int nZ, short nAngle, short nSe
         {
             if (byte_1A76C8)
             {
-                dbCrypt((char*)&sprite[i], sizeof(spritetype), gMapRev*sizeof(spritetype) | 'ttaM');
+                dbCrypt((char*)&sprite[i], sizeof(spritetype), gMapRev*sizeof(spritetype) | kMapHeaderNew);
             }
             IOBuffer1.Write(&sprite[i], sizeof(spritetype));
             if (byte_1A76C8)
             {
-                dbCrypt((char*)&sprite[i], sizeof(spritetype), gMapRev*sizeof(spritetype) | 'ttaM');
+                dbCrypt((char*)&sprite[i], sizeof(spritetype), gMapRev*sizeof(spritetype) | kMapHeaderNew);
             }
             if (sprite[i].extra > 0)
             {

--- a/source/blood/src/loadsave.cpp
+++ b/source/blood/src/loadsave.cpp
@@ -399,7 +399,8 @@ void MyLoadSave::Load(void)
     Read(yvel, nNumSprites*sizeof(yvel[0]));
     Read(zvel, nNumSprites*sizeof(zvel[0]));
     Read(&gMapRev, sizeof(gMapRev));
-    Read(&gSongId, sizeof(gSkyCount));
+    Read(&gSongId, sizeof(gSongId));
+    Read(&gSkyCount, sizeof(gSkyCount));
     Read(&gFogMode, sizeof(gFogMode));
 #ifdef NOONE_EXTENSIONS
     Read(&gModernMap, sizeof(gModernMap));
@@ -512,7 +513,8 @@ void MyLoadSave::Save(void)
     Write(yvel, nNumSprites*sizeof(yvel[0]));
     Write(zvel, nNumSprites*sizeof(zvel[0]));
     Write(&gMapRev, sizeof(gMapRev));
-    Write(&gSongId, sizeof(gSkyCount));
+    Write(&gSongId, sizeof(gSongId));
+    Write(&gSkyCount, sizeof(gSkyCount));
     Write(&gFogMode, sizeof(gFogMode));
 #ifdef NOONE_EXTENSIONS
     Write(&gModernMap, sizeof(gModernMap));


### PR DESCRIPTION
This PR resolves the warnings for db.cpp, properly fixes an oversight when saving gSongId/gSkyCount variables and bumps the save version up to 107.