### PR TITLE
Blood: Fix pitch invert for new polling method

### DIFF
--- a/source/blood/src/controls.cpp
+++ b/source/blood/src/controls.cpp
@@ -499,7 +499,7 @@ void ctrlGetInput(void)
         input.q16turn = fix16_sadd(input.q16turn, fix16_sdiv(fix16_from_int(info.mousex), F16(32)));
 
     if (gMouseAim)
-        input.q16mlook = fix16_sadd(input.q16mlook, fix16_sdiv(fix16_from_int(info.mousey), F16(128)));
+        input.q16mlook = fix16_sadd(input.q16mlook, fix16_sdiv(fix16_from_int(gMouseAimingFlipped ? info.mousey : -info.mousey), F16(128)));
     else
         input.forward -= info.mousey;
 
@@ -515,7 +515,7 @@ void ctrlGetInput(void)
         if (info.mousey == 0)
         {
             if (gMouseAim)
-                input.q16mlook = fix16_sadd(input.q16mlook, fix16_sdiv(fix16_from_float(scaleAdjustmentToInterval(info.dpitch)/16.f), F16(128)));
+                input.q16mlook = fix16_sadd(input.q16mlook, fix16_sdiv(fix16_from_float(scaleAdjustmentToInterval(gMouseAimingFlipped ? info.dpitch : -info.dpitch)/16.f), F16(128)));
             else
                 input.forward -= int(scaleAdjustmentToInterval(info.dpitch)/2.f);
         }
@@ -526,8 +526,6 @@ void ctrlGetInput(void)
             gCenterViewOnDrop = 1;
         }
     }
-    if (!gMouseAimingFlipped)
-        input.q16mlook = -input.q16mlook;
 
     if (KB_KeyPressed(sc_Pause)) // 0xc5 in disassembly
     {


### PR DESCRIPTION
This PR moves the pitch look inverting check to the calculation, rather than automatically doing it for each call.

The reason is due to the move to putting input polling at the start of the game tick, it'll always invert on every odd frame, and for multiplayer with stuttering this can cause issues.