### PR TITLE
Blood: Use original logic for applying sprite sector pal

### DIFF
--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -2636,16 +2636,6 @@ tspritetype *viewAddEffect(int nTSprite, VIEW_EFFECT nViewEffect)
 LOCATION gPrevSpriteLoc[kMaxSprites];
 static LOCATION gViewSpritePredictLoc;
 
-static void viewApplyDefaultPal(tspritetype *pTSprite, sectortype const *pSector)
-{
-    int const nXSector = pSector->extra;
-    XSECTOR const *pXSector = nXSector >= 0 ? &xsector[nXSector] : NULL;
-    if (pXSector && pXSector->color && (VanillaMode() || pSector->floorpal != 0))
-    {
-        pTSprite->pal = pSector->floorpal;
-    }
-}
-
 void viewProcessSprites(int32_t cX, int32_t cY, int32_t cZ, int32_t cA, int32_t smooth)
 {
     UNREFERENCED_PARAMETER(smooth);
@@ -2908,7 +2898,8 @@ void viewProcessSprites(int32_t cX, int32_t cY, int32_t cZ, int32_t cA, int32_t 
                     }
                     break;
                 default:
-                    viewApplyDefaultPal(pTSprite, pSector);
+                    if (pXSector && pXSector->color)
+                        pTSprite->pal = pSector->floorpal;
                     break;
             }
         }
@@ -2938,8 +2929,8 @@ void viewProcessSprites(int32_t cX, int32_t cY, int32_t cZ, int32_t cA, int32_t 
                 default:
                     if (pTSprite->type >= kItemKeySkull && pTSprite->type < kItemKeyMax)
                         pTSprite->shade = -128;
-
-                    viewApplyDefaultPal(pTSprite, pSector);
+                    if (pXSector && pXSector->color)
+                        pTSprite->pal = pSector->floorpal;
                     break;
             }
         }
@@ -2996,15 +2987,10 @@ void viewProcessSprites(int32_t cX, int32_t cY, int32_t cZ, int32_t cA, int32_t 
                 }
             }
 
-
-            
-
             if (pXSector && pXSector->color) pTSprite->pal = pSector->floorpal;
             if (powerupCheck(gView, kPwUpBeastVision) > 0) pTSprite->shade = -128;
 
             if (IsPlayerSprite(pTSprite)) {
-                viewApplyDefaultPal(pTSprite, pSector);
-
                 PLAYER *pPlayer = &gPlayer[pTSprite->type-kDudePlayer1];
                 if (powerupCheck(pPlayer, kPwUpShadowCloak) && !powerupCheck(gView, kPwUpBeastVision)) {
                     pTSprite->cstat |= 2;
@@ -3086,7 +3072,8 @@ void viewProcessSprites(int32_t cX, int32_t cY, int32_t cZ, int32_t cA, int32_t 
             break;
         }
         case kStatThing: {
-            viewApplyDefaultPal(pTSprite, pSector);
+            if (pXSector && pXSector->color)
+                pTSprite->pal = pSector->floorpal;
 
             if (pTSprite->type < kThingBase || pTSprite->type >= kThingMax || !gSpriteHit[nXSprite].florhit) {
                 if ((pTSprite->flags & kPhysMove) && getflorzofslope(pTSprite->sectnum, pTSprite->x, pTSprite->y) >= cZ)


### PR DESCRIPTION
This PR reverts 0d7bcf0462d5d899b7b14edd6a8c8be9609c22cd and uses the original logic for applying floor sector colors to sprites, as the color flag is stored in xsector.

Fixes #385