### PR TITLE
Blood: Use mod menu pic if it has been edited

### DIFF
--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -1766,7 +1766,7 @@ int app_main(int argc, char const * const * argv)
 
     LoadExtraArts();
     
-    if (!Bstrcmp(pINISelected->zName, "CRYPTIC.INI")) // if currently selected cryptic passage
+    if (tileGetCRC32(2046) != kSplashScreenCRC) // if menu pic has been changed, use over plasma pak default
         gMenuPicnum = 2046;
 
     levelLoadDefaults();

--- a/source/blood/src/view.h
+++ b/source/blood/src/view.h
@@ -68,6 +68,7 @@ enum INTERPOLATE_TYPE {
 
 #define CROSSHAIR_PAL (MAXPALOOKUPS-RESERVEDPALS-1)
 #define kCrosshairTile 2319
+#define kSplashScreenCRC 290208654
 #define kLoadScreen 2049
 #define kLoadScreenCRC -2051908571
 #define kLoadScreenWideBackWidth 256


### PR DESCRIPTION
This PR allows mods and cryptic passage to overwrite the default menu picnum tile, instead of comparing the INI filename.