### PR TITLE
Blood: Poll input before `ProcessFrame()`

### DIFF
--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -1905,6 +1905,7 @@ RESTART:
                     if (!frameJustDrawn)
                         break;
                     frameJustDrawn = false;
+                    ctrlGetInput();
                     gNetInput = gInput;
                     gInput = {};
                     do


### PR DESCRIPTION
This PR changes the polling input behavior for NBlood.

By placing input polling before `ProcessFrame()`, this ensures the main game loop has the latest input before processing frame, instead of polling input before waiting for vsync (if it is enabled).

For users who use vsync, this results in a measurable improvement of 1-2ms input to frame response.

Tested with 60hz and vsync on, and using a Samsung phone to record at 120hz video (measuring mouse movement to player movement).
Old: 10.41 frames
New: 9.09 frames