### PR TITLE
Blood: Disable autoaim on statue gargoyles and fix enemy count

### DIFF
--- a/source/blood/src/ai.cpp
+++ b/source/blood/src/ai.cpp
@@ -48,6 +48,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "blood.h"
 #include "db.h"
 #include "dude.h"
+#include "endgame.h"
 #include "eventq.h"
 #include "fx.h"
 #include "gameutil.h"
@@ -655,7 +656,8 @@ void aiActivateDude(spritetype *pSprite, XSPRITE *pXSprite)
     }
     case kDudeGargoyleStatueFlesh:
     case kDudeGargoyleStatueStone:
-        
+        if (!VanillaMode()) // stone activated, add to total count
+            gKillMgr.AddCount(1);
         #ifdef NOONE_EXTENSIONS
         // play gargoyle statue breaking animation if data1 = 1.
         if (gModernMap && pXSprite->data1 == 1) {

--- a/source/blood/src/endgame.cpp
+++ b/source/blood/src/endgame.cpp
@@ -135,6 +135,8 @@ bool CKillMgr::AllowedType(spritetype *pSprite)
         return false;
     if (pSprite->statnum != kStatDude)
         return false;
+    if (pSprite->type == kDudeGargoyleStatueFlesh || pSprite->type == kDudeGargoyleStatueStone) // if statue gargoyle, do not count as enemy until they activate
+        return VanillaMode();
     return pSprite->type != kDudeBat && pSprite->type != kDudeRat && pSprite->type != kDudeInnocent && pSprite->type != kDudeBurningInnocent;
 }
 


### PR DESCRIPTION
This PR adds a non-vanilla branch to ignore stone gargoyles for autoaim logic.

This fixes a vanilla bug where if there is a stone gargoyle closer to the player, the weapon will autoaim towards that instead of distant enemies.

See example image crosshair placement.

<img width="1082" height="683" alt="example" src="https://github.com/user-attachments/assets/a9e55212-cfbf-4969-b684-d4a3f60156aa" />

Additionally, the bug where inactive stone gargoyles are added to total enemy count has been fixed, as it will only be added to the enemy count after they've been activated.