### PR TITLE
Blood: Add 'pitchfork only' autoaim option

### DIFF
--- a/source/blood/src/menu.cpp
+++ b/source/blood/src/menu.cpp
@@ -431,7 +431,8 @@ CGameMenuItemChain itemOptionsChainOld("OLD MENU", 1, 0, 170, 320, 1, &menuOptio
 const char *pzAutoAimStrings[] = {
     "NEVER",
     "ALWAYS",
-    "HITSCAN ONLY"
+    "HITSCAN ONLY",
+    "PITCHFORK ONLY"
 };
 
 const char *pzWeaponSwitchStrings[] = {

--- a/source/blood/src/osdcmd.cpp
+++ b/source/blood/src/osdcmd.cpp
@@ -938,7 +938,7 @@ int32_t registerosdcommands(void)
     {
         { "crosshair", "enable/disable crosshair", (void *)&gAimReticle, CVAR_BOOL, 0, 1 },
 
-        { "cl_autoaim", "enable/disable weapon autoaim", (void *)&gAutoAim, CVAR_INT|CVAR_MULTI, 0, 2 },
+        { "cl_autoaim", "enable/disable weapon autoaim", (void *)&gAutoAim, CVAR_INT|CVAR_MULTI, 0, 3 },
 //        { "cl_automsg", "enable/disable automatically sending messages to all players", (void *)&ud.automsg, CVAR_BOOL, 0, 1 },
         { "cl_autorun", "enable/disable autorun", (void *)&gAutoRun, CVAR_BOOL, 0, 1 },
 //

--- a/source/blood/src/weapon.cpp
+++ b/source/blood/src/weapon.cpp
@@ -335,7 +335,8 @@ void UpdateAimVector(PLAYER * pPlayer)
     WEAPONTRACK *pWeaponTrack = &gWeaponTrack[pPlayer->curWeapon];
     int nTarget = -1;
     pPlayer->aimTargetsCount = 0;
-    if (gProfile[pPlayer->nPlayer].nAutoAim == 1 || (gProfile[pPlayer->nPlayer].nAutoAim == 2 && !pWeaponTrack->bIsProjectile) || pPlayer->curWeapon == kWeaponVoodoo || pPlayer->curWeapon == kWeaponLifeLeech)
+    const char bAutoAimWeapon = pPlayer->curWeapon == kWeaponVoodoo || pPlayer->curWeapon == kWeaponLifeLeech || (gProfile[pPlayer->nPlayer].nAutoAim == 3 && pPlayer->curWeapon == kWeaponPitchfork); // always autoaim for these weapons
+    if (gProfile[pPlayer->nPlayer].nAutoAim == 1 || (gProfile[pPlayer->nPlayer].nAutoAim == 2 && !pWeaponTrack->bIsProjectile) || bAutoAimWeapon)
     {
         int nClosest = 0x7fffffff;
         for (nSprite = headspritestat[kStatDude]; nSprite >= 0; nSprite = nextspritestat[nSprite])


### PR DESCRIPTION
Smaller enemies such as the hands, rats and fish appear to be designed in mind for autoaim as it's incredibly difficult to hit them precisely when autoaim is turned off.

This PR adds a new autoaim setting to allow players to always have autoaim set for the pitchfork weapon, so players who prefer not to use autoaim can have it only applied for the pitchfork.

<img width="1280" alt="test" src="https://github.com/user-attachments/assets/21ad2ae6-3470-4b98-a629-45f0c49f8d86" />